### PR TITLE
fix: deny better-sqlite3 install script so npm ci works on Windows without MSVC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,9 +120,11 @@ are written — keep them in mind when adding assertions or temp-dir cleanup:
   (see `apps/desktop-shell` `sidecar.test.ts`). This surfaces under full-suite
   load and usually *not* in an isolated run, so reproduce with `npm test`.
 
-`npm install` needs MSVC — see the README's Develop note for why the compile is
-both mandatory and unused. Electron 43 has no `postinstall`; `index.js` downloads
-the binary lazily on first launch, so `--ignore-scripts` does not break it.
+`npm install` does not need MSVC — see the README's Develop note for how
+`allowScripts` denies `better-sqlite3`'s implicit `node-gyp rebuild`, which
+would otherwise be both mandatory (node-gyp fails at *configure* without a
+toolchain) and unused (prebuilt binaries ship for every platform). Electron 43
+has no `postinstall`; `index.js` downloads the binary lazily on first launch.
 
 ## Verify in the browser, not just tests
 

--- a/README.md
+++ b/README.md
@@ -108,18 +108,12 @@ prevents deleted or renamed sources from leaving stale runtime files behind.
 `node_modules` and the root Turbo cache. `npm run clean:all` removes those too
 and must be followed by `npm install`.
 
-> **Windows:** `npm install` needs the Visual Studio C++ build tools:
->
-> ```powershell
-> winget install Microsoft.VisualStudio.2022.BuildTools --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
-> ```
->
-> npm runs `better-sqlite3`'s implicit `node-gyp rebuild`, and node-gyp fails at
-> *configure* if no MSVC toolchain is present — before it can evaluate the
-> `binding.gyp` guard that would have skipped the compile as unnecessary. The
-> compiled output is then unused: the loader prefers `prebuilds/win32-x64.node`.
-> To install without a toolchain, use `npm install --ignore-scripts` (Electron 43
-> has no `postinstall` — it downloads its binary lazily on first launch).
+> **Windows:** `npm install` does not need Visual Studio C++ build tools.
+> `better-sqlite3` ships prebuilt binaries for every platform (the loader
+> prefers `prebuilds/win32-x64.node`), so its implicit `node-gyp rebuild` is
+> unnecessary — the root `package.json#allowScripts` denies it explicitly
+> (`"better-sqlite3": false`) so npm skips the compile instead of letting
+> node-gyp fail at *configure* for want of an MSVC toolchain.
 
 > The `--concurrency=2` cap in `npm test` is intentional: uncapped, the parallel
 > vitest+esbuild workers can exhaust file descriptors/memory and fail en masse.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "electron-winstaller@5.4.4": true,
     "esbuild@0.28.2": true,
     "fs-xattr@0.3.1": true,
-    "macos-alias@0.2.12": true
+    "macos-alias@0.2.12": true,
+    "better-sqlite3": false
   },
   "overrides": {
     "better-sqlite3": "^13.0.0"


### PR DESCRIPTION
Fixes #9

## Summary

- `better-sqlite3@13.0.3` opts out of its native build via `"gypfile": false` in its own `package.json` (it ships prebuilt binaries for every platform, including `win32-x64`, and the loader prefers those).
- That field doesn't survive into `package-lock.json`, so a fresh clone's `npm ci` (or `npm install` against the checked-in lockfile) reifies `better-sqlite3` without knowing about the opt-out, and npm synthesizes an implicit `node-gyp rebuild`. That fails at *configure* on Windows without an MSVC toolchain.
- The root `package.json#allowScripts` already lists packages to allow their install scripts, but an absent entry is treated as "unreviewed" rather than denied, so `better-sqlite3` still ran its (unnecessary) rebuild.
- Adds an explicit `"better-sqlite3": false` deny entry, which is read from the root `package.json` directly and isn't subject to the lockfile round-trip gap.

Also updates the now-inaccurate Windows notes in `README.md` and `AGENTS.md` that described the old `--ignore-scripts`/MSVC-required workaround.

## Test plan

- [x] `rm -rf node_modules && npm ci` succeeds on Windows with no MSVC/Visual Studio toolchain present and without `--ignore-scripts`
- [x] `better-sqlite3` still loads and works correctly (verified via a smoke script against its prebuild)
- [x] `npm run build` — all 10 workspace tasks pass
- [x] `npx vitest run --dir packages/storage` — 101/101 tests pass (the workspace that depends on `better-sqlite3`)