### PR TITLE
fix: apply desktop provider secrets without restarting sidecar

### DIFF
--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -9,6 +9,7 @@
     "./agent-host": "./src/agent-host.ts",
     "./trigger-service": "./src/trigger-service.ts",
     "./protocol-run-manager": "./src/protocol-run-manager.ts",
+    "./sidecar-ipc": "./src/sidecar-ipc.ts",
     "./plugins-dir": "./src/plugins-dir.ts",
     "./package.json": "./package.json"
   },

--- a/apps/api-server/src/index.ts
+++ b/apps/api-server/src/index.ts
@@ -33,6 +33,11 @@ import {
   installProcessErrorHandlers,
   withLogContext,
 } from "@pizza-bot/logging";
+import {
+  applySidecarSecretUpdate,
+  isSidecarSecretUpdate,
+  type SidecarSecretUpdateResult,
+} from "./sidecar-ipc.js";
 
 export const API_VERSION = String(PROTOCOL_VERSION);
 
@@ -207,6 +212,23 @@ export async function main(): Promise<void> {
     .startAutomations()
     .catch((err) => console.error("[trigger-service] startup failed:", err));
 
+  const onParentMessage = (message: unknown): void => {
+    if (!isSidecarSecretUpdate(message)) return;
+    let ok = true;
+    try {
+      applySidecarSecretUpdate(message);
+    } catch {
+      ok = false;
+    }
+    const result: SidecarSecretUpdateResult = {
+      type: "secrets.updated",
+      requestId: message.requestId,
+      ok,
+    };
+    process.send?.(result);
+  };
+  process.on("message", onParentMessage);
+
   const server = serve({ fetch: app.fetch, hostname: network.hostname, port }, (info) => {
     console.log(
       `[api-server] listening on http://${network.hostname}:${info.port} ` +
@@ -225,6 +247,7 @@ export async function main(): Promise<void> {
   const shutdown = async (reason: string, exitAfter = false): Promise<void> => {
     if (closing) return;
     closing = true;
+    process.off("message", onParentMessage);
     console.log(`[api-server] ${reason}: shutting down`);
     const stopped = new Promise<void>((resolve) => server.close(() => resolve()));
     await host.close().catch((err) => console.error("[api-server] host close failed:", err));

--- a/apps/api-server/src/sidecar-ipc.test.ts
+++ b/apps/api-server/src/sidecar-ipc.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  applySidecarSecretUpdate,
+  isDesktopSecretName,
+  isSidecarSecretUpdate,
+  isSidecarSecretUpdateResult,
+  type SidecarSecretUpdate,
+} from "./sidecar-ipc.js";
+
+describe("sidecar secret IPC", () => {
+  it("accepts only desktop-owned secret names", () => {
+    expect(isDesktopSecretName("PIZZA_SECRET_OPENAI_APIKEY")).toBe(true);
+    expect(isDesktopSecretName("OPENAI_API_KEY")).toBe(false);
+    expect(isDesktopSecretName("PIZZA_API_TOKEN")).toBe(false);
+  });
+
+  it("validates update and acknowledgement messages", () => {
+    expect(
+      isSidecarSecretUpdate({
+        type: "secrets.update",
+        requestId: 1,
+        values: {
+          PIZZA_SECRET_OPENAI_APIKEY: "secret",
+          PIZZA_SECRET_OLD_KEY: null,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isSidecarSecretUpdate({
+        type: "secrets.update",
+        requestId: 1,
+        values: { PATH: "untrusted" },
+      }),
+    ).toBe(false);
+    expect(
+      isSidecarSecretUpdateResult({
+        type: "secrets.updated",
+        requestId: 1,
+        ok: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("applies additions and removals without retaining plaintext elsewhere", () => {
+    const env: NodeJS.ProcessEnv = {
+      PIZZA_SECRET_OLD_KEY: "old",
+      FIXED_VALUE: "unchanged",
+    };
+    const update: SidecarSecretUpdate = {
+      type: "secrets.update",
+      requestId: 1,
+      values: {
+        PIZZA_SECRET_OPENAI_APIKEY: "new",
+        PIZZA_SECRET_OLD_KEY: null,
+      },
+    };
+
+    applySidecarSecretUpdate(update, env);
+
+    expect(env).toEqual({
+      PIZZA_SECRET_OPENAI_APIKEY: "new",
+      FIXED_VALUE: "unchanged",
+    });
+  });
+});

--- a/apps/api-server/src/sidecar-ipc.ts
+++ b/apps/api-server/src/sidecar-ipc.ts
@@ -1,0 +1,60 @@
+/** Private parent/child messages used by the embedded desktop sidecar. */
+
+export interface SidecarSecretUpdate {
+  type: "secrets.update";
+  requestId: number;
+  values: Record<string, string | null>;
+}
+
+export interface SidecarSecretUpdateResult {
+  type: "secrets.updated";
+  requestId: number;
+  ok: boolean;
+}
+
+export function isDesktopSecretName(name: string): boolean {
+  return /^PIZZA_SECRET_[A-Za-z0-9_]+$/.test(name);
+}
+
+export function isSidecarSecretUpdate(value: unknown): value is SidecarSecretUpdate {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    (value as { type?: unknown }).type !== "secrets.update" ||
+    !Number.isSafeInteger((value as { requestId?: unknown }).requestId)
+  ) {
+    return false;
+  }
+  const values = (value as { values?: unknown }).values;
+  return Boolean(
+    values &&
+      typeof values === "object" &&
+      !Array.isArray(values) &&
+      Object.entries(values).every(
+        ([name, secret]) =>
+          isDesktopSecretName(name) && (typeof secret === "string" || secret === null),
+      ),
+  );
+}
+
+export function isSidecarSecretUpdateResult(
+  value: unknown,
+): value is SidecarSecretUpdateResult {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      (value as { type?: unknown }).type === "secrets.updated" &&
+      Number.isSafeInteger((value as { requestId?: unknown }).requestId) &&
+      typeof (value as { ok?: unknown }).ok === "boolean",
+  );
+}
+
+export function applySidecarSecretUpdate(
+  update: SidecarSecretUpdate,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  for (const [name, secret] of Object.entries(update.values)) {
+    if (secret === null) delete env[name];
+    else env[name] = secret;
+  }
+}

--- a/apps/desktop-shell/src/main.ts
+++ b/apps/desktop-shell/src/main.ts
@@ -112,12 +112,10 @@ let secretStore: SecretStore | undefined;
 let connectionStore: ConnectionStore | undefined;
 let notificationSettingsStore: NotificationSettingsStore | undefined;
 let notificationWatcher: ThreadActivityWatcher | undefined;
-let restartTimer: NodeJS.Timeout | undefined;
 let systemResumeTimer: NodeJS.Timeout | undefined;
 let shuttingDown = false;
 let rendererApiToken: string | undefined;
 let connectionChangeInFlight = false;
-let sidecarRestartInFlight = false;
 const activeNotifications = new BoundedRetention<Notification>(128);
 
 interface ActiveConnection {
@@ -385,16 +383,16 @@ function replaceWindowForConnection(connection: ActiveConnection): void {
   previous?.close();
 }
 
-/** Mutate encrypted secrets in main and restart the child to refresh its env. */
+/** Keep plaintext in main-to-sidecar IPC instead of the renderer's HTTP path. */
 function registerSecretIpc(): void {
   ipcMain.handle(SECRET_CHANNELS.list, () => secretStore?.list() ?? []);
-  ipcMain.handle(SECRET_CHANNELS.set, (_e, name: string, value: string) => {
+  ipcMain.handle(SECRET_CHANNELS.set, async (_e, name: string, value: string) => {
     secretStore?.set(name, value);
-    scheduleSidecarRestart();
+    await sidecar?.updateSecrets({ [name]: value });
   });
-  ipcMain.handle(SECRET_CHANNELS.delete, (_e, name: string) => {
+  ipcMain.handle(SECRET_CHANNELS.delete, async (_e, name: string) => {
     secretStore?.delete(name);
-    scheduleSidecarRestart();
+    await sidecar?.updateSecrets({ [name]: null });
   });
 }
 
@@ -408,10 +406,6 @@ function registerConnectionIpc(dataRoot: string): void {
     ) => {
       assertConnectionCanChange();
       connectionChangeInFlight = true;
-      if (restartTimer) {
-        clearTimeout(restartTimer);
-        restartTimer = undefined;
-      }
       try {
         const remoteUrl = normalizeRemoteUrl(input.remoteUrl);
         const savedToken = connectionStore?.remoteTokenFor(remoteUrl);
@@ -493,9 +487,6 @@ function assertConnectionCanChange(): void {
   if (connectionChangeInFlight) {
     throw new Error("A backend connection change is already in progress.");
   }
-  if (sidecarRestartInFlight) {
-    throw new Error("The embedded backend is restarting. Try again in a moment.");
-  }
 }
 
 function publicConnectionState(): {
@@ -533,53 +524,6 @@ async function activateRemoteConnection(next: ActiveConnection): Promise<void> {
   await oldSidecar
     ?.stop()
     .catch((err) => console.error("[shell] sidecar stop during remote switch failed:", err));
-}
-
-/** Coalesce secret changes because child env and the window API base are immutable. */
-function scheduleSidecarRestart(): void {
-  if (!sidecar) return;
-  if (restartTimer) clearTimeout(restartTimer);
-  restartTimer = setTimeout(() => {
-    restartTimer = undefined;
-    void restartSidecar();
-  }, 400);
-  restartTimer.unref?.();
-}
-
-async function restartSidecar(): Promise<void> {
-  if (
-    activeConnection?.mode !== "local" ||
-    sidecarRestartInFlight ||
-    connectionChangeInFlight
-  ) {
-    return;
-  }
-  sidecarRestartInFlight = true;
-  const dataRoot = resolveDataRoot();
-  const old = sidecar;
-  let nextSidecar: Sidecar | undefined;
-  try {
-    console.log("[shell] restarting sidecar to apply secret changes...");
-    sidecar = undefined;
-    await old?.stop();
-    const apiToken = localApiToken();
-    nextSidecar = await bootSidecar(dataRoot, apiToken);
-    sidecar = nextSidecar;
-    const next: ActiveConnection = {
-      mode: "local",
-      apiBase: nextSidecar.baseUrl,
-      apiToken,
-      managedByEnvironment: false,
-    };
-    setActiveConnection(next);
-    replaceWindowForConnection(next);
-  } catch (err) {
-    console.error("[shell] sidecar restart failed:", err);
-    await nextSidecar?.stop().catch(() => {});
-    sidecar = undefined;
-  } finally {
-    sidecarRestartInFlight = false;
-  }
 }
 
 function createWindow(connection: ActiveConnection): void {

--- a/apps/desktop-shell/src/sidecar.test.ts
+++ b/apps/desktop-shell/src/sidecar.test.ts
@@ -96,6 +96,35 @@ describe("startSidecar (real api-server)", () => {
         })
       ).status,
     ).toBe(200);
+    const originalEndpoint = sidecar.baseUrl;
+    const originalPid = sidecar.handshake.pid;
+    await sidecar.updateSecrets({
+      PIZZA_SECRET_TEST_APIKEY: "updated-without-restart",
+    });
+    const authHeaders = {
+      authorization: "Bearer sidecar-secret",
+      "content-type": "application/json",
+    };
+    const providerSave = await fetch(`${sidecar.baseUrl}/providers/openai`, {
+      method: "PUT",
+      headers: authHeaders,
+      body: JSON.stringify({
+        method: "api-key",
+        values: { apiKey: "${PIZZA_SECRET_TEST_APIKEY}" },
+      }),
+    });
+    expect(providerSave.status).toBe(200);
+    const preferenceSave = await fetch(
+      `${sidecar.baseUrl}/providers/openai/models`,
+      {
+        method: "PUT",
+        headers: authHeaders,
+        body: JSON.stringify({ mode: "all", selected: [] }),
+      },
+    );
+    expect(preferenceSave.status).toBe(200);
+    expect(sidecar.baseUrl).toBe(originalEndpoint);
+    expect(sidecar.handshake.pid).toBe(originalPid);
     await expect(sidecar.suspend()).resolves.toBe(true);
     await expect(sidecar.resume()).resolves.toBe(true);
 

--- a/apps/desktop-shell/src/sidecar.ts
+++ b/apps/desktop-shell/src/sidecar.ts
@@ -3,6 +3,11 @@ import { fork, execFileSync, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
+import {
+  isDesktopSecretName,
+  isSidecarSecretUpdateResult,
+  type SidecarSecretUpdate,
+} from "@pizza-bot/api-server/sidecar-ipc";
 import { findSystemNode } from "@pizza-bot/plugin-sdk/runtime-resolver";
 
 /**
@@ -80,6 +85,7 @@ export interface SidecarOptions {
 export interface Sidecar {
   readonly baseUrl: string;
   readonly handshake: SidecarHandshake;
+  updateSecrets(values: Record<string, string | null>): Promise<void>;
   suspend(): Promise<boolean>;
   resume(): Promise<boolean>;
   stop(): Promise<void>;
@@ -259,6 +265,7 @@ export async function startSidecar(opts: SidecarOptions): Promise<Sidecar> {
   let healthTimer: NodeJS.Timeout | undefined;
   let consecutiveFailures = 0;
   let restartInFlight: Promise<void> | undefined;
+  let secretRequestId = 0;
 
   const boot = await spawnOnce(opts);
   child = boot.child;
@@ -379,6 +386,64 @@ export async function startSidecar(opts: SidecarOptions): Promise<Sidecar> {
   }
   attach();
 
+  async function updateSecrets(values: Record<string, string | null>): Promise<void> {
+    if (!Object.keys(values).every(isDesktopSecretName)) {
+      throw new Error("sidecar secret update contains an invalid name");
+    }
+    if (stopped || !child.connected) {
+      throw new Error("sidecar IPC channel is unavailable");
+    }
+    const target = child;
+    const requestId = ++secretRequestId;
+    const message: SidecarSecretUpdate = {
+      type: "secrets.update",
+      requestId,
+      values,
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => finish(new Error("sidecar secret update timed out")),
+        healthTimeoutMs,
+      );
+      timeout.unref?.();
+
+      const onMessage = (response: unknown): void => {
+        if (
+          !isSidecarSecretUpdateResult(response) ||
+          response.requestId !== requestId
+        ) {
+          return;
+        }
+        finish(response.ok ? undefined : new Error("sidecar rejected secret update"));
+      };
+      const onExit = (): void => {
+        finish(new Error("sidecar exited during secret update"));
+      };
+      const finish = (error?: Error): void => {
+        clearTimeout(timeout);
+        target.off("message", onMessage);
+        target.off("exit", onExit);
+        if (error) reject(error);
+        else resolve();
+      };
+
+      target.on("message", onMessage);
+      target.once("exit", onExit);
+      try {
+        target.send(message, (error) => {
+          if (error) finish(new Error(`sidecar secret update failed: ${error.message}`));
+        });
+      } catch (error) {
+        finish(
+          error instanceof Error
+            ? error
+            : new Error("sidecar secret update failed"),
+        );
+      }
+    });
+  }
+
   // Self-scheduling prevents overlapping health requests.
   const scheduleHealth = (): void => {
     healthTimer = setTimeout(async () => {
@@ -418,6 +483,7 @@ export async function startSidecar(opts: SidecarOptions): Promise<Sidecar> {
     get handshake() {
       return handshake;
     },
+    updateSecrets,
     suspend: () => postLifecycle("suspend", healthTimeoutMs),
     resume: async () => {
       const healthy = await ping();

--- a/apps/web/src/lexicon.ts
+++ b/apps/web/src/lexicon.ts
@@ -52,7 +52,7 @@ export const L = {
   providerEnvBadge: "From environment",
   providerEnvNote: "This provider resolves its credentials from the ambient environment — no configuration needed.",
   secretRefHint: "Enter the name of an environment variable holding this secret, referenced as ${MY_VAR}. The value is never stored — only the reference.",
-  secretKeychainHint: "Stored encrypted in your OS keychain by the desktop app. The key never reaches the server or this page — only a reference is saved.",
+  secretKeychainHint: "Stored encrypted in your OS keychain by the desktop app. Only a generated reference is sent over HTTP or saved.",
   secretStoredPlaceholder: "•••••••• (stored — leave blank to keep)",
   secretUnavailablePlaceholder: "Enter this credential again",
   secretUnavailableHint: "The saved credential cannot be read by this app. Enter it again and save.",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -463,7 +463,9 @@ subscriptions recover after sleep or a half-open remote connection.
   notification preferences, and keeps the notification activity stream alive
   without a renderer window. `powerMonitor` coordinates suspend/resume with
   the embedded host; an unhealthy child is restarted, while a healthy child
-  reconnects MCP before recovering schedules.
+  reconnects MCP before recovering schedules. Keychain secret changes reach the
+  existing sidecar over private parent/child IPC, so provider edits do not
+  restart the host or unrelated MCP servers.
 - **cli** — a thin REPL driving the SDK `Client`/`ThreadStream` over HTTP against
   a running server (`PIZZA_REMOTE_URL`, default `http://localhost:8080`;
   `PIZZA_API_TOKEN` for bearer auth). It boots no runtime of its own — the same
@@ -580,7 +582,9 @@ not that path. Its limitations are explicit:
 A provider-configuration UI ships in Settings (`ProvidersSettings.tsx`): a
 declarative auth-field schema per provider renders a generic config form, and
 secrets go to the OS keychain via the desktop shell's `safeStorage` bridge —
-**never** plaintext on disk and never sent to the browser.
+**never** plaintext on disk or HTTP and never sent back to the browser. The
+desktop main process updates the embedded sidecar's environment over its private
+child-process IPC channel.
 
 ---
 


### PR DESCRIPTION
## Summary

- deliver desktop keychain secret changes to the live embedded API over private parent/child IPC
- validate and acknowledge only desktop-owned `PIZZA_SECRET_*` updates without restarting the sidecar, renderer, streams, or MCP children
- cover the complete secret update, provider save, and model-preference save sequence while asserting the sidecar PID and endpoint remain stable
- correct the provider keychain hint and document the desktop secret boundary

Fixes #18

## Verification

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm test` (18 tasks passed, including 339 API and 46 desktop tests)
- manually verified in the desktop app by the reporter