### PR TITLE
Fix deletion of the last conversation

### DIFF
--- a/apps/api-server/src/agent-host.test.ts
+++ b/apps/api-server/src/agent-host.test.ts
@@ -454,21 +454,6 @@ describe("AgentHost.deleteThread", () => {
     dataRoot = mkdtempSync(join(tmpdir(), "delete-data-"));
     pluginsDir = mkdtempSync(join(tmpdir(), "delete-plugins-"));
     host = await AgentHost.create({ dataRoot, pluginsDir });
-    // The checkpoints table is created lazily on first write; seed one so
-    // deleteThread's checkpoint purge runs against a table that exists, as it
-    // always does in production once a thread has taken a run.
-    await host.persistence.checkpointer.put(
-      { configurable: { thread_id: "seed", checkpoint_ns: "" } },
-      {
-        v: 4,
-        id: "chk-seed",
-        ts: "2026-07-04T00:00:00.000Z",
-        channel_values: {},
-        channel_versions: {},
-        versions_seen: {},
-      } as never,
-      { source: "input", step: 0 } as never,
-    );
   });
 
   afterEach(async () => {
@@ -497,7 +482,7 @@ describe("AgentHost.deleteThread", () => {
     expect(host.threadActivity.listAfter(0)).toHaveLength(0);
   });
 
-  it("reports deleted:false for an unknown thread", async () => {
+  it("reports deleted:false before the checkpoint schema has been initialized", async () => {
     await expect(host.deleteThread("missing")).resolves.toBe(false);
   });
 

--- a/apps/api-server/src/agent-host.ts
+++ b/apps/api-server/src/agent-host.ts
@@ -501,6 +501,10 @@ export class AgentHost {
       this.threadActivity.deleteByThread(threadId);
       const deleted = this.threadStore.delete(threadId);
       this.search.deleteThread(threadId);
+      // SqliteSaver.deleteThread skips its lazy schema setup on an unopened database.
+      await this.persistence.checkpointer.getTuple({
+        configurable: { thread_id: threadId, checkpoint_ns: "" },
+      });
       await this.persistence.checkpointer.deleteThread(threadId);
       completed = true;
       return deleted;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -43,6 +43,7 @@ import { LogsModule } from "./components/logs/LogsModule.js";
 import { useDesktopConnection } from "./use-desktop-connection.js";
 import { useDesktopNotifications } from "./desktop-notifications.js";
 import { initialThreadId } from "./initial-thread-selection.js";
+import { activeSelectionAfterDelete } from "./lib/list-nav.js";
 
 function panesClass(showRail: boolean): string {
   return showRail ? "panes no-inspector" : "panes solo";
@@ -287,11 +288,9 @@ export function App() {
       if (!prev.has(threadId)) return prev;
       const next = new Set(prev);
       next.delete(threadId);
-      setActiveThreadId((active) =>
-        active === threadId ? ([...next][next.size - 1] ?? null) : active,
-      );
       return next;
     });
+    setActiveThreadId((active) => activeSelectionAfterDelete(active, threadId));
     setThreadTitles((prev) => {
       if (!prev.has(threadId)) return prev;
       const next = new Map(prev);

--- a/apps/web/src/lib/list-nav.test.ts
+++ b/apps/web/src/lib/list-nav.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { nextNavIndex, scrollListItemIntoView, selectionAfterDelete } from "./list-nav.js";
+import {
+  activeSelectionAfterDelete,
+  nextNavIndex,
+  scrollListItemIntoView,
+  selectionAfterDelete,
+} from "./list-nav.js";
 
 describe("nextNavIndex (conversation-list arrow nav)", () => {
   it("moves down and up within range", () => {
@@ -46,6 +51,16 @@ describe("selectionAfterDelete", () => {
   it("returns undefined when no visible rows remain", () => {
     expect(selectionAfterDelete(["only"], 0)).toBeUndefined();
     expect(selectionAfterDelete([], -1)).toBeUndefined();
+  });
+});
+
+describe("activeSelectionAfterDelete", () => {
+  it("clears the deleted active row even when no replacement exists", () => {
+    expect(activeSelectionAfterDelete("new-thread", "new-thread")).toBeNull();
+  });
+
+  it("preserves a different active row", () => {
+    expect(activeSelectionAfterDelete("remaining", "deleted")).toBe("remaining");
   });
 });
 

--- a/apps/web/src/lib/list-nav.ts
+++ b/apps/web/src/lib/list-nav.ts
@@ -12,6 +12,13 @@ export function selectionAfterDelete<T>(
   return visibleItems[deletedIndex + 1] ?? visibleItems[deletedIndex - 1];
 }
 
+export function activeSelectionAfterDelete(
+  activeId: string | null,
+  deletedId: string,
+): string | null {
+  return activeId === deletedId ? null : activeId;
+}
+
 export function scrollListItemIntoView(
   itemId: string,
   firstItemId: string | undefined,


### PR DESCRIPTION
## Summary

- clear the active thread whenever that thread is deleted, even when a fresh draft is not in `openedThreads`
- initialize LangGraph's lazy SQLite checkpoint schema before deleting a first-ever unsent draft
- add regression coverage for empty active selection and uninitialized checkpoint deletion

## Verification

- `npm test -w @pizza-bot/web` (259 tests)
- `npm test -w @pizza-bot/api-server` (333 tests)
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- `npx tsc --noEmit -p apps/api-server/tsconfig.json`
- ESLint on changed files
- `npm run build`
- Playwright against a fresh data root: first draft deletion returned 200 and immediately rendered both empty-inbox states

Fixes #11