### PR TITLE
Leave an empty inbox unselected until New

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,9 @@ first line of documentation.
 
 Every agent-driven change MUST use a dedicated branch in an isolated worktree.
 Make all edits in that worktree; keep the main checkout available for review.
+Name branches `<type>/<kebab-case-description>` using an intent such as `fix`,
+`feat`, `refactor`, `docs`, `test`, or `chore`. Branch names MUST describe the
+change, not the implementation tool, agent, author, or worktree.
 
 A fresh worktree needs its own `npm install` before building or testing;
 otherwise workspace imports can resolve against stale output from another

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -42,6 +42,7 @@ import { AppNavigation } from "./components/AppNavigation.js";
 import { LogsModule } from "./components/logs/LogsModule.js";
 import { useDesktopConnection } from "./use-desktop-connection.js";
 import { useDesktopNotifications } from "./desktop-notifications.js";
+import { initialThreadId } from "./initial-thread-selection.js";
 
 function panesClass(showRail: boolean): string {
   return showRail ? "panes no-inspector" : "panes solo";
@@ -155,23 +156,16 @@ export function App() {
       }
       return changed ? next : prev;
     });
-    // On the first load, land on the most recent conversation (or a fresh draft
-    // when there are none) instead of a dead-end empty state. Never overrides a
-    // thread the user already opened.
+    // On the first load, land on the most recent persisted conversation without
+    // overriding a thread the user already opened.
     if (!didAutoOpenRef.current && activeThreadIdRef.current === null) {
       didAutoOpenRef.current = true;
-      const recency = (t: ThreadInfo) =>
-        t.lastActivityAt ? Date.parse(t.lastActivityAt) : 0;
-      const mostRecent = rows.reduce<ThreadInfo | null>(
-        (best, t) => (best === null || recency(t) > recency(best) ? t : best),
-        null,
-      );
-      if (mostRecent) {
-        setOpenedThreads((prev) => (prev.has(mostRecent.threadId) ? prev : new Set(prev).add(mostRecent.threadId)));
-        setActiveThreadId(mostRecent.threadId);
-      } else {
-        shouldFocusComposerRef.current = true;
-        setActiveThreadId(freshThreadId());
+      const threadId = initialThreadId(rows);
+      if (threadId) {
+        setOpenedThreads((prev) =>
+          prev.has(threadId) ? prev : new Set(prev).add(threadId),
+        );
+        setActiveThreadId(threadId);
       }
     }
   }, []);

--- a/apps/web/src/initial-thread-selection.test.ts
+++ b/apps/web/src/initial-thread-selection.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { initialThreadId } from "./initial-thread-selection.js";
+
+describe("initialThreadId", () => {
+  it("leaves an empty inbox without an active conversation", () => {
+    expect(initialThreadId([])).toBeNull();
+  });
+
+  it("selects the most recently active persisted conversation", () => {
+    expect(
+      initialThreadId([
+        {
+          threadId: "older",
+          lastActivityAt: "2026-08-10T12:00:00.000Z",
+        },
+        {
+          threadId: "newer",
+          lastActivityAt: "2026-08-12T12:00:00.000Z",
+        },
+      ]),
+    ).toBe("newer");
+  });
+});

--- a/apps/web/src/initial-thread-selection.ts
+++ b/apps/web/src/initial-thread-selection.ts
@@ -1,0 +1,13 @@
+import type { ThreadInfo } from "./api-client.js";
+
+type InitialThread = Pick<ThreadInfo, "threadId" | "lastActivityAt">;
+
+export function initialThreadId(rows: readonly InitialThread[]): string | null {
+  const recency = (thread: InitialThread) =>
+    thread.lastActivityAt ? Date.parse(thread.lastActivityAt) : 0;
+  return rows.reduce<InitialThread | null>(
+    (best, thread) =>
+      best === null || recency(thread) > recency(best) ? thread : best,
+    null,
+  )?.threadId ?? null;
+}


### PR DESCRIPTION
# What and why

When no persisted conversations exist, leave the inbox on its empty state until the user explicitly presses **New**. This avoids giving each connected client a different synthetic draft while preserving automatic selection of the most recently active persisted conversation. Explicit New drafts and first-send server/checkpoint creation remain unchanged.

Also document intent-based branch naming in `AGENTS.md`.

Closes #4

## Gates

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

## Verified how

- [x] Drove the change in a real app (web/desktop/CLI) - launched the web app against a scratch empty backend and confirmed it showed no synthetic conversation or composer before New; pressing New created one focused local draft while `/threads/list` remained empty until send.
- [ ] Tests only (explain why that is sufficient here)

## Layering

- [x] `packages/core` gained no `node:*`, DOM, `deepagents`, or `@langchain/langgraph` import
- [x] Only `packages/runtime-langgraph` imports the graph engine
- [x] `apps/web` imports no runtime and no model binding
- [x] Docs touched by this change were updated (README / AGENTS.md / docs/ARCHITECTURE.md)