### PR TITLE
feat: add targeted MCP reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ String fields in `.mcp.json` expand environment references at connect time. Set
 Startup runs at most three connections at a time and gives each attempt 20
 seconds by default; override those limits with `PIZZA_MCP_STARTUP_CONCURRENCY`
 and `PIZZA_MCP_CONNECTION_TIMEOUT_MS`.
+An enabled server that exhausts its connection attempts can be retried from its
+MCP Servers detail screen without reconnecting healthy servers.
 
 ### Shipped MCP Status example
 

--- a/apps/api-server/src/agent-host.ts
+++ b/apps/api-server/src/agent-host.ts
@@ -1124,6 +1124,15 @@ export class AgentHost {
     return (await this.listMcpServers()).find((candidate) => candidate.id === id);
   }
 
+  async reconnectMcpServer(id: string): Promise<McpServerListEntry | undefined> {
+    const reconnect = this.mcpReloads.then(() => this.reconnectMcpServerOnce(id));
+    this.mcpReloads = reconnect.then(
+      () => {},
+      () => {},
+    );
+    return reconnect;
+  }
+
   async mcpServerDisableBlockers(
     id: string,
   ): Promise<Array<{ id: string; name: string }>> {
@@ -1208,7 +1217,7 @@ export class AgentHost {
     });
     console.error(
       `[mcp] server "${server}" crashed — invalidating ${deadToolNames.size} tool(s); ` +
-        `re-add it via the MCP settings to reconnect`,
+        "scheduling reconnect",
     );
     const nextCatalog: ToolCatalog = { ...this.mcpCatalog };
     delete nextCatalog[server];
@@ -1229,7 +1238,7 @@ export class AgentHost {
     const timer = setTimeout(() => {
       this.mcpRecoveryTimers.delete(server);
       if (this.closing) return;
-      void this.reloadMcpServers().catch((err) => {
+      void this.reconnectMcpServer(server).catch((err) => {
         console.error(`[mcp] automatic recovery after "${server}" crash failed:`, err);
       });
     }, 1_000);
@@ -1257,6 +1266,105 @@ export class AgentHost {
           ),
         )
       : {};
+  }
+
+  private async reconnectMcpServerOnce(
+    id: string,
+  ): Promise<McpServerListEntry | undefined> {
+    await this.warmup;
+    const userEntries = await this.loadUserMcpEntries();
+    const merged = this.effectiveMcpEntries(
+      this.pluginMcpServers ?? {},
+      userEntries,
+    );
+    const entry = merged[id];
+    if (!entry) return undefined;
+    if (entry.enabled === false) {
+      return (await this.listMcpServers()).find((server) => server.id === id);
+    }
+
+    const previousLifecycle = this.mcpLifecycle.get(id);
+    const previousTools = this.mcpTools;
+    const previousCatalog = this.mcpCatalog;
+    this.mcpLifecycle.set(id, { status: "loading", toolCount: 0 });
+
+    const result = await connectMcpServers(
+      { [id]: entry },
+      process.env.PIZZA_MCP_NODE_PATH ?? undefined,
+      (m) => console.log(`[mcp] ${m}`),
+      "pipe",
+      this.providerMcpEnv,
+      {
+        electronRunAsNode:
+          Boolean(process.versions.electron) &&
+          process.env.PIZZA_MCP_NODE_PATH === process.execPath,
+        connectionTimeoutMs: positiveInt(
+          process.env.PIZZA_MCP_CONNECTION_TIMEOUT_MS,
+          20_000,
+        ),
+        onStatus: (event) => this.recordMcpStatus(event),
+      },
+    );
+    const connectedTools = result.catalog[id];
+    if (!result.client || !connectedTools) {
+      return (await this.listMcpServers()).find((server) => server.id === id);
+    }
+
+    const nextTools = Object.fromEntries(
+      Object.entries(previousTools).filter(
+        ([name]) => !name.startsWith(`mcp:${id}:`),
+      ),
+    );
+    Object.assign(nextTools, result.tools);
+    const nextCatalog: ToolCatalog = {
+      ...previousCatalog,
+      [id]: connectedTools,
+    };
+    const plugins = this.pluginsImpl;
+    if (!plugins) {
+      await result.client.close().catch(() => {});
+      if (previousLifecycle) this.mcpLifecycle.set(id, previousLifecycle);
+      else this.mcpLifecycle.delete(id);
+      throw new Error("MCP client pool is unavailable");
+    }
+
+    const mutable = plugins as { client?: McpClientPool };
+    const existingPool = mutable.client;
+    let activePool: McpClientPool;
+    let displaced: McpClientPool | undefined;
+    if (existingPool) {
+      displaced = existingPool.replaceServer(id, result.client);
+      activePool = existingPool;
+    } else {
+      activePool = result.client;
+      mutable.client = activePool;
+    }
+
+    try {
+      await this.applyMcpCapabilities(nextTools, nextCatalog);
+      await this.mcpHealth.armServer(
+        activePool as McpClientLike,
+        id,
+        connectedTools,
+        (server) => this.handleMcpCrash(server),
+      );
+      this.retireMcpClient(displaced);
+    } catch (error) {
+      let failedReplacement: McpClientPool | undefined;
+      if (existingPool) {
+        failedReplacement = existingPool.replaceServer(id, displaced);
+      } else {
+        delete mutable.client;
+        failedReplacement = activePool;
+      }
+      await failedReplacement?.close().catch(() => {});
+      if (previousLifecycle) this.mcpLifecycle.set(id, previousLifecycle);
+      else this.mcpLifecycle.delete(id);
+      await this.applyMcpCapabilities(previousTools, previousCatalog).catch(() => {});
+      throw error;
+    }
+
+    return (await this.listMcpServers()).find((server) => server.id === id);
   }
 
   private effectiveMcpEntries(

--- a/apps/api-server/src/mcp-health-monitor.test.ts
+++ b/apps/api-server/src/mcp-health-monitor.test.ts
@@ -97,6 +97,33 @@ describe("McpHealthMonitor", () => {
     expect(onCrash).toHaveBeenCalledExactlyOnceWith("outlook");
   });
 
+  it("re-arms one server without invalidating sibling crash handlers", async () => {
+    const mon = new McpHealthMonitor();
+    const oldOutlook = {} as FakeConn;
+    const calendar = {} as FakeConn;
+    const newOutlook = {} as FakeConn;
+    const onCrash = vi.fn();
+    await mon.arm(
+      fakeClient({ outlook: oldOutlook, calendar }),
+      catalogOf({ outlook: ["mail"], calendar: ["events"] }),
+      onCrash,
+    );
+
+    await mon.armServer(
+      fakeClient({ outlook: newOutlook }),
+      "outlook",
+      ["mail", "send"],
+      onCrash,
+    );
+    oldOutlook.onclose?.();
+    expect(onCrash).not.toHaveBeenCalled();
+
+    calendar.onclose?.();
+    expect(onCrash).toHaveBeenCalledExactlyOnceWith("calendar");
+    newOutlook.onclose?.();
+    expect(onCrash).toHaveBeenNthCalledWith(2, "outlook");
+  });
+
   it("only fires onCrash once for repeated closes of the same server", async () => {
     const mon = new McpHealthMonitor();
     const conns = { outlook: {} as FakeConn };

--- a/apps/api-server/src/mcp-health-monitor.ts
+++ b/apps/api-server/src/mcp-health-monitor.ts
@@ -31,59 +31,71 @@ export class McpHealthMonitor {
   readonly #health = new Map<string, McpServerHealth>();
   readonly #stderrTails = new Map<string, string[]>();
   readonly #lastError = new Map<string, string>();
-  #generation = 0;
+  readonly #tokens = new Map<string, object>();
 
   async arm(
     client: McpClientLike,
     catalog: Record<string, readonly string[]>,
     onCrash: (server: string) => void,
   ): Promise<void> {
-    // Generation checks ignore late events from reload and shutdown teardown.
-    const generation = ++this.#generation;
+    this.disarm();
     this.#health.clear();
     this.#stderrTails.clear();
     this.#lastError.clear();
 
     for (const [server, toolNames] of Object.entries(catalog)) {
-      this.#health.set(server, { status: "connected", toolCount: toolNames.length });
-      const conn = await client.getClient(server).catch(() => undefined);
-      if (!conn || generation !== this.#generation) continue;
-
-      const stderr = conn.transport?.stderr;
-      if (stderr) {
-        const tail: string[] = [];
-        this.#stderrTails.set(server, tail);
-        stderr.on("data", (chunk) => {
-          const text = chunk.toString();
-          for (const line of text.split(/\r?\n/)) {
-            if (line.length === 0) continue;
-            const sanitizedLine = redactDiagnosticText(line);
-            this.#log.info(sanitizedLine, {
-              event: "mcp.stderr",
-              mcpServer: server,
-              stream: "stderr",
-            });
-            tail.push(sanitizedLine);
-            if (tail.length > STDERR_TAIL_LINES) tail.shift();
-          }
-        });
-      }
-
-      conn.onerror = (error: Error) => {
-        if (generation !== this.#generation) return;
-        this.#lastError.set(server, redactDiagnosticText(error.message));
-        this.#log.error("MCP connection error", error, {
-          event: "mcp.connection_error",
-          mcpServer: server,
-        });
-      };
-      conn.onclose = () => this.#onClose(server, generation, onCrash);
+      await this.armServer(client, server, toolNames, onCrash);
     }
+  }
+
+  async armServer(
+    client: McpClientLike,
+    server: string,
+    toolNames: readonly string[],
+    onCrash: (server: string) => void,
+  ): Promise<void> {
+    const token = {};
+    this.#tokens.set(server, token);
+    this.#health.set(server, { status: "connected", toolCount: toolNames.length });
+    this.#stderrTails.delete(server);
+    this.#lastError.delete(server);
+    const conn = await client.getClient(server).catch(() => undefined);
+    if (!conn || this.#tokens.get(server) !== token) return;
+
+    const stderr = conn.transport?.stderr;
+    if (stderr) {
+      const tail: string[] = [];
+      this.#stderrTails.set(server, tail);
+      stderr.on("data", (chunk) => {
+        const text = chunk.toString();
+        for (const line of text.split(/\r?\n/)) {
+          if (line.length === 0) continue;
+          const sanitizedLine = redactDiagnosticText(line);
+          this.#log.info(sanitizedLine, {
+            event: "mcp.stderr",
+            mcpServer: server,
+            stream: "stderr",
+          });
+          tail.push(sanitizedLine);
+          if (tail.length > STDERR_TAIL_LINES) tail.shift();
+        }
+      });
+    }
+
+    conn.onerror = (error: Error) => {
+      if (this.#tokens.get(server) !== token) return;
+      this.#lastError.set(server, redactDiagnosticText(error.message));
+      this.#log.error("MCP connection error", error, {
+        event: "mcp.connection_error",
+        mcpServer: server,
+      });
+    };
+    conn.onclose = () => this.#onClose(server, token, onCrash);
   }
 
   disarm(): void {
     // client.close() invokes onclose, so invalidate handlers before intentional teardown.
-    this.#generation++;
+    this.#tokens.clear();
   }
 
   snapshot(): Record<string, McpServerHealth> {
@@ -94,8 +106,8 @@ export class McpHealthMonitor {
     return out;
   }
 
-  #onClose(server: string, generation: number, onCrash: (server: string) => void): void {
-    if (generation !== this.#generation) return;
+  #onClose(server: string, token: object, onCrash: (server: string) => void): void {
+    if (this.#tokens.get(server) !== token) return;
     const current = this.#health.get(server);
     if (!current || current.status === "crashed") return;
     this.#health.set(server, {

--- a/apps/api-server/src/routes-mcp.test.ts
+++ b/apps/api-server/src/routes-mcp.test.ts
@@ -64,6 +64,100 @@ describe("mcp-server routes: GET/POST/PATCH/DELETE /mcp-servers", () => {
     expect(status!.toolCount).toBeGreaterThan(0);
   }, 20_000);
 
+  it("reconnects one failed server without replacing healthy sibling tools", async () => {
+    writeFileSync(
+      configFile,
+      JSON.stringify({
+        mcpServers: {
+          recoverable: { command: "pizza-bot-command-that-does-not-exist" },
+        },
+      }),
+    );
+    await host.reloadMcpServers();
+    expect((await list()).find((server) => server.id === "recoverable")).toMatchObject({
+      status: "error",
+      toolCount: 0,
+    });
+    const beforeTools = (host as unknown as {
+      mcpTools: Record<string, unknown>;
+    }).mcpTools;
+    const healthyTool = beforeTools["mcp:mcp-status:get_mcp_status"];
+
+    const failedRetry = await app.request(
+      "/mcp-servers/recoverable/reconnect",
+      { method: "POST" },
+    );
+    expect(failedRetry.status).toBe(200);
+    expect(await failedRetry.json()).toMatchObject({
+      id: "recoverable",
+      status: "error",
+    });
+    expect(
+      (host as unknown as { mcpTools: Record<string, unknown> }).mcpTools[
+        "mcp:mcp-status:get_mcp_status"
+      ],
+    ).toBe(healthyTool);
+
+    writeFileSync(
+      configFile,
+      JSON.stringify({
+        mcpServers: {
+          recoverable: { command: "node", args: [STATUS_SERVER] },
+        },
+      }),
+    );
+    const response = await app.request("/mcp-servers/recoverable/reconnect", {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      id: "recoverable",
+      status: "connected",
+      toolCount: 1,
+    });
+    const afterTools = (host as unknown as {
+      mcpTools: Record<string, unknown>;
+    }).mcpTools;
+    expect(afterTools["mcp:mcp-status:get_mcp_status"]).toBe(healthyTool);
+    expect(afterTools).toHaveProperty("mcp:recoverable:get_mcp_status");
+  }, 30_000);
+
+  it("rejects reconnecting connected, disabled, and unknown servers", async () => {
+    const connected = await app.request("/mcp-servers/mcp-status/reconnect", {
+      method: "POST",
+    });
+    expect(connected.status).toBe(409);
+    expect(await connected.json()).toMatchObject({
+      error: "mcp_not_reconnectable",
+    });
+
+    writeFileSync(
+      configFile,
+      JSON.stringify({
+        mcpServers: {
+          sleeping: {
+            command: "node",
+            args: [STATUS_SERVER],
+            enabled: false,
+          },
+        },
+      }),
+    );
+    await host.reloadMcpServers();
+
+    const disabled = await app.request("/mcp-servers/sleeping/reconnect", {
+      method: "POST",
+    });
+    expect(disabled.status).toBe(409);
+    expect(await disabled.json()).toMatchObject({ error: "mcp_disabled" });
+
+    const missing = await app.request("/mcp-servers/missing/reconnect", {
+      method: "POST",
+    });
+    expect(missing.status).toBe(404);
+  }, 20_000);
+
   it("enforces skill and MCP enablement dependencies for plugin contributions", async () => {
     const initial = (await (await app.request("/mcp-servers")).json()) as {
       servers: Array<{

--- a/apps/api-server/src/routes-mcp.ts
+++ b/apps/api-server/src/routes-mcp.ts
@@ -105,6 +105,33 @@ export function mcpRoutes(host: AgentHost): Hono {
     }
   });
 
+  app.post("/mcp-servers/:id/reconnect", async (c) => {
+    const current = (await host.listMcpServers()).find(
+      (server) => server.id === c.req.param("id"),
+    );
+    if (!current) return c.json({ error: "not_found" }, 404);
+    if (!current.enabled) {
+      return c.json(
+        {
+          error: "mcp_disabled",
+          detail: "Enable this MCP server before reconnecting it.",
+        },
+        409,
+      );
+    }
+    if (current.status !== "error" && current.status !== "crashed") {
+      return c.json(
+        {
+          error: "mcp_not_reconnectable",
+          detail: "Only failed or crashed MCP servers can be reconnected.",
+        },
+        409,
+      );
+    }
+    const server = await host.reconnectMcpServer(current.id);
+    return server ? c.json(server) : c.json({ error: "not_found" }, 404);
+  });
+
   app.get("/mcp-servers/:id", async (c) => {
     const entry = await host.userMcpServer(c.req.param("id"));
     if (!entry) return c.json({ error: "not_found" }, 404);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -426,6 +426,7 @@ export function App() {
                 onCreate={mcpAdmin.create}
                 onUpdate={mcpAdmin.update}
                 onSetEnabled={mcpAdmin.setEnabled}
+                onReconnect={mcpAdmin.reconnect}
                 onDelete={mcpAdmin.remove}
                 onGetDoc={mcpAdmin.getDoc}
               />

--- a/apps/web/src/api-client.ts
+++ b/apps/web/src/api-client.ts
@@ -268,6 +268,14 @@ export class ApiClient {
     });
   }
 
+  async reconnectMcpServer(id: string): Promise<McpServerRow> {
+    return this.json(
+      "reconnect MCP server",
+      `/mcp-servers/${encodeURIComponent(id)}/reconnect`,
+      { method: "POST" },
+    );
+  }
+
   async deleteMcpServer(id: string): Promise<boolean> {
     return deletedFlag(
       await this.json("delete mcp server", `/mcp-servers/${encodeURIComponent(id)}`, { method: "DELETE" }),

--- a/apps/web/src/components/StatusBar.test.tsx
+++ b/apps/web/src/components/StatusBar.test.tsx
@@ -143,7 +143,7 @@ describe("StatusBar", () => {
     );
   });
 
-  it("reserves MCP failure styling for terminal failures", () => {
+  it("uses warning styling when at least one MCP server remains available", () => {
     const html = renderStatusBar(
       false,
       true,
@@ -154,6 +154,22 @@ describe("StatusBar", () => {
     );
 
     expect(html).toContain("MCP servers: 1/2 servers loaded · 1 failed");
+    expect(html).toContain(
+      'class="statusbar-icon text-warn" type="button" aria-label="MCP servers:',
+    );
+  });
+
+  it("reserves MCP failure styling for complete unavailability", () => {
+    const html = renderStatusBar(
+      false,
+      true,
+      statusWithMcp([
+        { name: "calendar", status: "error", toolCount: 0 },
+        { name: "mail", status: "crashed", toolCount: 0 },
+      ]),
+    );
+
+    expect(html).toContain("MCP servers: 0/2 servers loaded · 2 failed");
     expect(html).toContain(
       'class="statusbar-icon text-bad" type="button" aria-label="MCP servers:',
     );

--- a/apps/web/src/components/StatusBar.tsx
+++ b/apps/web/src/components/StatusBar.tsx
@@ -209,7 +209,9 @@ export function StatusBar({
     : status.mcp.total === 0
       ? "warn"
       : mcpFailed > 0
-        ? "bad"
+        ? status.mcp.loaded > 0 || mcpLoading > 0
+          ? "warn"
+          : "bad"
         : mcpLoading > 0
           ? "info"
           : status.mcp.available

--- a/apps/web/src/components/mcp/McpReconnectControl.test.tsx
+++ b/apps/web/src/components/mcp/McpReconnectControl.test.tsx
@@ -1,0 +1,47 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { McpServerRow } from "@/api-client";
+import { AppToastProvider } from "../AppToast.js";
+import { McpReconnectControl } from "./McpReconnectControl.js";
+
+function server(
+  status: McpServerRow["status"],
+  enabled = true,
+): McpServerRow {
+  return {
+    id: "documents",
+    source: "plugin",
+    entry: { command: "node" },
+    enabled,
+    status,
+    toolCount: 0,
+    detail: "connection timed out after 20000ms",
+    dependentSkills: [],
+  };
+}
+
+function render(status: McpServerRow["status"], enabled = true): string {
+  return renderToStaticMarkup(
+    <AppToastProvider>
+      <McpReconnectControl
+        server={server(status, enabled)}
+        onReconnect={vi.fn()}
+      />
+    </AppToastProvider>,
+  );
+}
+
+describe("McpReconnectControl", () => {
+  it("shows the failure detail and retry action for a failed server", () => {
+    const html = render("error");
+    expect(html).toContain("Connection failed");
+    expect(html).toContain("connection timed out after 20000ms");
+    expect(html).toContain("Retry connection");
+    expect(html).toContain("lucide-refresh-cw");
+  });
+
+  it("does not offer reconnect while connected or disabled", () => {
+    expect(render("connected")).not.toContain("Retry connection");
+    expect(render("error", false)).not.toContain("Retry connection");
+  });
+});

--- a/apps/web/src/components/mcp/McpReconnectControl.tsx
+++ b/apps/web/src/components/mcp/McpReconnectControl.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { RefreshCw } from "lucide-react";
+import type { McpServerRow } from "@/api-client";
+import { useAppToast } from "../AppToast.js";
+
+export function McpReconnectControl({
+  server,
+  onReconnect,
+}: {
+  server: McpServerRow;
+  onReconnect: (id: string) => Promise<McpServerRow>;
+}) {
+  const notify = useAppToast();
+  const [busy, setBusy] = useState(false);
+  if (
+    !server.enabled ||
+    (server.status !== "error" && server.status !== "crashed")
+  ) {
+    return null;
+  }
+
+  const retry = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const next = await onReconnect(server.id);
+      if (next.status === "connected") {
+        notify({ title: `${server.id} connected`, tone: "success" });
+      } else {
+        notify({
+          title: `Could not connect ${server.id}`,
+          description: next.detail,
+          tone: "error",
+        });
+      }
+    } catch (error) {
+      notify({
+        title: `Could not connect ${server.id}`,
+        description: error instanceof Error ? error.message : undefined,
+        tone: "error",
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="mcp-reconnect" aria-live="polite">
+      <div className="mcp-reconnect-copy">
+        <div className="mcp-reconnect-title">
+          {server.status === "crashed" ? "Connection lost" : "Connection failed"}
+        </div>
+        <div className="mcp-reconnect-detail">
+          {server.detail ?? "The server did not complete MCP initialization."}
+        </div>
+      </div>
+      <button
+        type="button"
+        className="btn-secondary mcp-reconnect-button"
+        disabled={busy}
+        onClick={() => void retry()}
+      >
+        <RefreshCw
+          size={14}
+          className={busy ? "mcp-reconnect-spinner" : undefined}
+        />
+        {busy ? "Retrying..." : "Retry connection"}
+      </button>
+    </section>
+  );
+}

--- a/apps/web/src/components/mcp/McpServerCard.tsx
+++ b/apps/web/src/components/mcp/McpServerCard.tsx
@@ -9,10 +9,17 @@ export interface McpServerCardProps {
   server: McpServerRow;
   onBack?: () => void;
   enablement?: ReactNode;
+  reconnectControl?: ReactNode;
   dependents?: ReactNode;
 }
 
-export function McpServerCard({ server, enablement, dependents, onBack }: McpServerCardProps) {
+export function McpServerCard({
+  server,
+  enablement,
+  reconnectControl,
+  dependents,
+  onBack,
+}: McpServerCardProps) {
   const isStdio = "command" in server.entry;
   const statusLabel =
     server.status === "connected"
@@ -59,6 +66,7 @@ export function McpServerCard({ server, enablement, dependents, onBack }: McpSer
       </header>
 
       {enablement}
+      {reconnectControl}
 
       <section className="resource-card-section">
         <h3 className="resource-card-section-title">

--- a/apps/web/src/components/mcp/McpServerEditor.tsx
+++ b/apps/web/src/components/mcp/McpServerEditor.tsx
@@ -10,6 +10,7 @@ export interface McpServerEditorProps {
   onSave: (id: string, entry: McpServerEntryWire) => Promise<void>;
   onDelete?: () => Promise<void>;
   enablement?: ReactNode;
+  reconnectControl?: ReactNode;
   dependents?: ReactNode;
   onCancel: () => void;
 }
@@ -34,7 +35,15 @@ function fromRows(rows: KV[]): Record<string, string> | undefined {
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
-export function McpServerEditor({ server, onSave, onDelete, enablement, dependents, onCancel }: McpServerEditorProps) {
+export function McpServerEditor({
+  server,
+  onSave,
+  onDelete,
+  enablement,
+  reconnectControl,
+  dependents,
+  onCancel,
+}: McpServerEditorProps) {
   const notify = useAppToast();
   const isNew = server === null;
   const entry = server?.entry;
@@ -106,6 +115,7 @@ export function McpServerEditor({ server, onSave, onDelete, enablement, dependen
 
       <div className="resource-editor-body">
         {enablement}
+        {reconnectControl}
 
         <label className="field">
           <span className="field-label">Name</span>

--- a/apps/web/src/components/mcp/McpServersModule.tsx
+++ b/apps/web/src/components/mcp/McpServersModule.tsx
@@ -14,12 +14,14 @@ import {
   type CapabilityVisualState,
 } from "../CapabilityControls.js";
 import { McpDependents } from "./McpDependents.js";
+import { McpReconnectControl } from "./McpReconnectControl.js";
 
 export interface McpServersModuleProps {
   servers: McpServerRow[];
   onCreate: (id: string, entry: McpServerEntryWire) => Promise<McpServerRow>;
   onUpdate: (id: string, entry: McpServerEntryWire) => Promise<McpServerRow>;
   onSetEnabled: (id: string, enabled: boolean) => Promise<McpServerRow>;
+  onReconnect: (id: string) => Promise<McpServerRow>;
   onDelete: (id: string) => Promise<boolean>;
   onGetDoc: (id: string) => Promise<McpServerDoc | undefined>;
 }
@@ -40,7 +42,15 @@ function mcpVisualState(server: McpServerRow): CapabilityVisualState {
   return "unavailable";
 }
 
-export function McpServersModule({ servers, onCreate, onUpdate, onSetEnabled, onDelete, onGetDoc }: McpServersModuleProps) {
+export function McpServersModule({
+  servers,
+  onCreate,
+  onUpdate,
+  onSetEnabled,
+  onReconnect,
+  onDelete,
+  onGetDoc,
+}: McpServersModuleProps) {
   return (
     <ResourceModule
       items={servers}
@@ -95,6 +105,7 @@ export function McpServersModule({ servers, onCreate, onUpdate, onSetEnabled, on
           onCreate={onCreate}
           onUpdate={onUpdate}
           onSetEnabled={onSetEnabled}
+          onReconnect={onReconnect}
           onDelete={onDelete}
           onGetDoc={onGetDoc}
         />
@@ -112,6 +123,7 @@ function McpServerDetail({
   onCreate,
   onUpdate,
   onSetEnabled,
+  onReconnect,
   onDelete,
   onGetDoc,
 }: {
@@ -120,7 +132,7 @@ function McpServerDetail({
   setSelection: (next: import("../ResourceModule.js").ResourceSelection) => void;
   backToList?: () => void;
   confirmAction: import("../ResourceModule.js").ResourceDetailArgs<McpServerRow>["confirmAction"];
-} & Pick<McpServersModuleProps, "onCreate" | "onUpdate" | "onSetEnabled" | "onDelete" | "onGetDoc">) {
+} & Pick<McpServersModuleProps, "onCreate" | "onUpdate" | "onSetEnabled" | "onReconnect" | "onDelete" | "onGetDoc">) {
   const isUser = selected?.source === "user";
   const doc = useKeyedDoc(
     selection?.mode === "view" && isUser && selected ? selected.id : null,
@@ -149,6 +161,9 @@ function McpServerDetail({
       onChange={(enabled) => onSetEnabled(selected.id, enabled)}
     />
   ) : undefined;
+  const reconnectControl = selected ? (
+    <McpReconnectControl server={selected} onReconnect={onReconnect} />
+  ) : undefined;
   const dependents = selected ? <McpDependents skills={selected.dependentSkills} /> : undefined;
 
   if (selection?.mode === "new") {
@@ -172,6 +187,7 @@ function McpServerDetail({
         key={doc.id}
         server={doc}
         enablement={enablement}
+        reconnectControl={reconnectControl}
         dependents={dependents}
         onSave={handleSave}
         onDelete={() =>
@@ -194,6 +210,7 @@ function McpServerDetail({
       <McpServerCard
         server={selected}
         enablement={enablement}
+        reconnectControl={reconnectControl}
         dependents={dependents}
         onBack={backToList}
       />

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1261,6 +1261,18 @@ body {
 .mcp-transport-toggle .btn-secondary.active {
   border-color: var(--brand); color: var(--text);
 }
+.mcp-reconnect {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  padding: 14px 0; border-bottom: 1px solid var(--border);
+}
+.mcp-reconnect-copy { min-width: 0; }
+.mcp-reconnect-title { font-size: 13.5px; font-weight: 700; color: var(--bad); }
+.mcp-reconnect-detail {
+  margin-top: 3px; font-size: 12px; line-height: 1.4; color: var(--dim);
+  overflow-wrap: anywhere;
+}
+.mcp-reconnect-button { flex: 0 0 auto; }
+.mcp-reconnect-spinner { animation: statusbar-spin .9s linear infinite; }
 .mcp-arg-rows { list-style: none; margin: 0 0 10px; padding: 0; display: flex; flex-direction: column; gap: 8px; }
 .mcp-arg-row { display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center; }
 .mcp-kv-rows { list-style: none; margin: 0 0 10px; padding: 0; display: flex; flex-direction: column; gap: 8px; }
@@ -1299,6 +1311,11 @@ body {
 .resource-editor-actions-spacer { flex: 1; }
 .resource-editor-delete { color: var(--danger, #e5484d); }
 .resource-editor-delete:hover:not(:disabled) { border-color: var(--danger, #e5484d); }
+
+@media (max-width: 560px) {
+  .mcp-reconnect { align-items: stretch; flex-direction: column; }
+  .mcp-reconnect-button { align-self: flex-start; }
+}
 
 .resource-generate {
   display: flex; flex-direction: column; gap: 8px;

--- a/apps/web/src/use-app-data.ts
+++ b/apps/web/src/use-app-data.ts
@@ -165,10 +165,24 @@ export function useMcpServersAdmin(client: ApiClient, intervalMs = 5_000, enable
     (id: string, enabled: boolean) => client.setMcpServerEnabled(id, enabled),
     refresh,
   );
+  const reconnect = refreshAfter(
+    (id: string) => client.reconnectMcpServer(id),
+    refresh,
+  );
   const remove = refreshAfter((id: string) => client.deleteMcpServer(id), refresh);
   const getDoc = useCallback((id: string) => client.getMcpServer(id), [client]);
 
-  return { servers, loading, refresh, create, update, setEnabled, remove, getDoc };
+  return {
+    servers,
+    loading,
+    refresh,
+    create,
+    update,
+    setEnabled,
+    reconnect,
+    remove,
+    getDoc,
+  };
 }
 
 // onModelsStale re-fetches the model catalog: configuring or removing a provider,

--- a/packages/plugin-sdk/src/mcp-connect.test.ts
+++ b/packages/plugin-sdk/src/mcp-connect.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { chmodSync, mkdtempSync, statSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { connectMcpServers } from "./plugin-host.js";
+import { connectMcpServers, McpClientPool } from "./plugin-host.js";
 import {
   loadUserMcpServers,
   writeUserMcpServers,
@@ -204,6 +204,42 @@ describe("connectMcpServers", () => {
     );
     expect(r).toMatchObject({ tools: {}, catalog: {}, errors: {} });
     expect(events).toEqual([]);
+  });
+});
+
+describe("McpClientPool", () => {
+  it("transfers one replacement without disturbing sibling ownership", async () => {
+    const oldMail = {
+      getClient: vi.fn(async () => ({ id: "old-mail" })),
+      close: vi.fn(async () => {}),
+    };
+    const calendar = {
+      getClient: vi.fn(async () => ({ id: "calendar" })),
+      close: vi.fn(async () => {}),
+    };
+    const newMail = {
+      getClient: vi.fn(async () => ({ id: "new-mail" })),
+      close: vi.fn(async () => {}),
+    };
+    const pool = new McpClientPool(
+      new Map([
+        ["mail", oldMail as never],
+        ["calendar", calendar as never],
+      ]),
+    );
+    const replacement = new McpClientPool(
+      new Map([["mail", newMail as never]]),
+    );
+
+    const displaced = pool.replaceServer("mail", replacement);
+
+    expect(replacement.size).toBe(0);
+    await expect(pool.getClient("mail")).resolves.toEqual({ id: "new-mail" });
+    await expect(pool.getClient("calendar")).resolves.toEqual({ id: "calendar" });
+    await displaced?.close();
+    expect(oldMail.close).toHaveBeenCalledOnce();
+    expect(calendar.close).not.toHaveBeenCalled();
+    expect(newMail.close).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/plugin-sdk/src/plugin-host.ts
+++ b/packages/plugin-sdk/src/plugin-host.ts
@@ -86,10 +86,10 @@ interface ToolListingClient {
  * successful connections independent from failed or restarting siblings.
  */
 export class McpClientPool {
-  readonly #clients: ReadonlyMap<string, MultiServerMCPClient>;
+  readonly #clients: Map<string, MultiServerMCPClient>;
 
   constructor(clients: ReadonlyMap<string, MultiServerMCPClient>) {
-    this.#clients = clients;
+    this.#clients = new Map(clients);
   }
 
   get size(): number {
@@ -98,6 +98,29 @@ export class McpClientPool {
 
   async getClient(serverName: string): Promise<ServerClient> {
     return this.#clients.get(serverName)?.getClient(serverName);
+  }
+
+  /**
+   * Transfers one connection from `replacement` and returns the displaced
+   * connection as a separately owned pool.
+   */
+  replaceServer(
+    serverName: string,
+    replacement: McpClientPool | undefined,
+  ): McpClientPool | undefined {
+    const previous = this.#clients.get(serverName);
+    const next = replacement
+      ? replacement.#clients.get(serverName)
+      : undefined;
+    if (next && replacement) {
+      this.#clients.set(serverName, next);
+      replacement.#clients.delete(serverName);
+    } else {
+      this.#clients.delete(serverName);
+    }
+    return previous
+      ? new McpClientPool(new Map([[serverName, previous]]))
+      : undefined;
   }
 
   async close(): Promise<void> {


### PR DESCRIPTION
# What and why

Add a manual **Retry connection** action for enabled MCP servers that have failed or crashed. Reconnection is scoped to the selected server, so healthy sibling clients and tools remain available. Automatic crash recovery now uses the same targeted path.

The status bar uses the theme warning token for partial MCP availability and reserves red for complete unavailability.

Fixes #13

## Gates

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

## Verified how

- [x] Drove the change in a real app (web/desktop/CLI) - launched the desktop development app with one connected and one failed MCP server; verified the warning status at desktop and mobile widths, exercised a failed retry, then killed `mcp-status`, blocked its automatic restart, restored its entrypoint, and confirmed **Retry connection** recovered it without restarting healthy servers.
- [ ] Tests only (explain why that is sufficient here)

Focused verification after the final API guard passed 60 tests across the MCP routes, health monitor, client pool, retry control, and status bar.

## Layering

- [x] `packages/core` gained no `node:*`, DOM, `deepagents`, or `@langchain/langgraph` import
- [x] Only `packages/runtime-langgraph` imports the graph engine
- [x] `apps/web` imports no runtime and no model binding
- [x] Docs touched by this change were updated (README / AGENTS.md / docs/ARCHITECTURE.md)