### PR TITLE
Fix Windows taskbar icon

### DIFF
--- a/apps/desktop-shell/forge.config.ts
+++ b/apps/desktop-shell/forge.config.ts
@@ -75,6 +75,8 @@ const config: ForgeConfig = {
       path.join(repoRoot, "dist", "THIRD_PARTY_LICENSES.txt"),
       path.join(shellRoot, "dist-server"),
       path.join(repoRoot, "apps", "web", "dist"),
+      path.join(iconsDir, "icon.ico"),
+      path.join(iconsDir, "icon.png"),
       // Staged, not repo-root: shipped plugins need their own node_modules.
       path.join(shellRoot, "dist-plugins", "plugins"),
       path.join(repoRoot, "skills"),

--- a/apps/desktop-shell/src/main.ts
+++ b/apps/desktop-shell/src/main.ts
@@ -25,6 +25,7 @@ import { findMcpNode } from "@pizza-bot/plugin-sdk/runtime-resolver";
 import { PROTOCOL_VERSION } from "@pizza-bot/core";
 import { isAllowedRendererNavigation } from "./navigation-policy.js";
 import { handleSquirrelStartup, SQUIRREL_APP_ID } from "./squirrel-startup.js";
+import { resolveWindowIconPath } from "./window-icon.js";
 import {
   BoundedRetention,
   NATIVE_NOTIFICATION_CHANNELS,
@@ -585,11 +586,18 @@ async function restartSidecar(): Promise<void> {
 function createWindow(connection: ActiveConnection): void {
   rendererApiToken = connection.apiToken;
   const rendererEntry = resolveRendererEntry();
+  const windowIcon = resolveWindowIconPath({
+    platform: process.platform,
+    packaged: app.isPackaged,
+    appPath: app.getAppPath(),
+    resourcesPath: process.resourcesPath,
+  });
   const win = new BrowserWindow({
     width: 1200,
     height: 800,
     center: true,
     title: "Pizza Bot OSS",
+    ...(windowIcon ? { icon: windowIcon } : {}),
     webPreferences: {
       // Sandboxed Electron preloads load as CommonJS.
       preload: path.join(__dirname, "preload.cjs"),

--- a/apps/desktop-shell/src/main.ts
+++ b/apps/desktop-shell/src/main.ts
@@ -59,7 +59,12 @@ if (handleSquirrelStartup()) {
 if (!app.requestSingleInstanceLock()) {
   process.exit(0);
 }
-if (process.platform === "win32") {
+// Dev runs (`electron .`) share this process's win32 platform check but must not
+// register the production AUMID against node_modules/electron/dist/electron.exe —
+// Windows caches that pairing (Start Menu shortcut + jump-list store) keyed by the
+// AUMID string, and the generic Electron name/icon then bleeds into the real
+// packaged install on the same machine, surviving reinstalls.
+if (process.platform === "win32" && app.isPackaged) {
   app.setAppUserModelId(SQUIRREL_APP_ID);
 }
 

--- a/apps/desktop-shell/src/window-icon.test.ts
+++ b/apps/desktop-shell/src/window-icon.test.ts
@@ -1,0 +1,49 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveWindowIconPath } from "./window-icon.js";
+
+const appPath = path.join("/repo", "apps", "desktop-shell");
+const resourcesPath = path.join("/installed", "resources");
+
+describe("window icon", () => {
+  it("uses the checked-in ICO for Windows development", () => {
+    expect(
+      resolveWindowIconPath({
+        platform: "win32",
+        packaged: false,
+        appPath,
+        resourcesPath,
+      }),
+    ).toBe(path.join("/repo", "assets", "icons", "icon.ico"));
+  });
+
+  it("uses the staged ICO for packaged Windows builds", () => {
+    expect(
+      resolveWindowIconPath({
+        platform: "win32",
+        packaged: true,
+        appPath,
+        resourcesPath,
+      }),
+    ).toBe(path.join(resourcesPath, "icon.ico"));
+  });
+
+  it("uses PNG on Linux and the app bundle icon on macOS", () => {
+    expect(
+      resolveWindowIconPath({
+        platform: "linux",
+        packaged: false,
+        appPath,
+        resourcesPath,
+      }),
+    ).toBe(path.join("/repo", "assets", "icons", "icon.png"));
+    expect(
+      resolveWindowIconPath({
+        platform: "darwin",
+        packaged: false,
+        appPath,
+        resourcesPath,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop-shell/src/window-icon.ts
+++ b/apps/desktop-shell/src/window-icon.ts
@@ -1,0 +1,23 @@
+import path from "node:path";
+
+export interface WindowIconPaths {
+  platform: NodeJS.Platform;
+  packaged: boolean;
+  appPath: string;
+  resourcesPath: string;
+}
+
+export function resolveWindowIconPath({
+  platform,
+  packaged,
+  appPath,
+  resourcesPath,
+}: WindowIconPaths): string | undefined {
+  if (platform === "darwin") return undefined;
+
+  const iconName = platform === "win32" ? "icon.ico" : "icon.png";
+  const iconsDir = packaged
+    ? resourcesPath
+    : path.resolve(appPath, "..", "..", "assets", "icons");
+  return path.join(iconsDir, iconName);
+}

--- a/apps/desktop-shell/src/window-icon.ts
+++ b/apps/desktop-shell/src/window-icon.ts
@@ -18,6 +18,6 @@ export function resolveWindowIconPath({
   const iconName = platform === "win32" ? "icon.ico" : "icon.png";
   const iconsDir = packaged
     ? resourcesPath
-    : path.resolve(appPath, "..", "..", "assets", "icons");
+    : path.join(appPath, "..", "..", "assets", "icons");
   return path.join(iconsDir, iconName);
 }


### PR DESCRIPTION
# What and why

Closes #15.

- Set an explicit `.ico` on Windows `BrowserWindow` instances so development launches do not inherit Electron's taskbar icon.
- Use the checked-in PNG on Linux and leave macOS on its app-bundle icon.
- Stage both runtime icon assets in packaged resources and test platform/path selection.

## Gates

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

## Verified how

- [ ] Drove the change in a real app (web/desktop/CLI) - describe what you saw
- [x] Tests only (explain why that is sufficient here)

The full suite passed, including all 49 desktop-shell tests. `npm run desktop:package` also completed, and the packaged `resources/icon.ico` and `resources/icon.png` SHA-256 hashes match the checked-in assets. Visual Windows verification remains for Windows CI/manual review because this checkout is on macOS.

## Layering

- [x] `packages/core` gained no `node:*`, DOM, `deepagents`, or `@langchain/langgraph` import
- [x] Only `packages/runtime-langgraph` imports the graph engine
- [x] `apps/web` imports no runtime and no model binding
- [x] Docs touched by this change were updated (README / AGENTS.md / docs/ARCHITECTURE.md)
