### PR TITLE
Support Bedrock Mantle Responses and Messages APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ CLI development, desktop packages, and remote backends.
 | Terminal CLI | Scripts, terminals, and remote backends | [CLI](docs/RUNNING.md#cli) |
 | Standalone backend | Remote Electron, Docker, or Linux services | [Backend guide](docs/STANDALONE_BACKEND.md) |
 
+A running api-server needs access to at least one model provider; HTTP clients
+do not. Configure Amazon Bedrock, Anthropic, Google Gemini, OpenAI, OpenRouter,
+or Ollama in **Settings > Providers**. Bedrock accepts an AWS profile, AWS
+access keys, or a Bedrock API key, with an optional region override; otherwise
+`AWS_REGION` or `us-west-2` is used. Bedrock combines its native catalog with
+the regional Mantle catalog and routes models through Converse, OpenAI
+Responses, or Anthropic Messages according to their advertised API family.
+OpenAI and Anthropic also accept custom Base URLs for compatible endpoints;
+OpenAI can explicitly select Responses or Chat Completions, and Anthropic
+supports `x-api-key` or bearer authentication. Select a model with
+`PIZZA_MODEL=<provider>:<id>`. Desktop-entered secrets go to the OS keychain;
+server configuration persists only environment-variable references.
+
 ## Extend it
 
 Add MCP servers from the UI or `<PIZZA_DATA_ROOT>/.mcp.json`. Add Agent Skills

--- a/apps/api-server/src/routes-providers.test.ts
+++ b/apps/api-server/src/routes-providers.test.ts
@@ -227,14 +227,34 @@ describe("provider routes", () => {
   it("passes a non-secret field through unredacted", async () => {
     await put("openai", {
       method: "api-key",
-      values: { apiKey: "${OPENAI_API_KEY}", baseUrl: "https://proxy.example.com/v1" },
+      values: {
+        apiKey: "${OPENAI_API_KEY}",
+        baseUrl: "https://proxy.example.com/v1",
+        apiMode: "responses",
+      },
     });
     const openai = (await list()).find((p) => p.id === "openai")!;
     expect(openai.config?.values.baseUrl).toBe("https://proxy.example.com/v1");
+    expect(openai.config?.values.apiMode).toBe("responses");
     expect(openai.config?.values.apiKey).toEqual({
       hasValue: true,
       available: false,
     });
+
+    await put("anthropic", {
+      method: "api-key",
+      values: {
+        apiKey: "${ANTHROPIC_API_KEY}",
+        baseUrl: "https://proxy.example.com/anthropic",
+        authMode: "api-key",
+        catalogProvider: "anthropic-compatible",
+      },
+    });
+    const anthropic = (await list()).find((p) => p.id === "anthropic")!;
+    expect(anthropic.config?.values.baseUrl)
+      .toBe("https://proxy.example.com/anthropic");
+    expect(anthropic.config?.values.authMode).toBe("api-key");
+    expect(anthropic.config?.values.catalogProvider).toBe("anthropic-compatible");
   });
 
   it("rejects a raw secret value with 400 and persists nothing", async () => {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -532,7 +532,16 @@ under `inference-providers/providers/<id>` (Bedrock keeps its own subdirectory f
 the shim's multiple files). Provider quirks stay provider-local: the Bedrock
 adapter (`inference-providers/providers/bedrock`) owns the `maxTokens` default
 (8192, so Sonnet-5 adaptive thinking can't blank a turn) and a temporary
-reasoning-replay shim; a new provider owns its own.
+reasoning-replay shim. It also combines native Bedrock discovery with Mantle's
+regional `/v1/models` catalog and records the protocol supplied by each source:
+inference profiles and other native models use Converse, raw OpenAI model
+families use Responses, and raw Anthropic model families use Messages. Mantle
+catalog entries retain the protocol family exposed by that catalog. The regional
+Mantle host and protocol paths are Bedrock concerns, and its HTTP transport
+supports both Bedrock API keys and SigV4 credentials. The OpenAI adapter
+independently selects Automatic, Responses, or Chat Completions for custom
+compatible endpoints. The Anthropic adapter likewise owns custom Messages API
+endpoints and `x-api-key` versus bearer authentication.
 
 Skill workers mark terminal responses whose provider metadata reports an
 output-token limit with an `OUTPUT_TRUNCATED` notice. DeepAgents carries that
@@ -540,8 +549,8 @@ notice in the task result so Pizza Bot can distinguish incomplete delegated work
 from a completed result. The worker does not retry the model call, and this
 behavior is not installed on Pizza Bot itself.
 
-The Bedrock shim subclasses `ChatBedrockConverse` and strips prior reasoning
-blocks only at its three model-call entry points. This is intentionally below
+The Bedrock Converse shim subclasses `ChatBedrockConverse` and strips prior
+reasoning blocks only at its three model-call entry points. This is intentionally below
 DeepAgents: Pizza Bot and all skill workers use ordinary initialized LangChain
 model instances, with no replacement subgraphs. The shim is
 necessary because `@langchain/aws` currently discards Bedrock reasoning signatures

--- a/package-lock.json
+++ b/package-lock.json
@@ -16042,7 +16042,8 @@
         "@langchain/openrouter": "^0.4.6",
         "@pizza-bot/core": "*",
         "@pizza-bot/plugin-sdk": "*",
-        "@smithy/core": "^3.31.1"
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12"
       }
     },
     "packages/logging": {

--- a/packages/inference-providers/package.json
+++ b/packages/inference-providers/package.json
@@ -25,6 +25,7 @@
     "@langchain/openrouter": "^0.4.6",
     "@pizza-bot/core": "*",
     "@pizza-bot/plugin-sdk": "*",
-    "@smithy/core": "^3.31.1"
+    "@smithy/core": "^3.31.1",
+    "@smithy/signature-v4": "^5.6.12"
   }
 }

--- a/packages/inference-providers/src/providers/anthropic.test.ts
+++ b/packages/inference-providers/src/providers/anthropic.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
-import { AnthropicLangChainModelProvider } from "./anthropic.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AnthropicLangChainModelProvider, normalizeBaseUrl } from "./anthropic.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("Anthropic model discovery", () => {
   it("lists models returned by Anthropic", async () => {
@@ -12,9 +16,10 @@ describe("Anthropic model discovery", () => {
     const provider = new AnthropicLangChainModelProvider({
       apiKey: "test-key",
       baseUrl: "https://anthropic.example/",
+      catalogProvider: "anthropic-compatible",
       fetch: fetchFn,
       modelsDevFetch: vi.fn(async () => new Response(JSON.stringify({
-        anthropic: {
+        "anthropic-compatible": {
           models: {
             "claude-sonnet-5": {
               limit: { context: 1_000_000, output: 128_000 },
@@ -59,6 +64,7 @@ describe("Anthropic model discovery", () => {
       retryable: false,
     });
   });
+
 });
 
 describe("Anthropic model construction", () => {
@@ -87,4 +93,194 @@ describe("Anthropic model construction", () => {
       toolCalling: true,
     });
   });
+
+  it("streams tool calls through a custom Messages endpoint", async () => {
+    const requests: Array<{
+      url: string;
+      authorization: string | null;
+      apiKey: string | null;
+      hasTool: boolean;
+    }> = [];
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      requests.push({
+        url: String(input),
+        authorization: headers.get("authorization"),
+        apiKey: headers.get("x-api-key"),
+        hasTool: String(init?.body).includes("lookup"),
+      });
+      return eventStream([
+        {
+          type: "message_start",
+          message: {
+            id: "msg_1",
+            type: "message",
+            role: "assistant",
+            model: "anthropic.claude-opus-5",
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 10, output_tokens: 1 },
+          },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "lookup",
+            input: {},
+          },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: "{}" },
+        },
+        { type: "content_block_stop", index: 0 },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "tool_use", stop_sequence: null },
+          usage: { output_tokens: 5 },
+        },
+        { type: "message_stop" },
+      ]);
+    }));
+    const provider = new AnthropicLangChainModelProvider({
+      models: [{
+        id: "anthropic.claude-opus-5",
+        provider: "anthropic",
+        displayName: "Claude Opus 5",
+      }],
+    });
+    provider.configure({
+      method: "api-key",
+      values: {
+        apiKey: "test-key",
+        baseUrl: "https://proxy.example/anthropic",
+        authMode: "api-key",
+      },
+    });
+
+    const model = await provider.buildModel("anthropic.claude-opus-5");
+    const chunks = await collect(model.bindTools!([TEST_TOOL]).stream("hello"));
+    const toolChunks = chunks.flatMap(
+      (chunk) => (chunk as { tool_call_chunks?: Array<{ name?: string; args?: string }> })
+        .tool_call_chunks ?? [],
+    );
+
+    expect(requests).toEqual([{
+      url: "https://proxy.example/anthropic/v1/messages",
+      authorization: null,
+      apiKey: "test-key",
+      hasTool: true,
+    }]);
+    expect(toolChunks).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "lookup" }),
+      expect.objectContaining({ args: "{}" }),
+    ]));
+  });
+
+  it("supports bearer authentication with a custom Messages URL", async () => {
+    const requests: Array<{
+      url: string;
+      authorization: string | null;
+      apiKey: string | null;
+    }> = [];
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      requests.push({
+        url: String(input),
+        authorization: headers.get("authorization"),
+        apiKey: headers.get("x-api-key"),
+      });
+      return anthropicError("stop");
+    }));
+    const provider = new AnthropicLangChainModelProvider({
+      apiKey: "test-key",
+      baseUrl: "https://proxy.example/anthropic/v1/messages",
+      authMode: "bearer",
+      models: [{
+        id: "anthropic.claude-opus-5",
+        provider: "anthropic",
+        displayName: "Claude Opus 5",
+      }],
+    });
+
+    const model = await provider.buildModel("anthropic.claude-opus-5");
+    await expect(collect(model.stream("hello"))).rejects.toThrow("stop");
+
+    expect(requests).toEqual([{
+      url: "https://proxy.example/anthropic/v1/messages",
+      authorization: "Bearer test-key",
+      apiKey: null,
+    }]);
+  });
+
+  it("exposes custom endpoint metadata and bearer authentication in provider settings", () => {
+    const provider = new AnthropicLangChainModelProvider();
+    const fields = provider.authSchema[0]?.fields;
+
+    expect(fields?.find((field) => field.key === "baseUrl")).toMatchObject({
+      type: "text",
+      required: false,
+    });
+    expect(fields?.find((field) => field.key === "authMode")).toMatchObject({
+      type: "select",
+      default: "api-key",
+      options: [
+        { value: "api-key" },
+        { value: "bearer" },
+      ],
+    });
+    expect(fields?.find((field) => field.key === "catalogProvider")).toMatchObject({
+      label: "models.dev provider",
+      type: "text",
+      required: false,
+    });
+  });
 });
+
+describe("Anthropic endpoint normalization", () => {
+  it("accepts either an API base URL or a full Messages URL", () => {
+    expect(normalizeBaseUrl("https://api.anthropic.com/")).toBe("https://api.anthropic.com");
+    expect(normalizeBaseUrl(
+      "https://proxy.example/anthropic/v1/messages",
+    )).toBe("https://proxy.example/anthropic");
+  });
+});
+
+const TEST_TOOL = {
+  type: "function" as const,
+  function: {
+    name: "lookup",
+    description: "Look up a value",
+    parameters: { type: "object", properties: {} },
+  },
+};
+
+function anthropicError(message: string): Response {
+  return new Response(JSON.stringify({
+    error: { message, type: "invalid_request_error" },
+  }), {
+    status: 400,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function collect<T>(stream: Promise<AsyncIterable<T>>): Promise<T[]> {
+  const chunks: T[] = [];
+  for await (const chunk of await stream) chunks.push(chunk);
+  return chunks;
+}
+
+function eventStream(events: Array<{ type: string } & Record<string, unknown>>): Response {
+  const body = events
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}

--- a/packages/inference-providers/src/providers/anthropic.ts
+++ b/packages/inference-providers/src/providers/anthropic.ts
@@ -16,6 +16,8 @@ import {
 const DEFAULT_BASE_URL = "https://api.anthropic.com";
 const FETCH_TIMEOUT_MS = 5_000;
 
+export type AnthropicAuthMode = "api-key" | "bearer";
+
 interface AnthropicModelsResponse {
   data?: Array<{ id?: string; display_name?: string }>;
 }
@@ -67,6 +69,8 @@ export interface AnthropicProviderOptions {
   fetch?: typeof fetch;
   modelsDev?: ModelsDevCatalogLoader;
   modelsDevFetch?: typeof fetch;
+  authMode?: AnthropicAuthMode;
+  catalogProvider?: string;
 }
 
 class AnthropicBuildError extends Error {
@@ -84,7 +88,32 @@ const AUTH_SCHEMA: readonly ProviderAuthMethod[] = [
   {
     id: "api-key",
     label: "API key",
-    fields: [{ key: "apiKey", label: "API key", type: "password", required: true }],
+    fields: [
+      {
+        key: "apiKey",
+        label: "API key or bearer token",
+        type: "password",
+        required: true,
+      },
+      { key: "baseUrl", label: "Base URL", type: "text", required: false },
+      {
+        key: "authMode",
+        label: "Authentication",
+        type: "select",
+        required: false,
+        default: "api-key",
+        options: [
+          { value: "api-key", label: "API key (x-api-key)" },
+          { value: "bearer", label: "Bearer token (Authorization)" },
+        ],
+      },
+      {
+        key: "catalogProvider",
+        label: "models.dev provider",
+        type: "text",
+        required: false,
+      },
+    ],
   },
 ];
 
@@ -93,19 +122,23 @@ export class AnthropicLangChainModelProvider implements ModelProvider {
   readonly authSchema = AUTH_SCHEMA;
   private readonly models: ModelDescriptor[] | undefined;
   private readonly maxTokens: number;
-  private readonly baseUrl: string;
   private readonly fetchFn: typeof fetch;
   private readonly modelsDev: ModelsDevCatalogLoader;
   private readonly descriptors = new Map<string, ModelDescriptor>();
   private apiKey: string | undefined;
+  private baseUrl: string | undefined;
+  private authMode: AnthropicAuthMode;
+  private catalogProvider: string | undefined;
 
   constructor(opts: AnthropicProviderOptions = {}) {
     this.models = opts.models;
     this.maxTokens = resolveMaxTokens(opts.maxTokens);
-    this.baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+    this.baseUrl = normalizeBaseUrl(opts.baseUrl);
     this.fetchFn = opts.fetch ?? fetch;
     this.modelsDev = resolveModelsDevCatalog(opts.modelsDev, opts.modelsDevFetch);
     this.apiKey = opts.apiKey;
+    this.authMode = opts.authMode ?? "api-key";
+    this.catalogProvider = opts.catalogProvider;
     for (const descriptor of opts.models ?? []) {
       this.descriptors.set(descriptor.id, descriptor);
     }
@@ -114,6 +147,9 @@ export class AnthropicLangChainModelProvider implements ModelProvider {
   configure(cfg: ResolvedProviderConfig): void {
     const key = cfg.values.apiKey?.trim();
     if (key) this.apiKey = key;
+    this.baseUrl = normalizeBaseUrl(cfg.values.baseUrl);
+    this.authMode = cfg.values.authMode === "bearer" ? "bearer" : "api-key";
+    this.catalogProvider = cfg.values.catalogProvider?.trim() || undefined;
     if (!this.models) this.descriptors.clear();
   }
 
@@ -121,13 +157,12 @@ export class AnthropicLangChainModelProvider implements ModelProvider {
     if (this.models) return this.models;
     const apiKey = this.apiKey ?? process.env.ANTHROPIC_API_KEY;
     if (!apiKey) throw missingCatalogCredentials("Anthropic");
+    const baseUrl = this.resolvedBaseUrl();
+    const catalog = modelCatalogRequest(baseUrl, this.authHeaders(apiKey));
 
     try {
-      const response = await this.fetchFn(`${this.baseUrl}/v1/models?limit=1000`, {
-        headers: {
-          "anthropic-version": "2023-06-01",
-          "x-api-key": apiKey,
-        },
+      const response = await this.fetchFn(catalog.url, {
+        headers: catalog.headers,
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
       if (!response.ok) throw catalogHttpError("Anthropic", response.status);
@@ -142,7 +177,11 @@ export class AnthropicLangChainModelProvider implements ModelProvider {
           supportsVision: true,
         }];
       });
-      const descriptors = await enrichModelDescriptors(discovered, "anthropic", this.modelsDev);
+      const descriptors = await enrichModelDescriptors(
+        discovered,
+        this.catalogProvider ?? "anthropic",
+        this.modelsDev,
+      );
       this.descriptors.clear();
       for (const descriptor of descriptors) {
         this.descriptors.set(descriptor.id, descriptor);
@@ -165,7 +204,6 @@ export class AnthropicLangChainModelProvider implements ModelProvider {
   }
 
   private async construct(modelId: string): Promise<BaseChatModel> {
-    const { ChatAnthropic } = await import("@langchain/anthropic");
     const apiKey = this.apiKey ?? process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
       throw new AnthropicBuildError("No Anthropic API key configured (set ANTHROPIC_API_KEY).", "AUTH_EXPIRED");
@@ -174,17 +212,100 @@ export class AnthropicLangChainModelProvider implements ModelProvider {
       await this.listModels().catch(() => []);
     }
     const descriptor = this.descriptors.get(modelId);
-
-    class ContextAwareChatAnthropic extends ChatAnthropic {
-      override get profile() {
-        return withContextWindow(super.profile, descriptor?.contextWindow);
-      }
-    }
-
-    return new ContextAwareChatAnthropic({
-      model: modelId,
+    return createAnthropicChatModel({
+      modelId,
       apiKey,
       maxTokens: this.maxTokens,
+      baseUrl: this.resolvedBaseUrl(),
+      authMode: this.authMode,
+      fetch: this.fetchFn,
+      ...(descriptor ? { descriptor } : {}),
     });
   }
+
+  private resolvedBaseUrl(): string {
+    return this.baseUrl ??
+      normalizeBaseUrl(process.env.ANTHROPIC_BASE_URL ?? process.env.ANTHROPIC_API_URL) ??
+      DEFAULT_BASE_URL;
+  }
+
+  private authHeaders(apiKey: string): Record<string, string> {
+    return {
+      "anthropic-version": "2023-06-01",
+      ...(this.authMode === "bearer"
+        ? { authorization: `Bearer ${apiKey}` }
+        : { "x-api-key": apiKey }),
+    };
+  }
+}
+
+export interface AnthropicChatModelOptions {
+  modelId: string;
+  apiKey: string;
+  maxTokens: number;
+  baseUrl: string;
+  authMode: AnthropicAuthMode;
+  descriptor?: ModelDescriptor;
+  fetch?: typeof fetch;
+}
+
+export async function createAnthropicChatModel(
+  options: AnthropicChatModelOptions,
+): Promise<BaseChatModel> {
+  const { ChatAnthropic } = await import("@langchain/anthropic");
+  const {
+    modelId,
+    apiKey,
+    maxTokens,
+    baseUrl,
+    authMode,
+    descriptor,
+    fetch: fetchFn,
+  } = options;
+  const defaultHeaders = authMode === "bearer"
+    ? {
+        authorization: `Bearer ${apiKey}`,
+        "x-api-key": null,
+      }
+    : undefined;
+
+  class ContextAwareChatAnthropic extends ChatAnthropic {
+    override get profile() {
+      return withContextWindow(super.profile, descriptor?.contextWindow);
+    }
+  }
+
+  return new ContextAwareChatAnthropic({
+    model: modelId,
+    apiKey,
+    maxTokens,
+    anthropicApiUrl: baseUrl,
+    ...((defaultHeaders || fetchFn)
+      ? {
+          clientOptions: {
+            ...(defaultHeaders ? { defaultHeaders } : {}),
+            ...(fetchFn ? { fetch: fetchFn } : {}),
+          },
+        }
+      : {}),
+  });
+}
+
+export function normalizeBaseUrl(value: string | undefined): string | undefined {
+  const baseUrl = value?.trim().replace(/\/+$/, "");
+  if (!baseUrl) return undefined;
+  return baseUrl.replace(/\/v1\/messages$/i, "");
+}
+
+function modelCatalogRequest(
+  baseUrl: string,
+  defaultHeaders: Record<string, string>,
+): {
+  url: string;
+  headers: Record<string, string>;
+} {
+  return {
+    url: `${baseUrl}/v1/models?limit=1000`,
+    headers: defaultHeaders,
+  };
 }

--- a/packages/inference-providers/src/providers/bedrock/langchain.test.ts
+++ b/packages/inference-providers/src/providers/bedrock/langchain.test.ts
@@ -11,6 +11,7 @@ const sdk = vi.hoisted(() => ({
   nodeCredentials: Symbol("node-credentials"),
   fromIni: vi.fn(),
   fromNodeProviderChain: vi.fn(),
+  mantleFetch: vi.fn(),
 }));
 
 vi.mock("@aws-sdk/credential-providers", () => ({
@@ -73,6 +74,11 @@ describe("BedrockLangChainModelProvider authentication", () => {
     sdk.bedrockSend.mockReset().mockResolvedValue({});
     sdk.fromIni.mockReset().mockReturnValue(sdk.iniCredentials);
     sdk.fromNodeProviderChain.mockReset().mockReturnValue(sdk.nodeCredentials);
+    sdk.mantleFetch.mockReset().mockResolvedValue(new Response(
+      JSON.stringify({ data: [] }),
+      { status: 200 },
+    ));
+    vi.stubGlobal("fetch", sdk.mantleFetch);
   });
 
   it("exposes discovered profiles and uses the configured profile for credentials", async () => {
@@ -101,9 +107,10 @@ describe("BedrockLangChainModelProvider authentication", () => {
 
     await provider.buildModel("global.anthropic.claude-sonnet-5");
 
-    expect(sdk.fromIni).toHaveBeenCalledTimes(2);
+    expect(sdk.fromIni).toHaveBeenCalledTimes(3);
     expect(sdk.fromIni).toHaveBeenNthCalledWith(1, { profile: "production" });
     expect(sdk.fromIni).toHaveBeenNthCalledWith(2, { profile: "production" });
+    expect(sdk.fromIni).toHaveBeenNthCalledWith(3, { profile: "production" });
     expect(sdk.fromNodeProviderChain).not.toHaveBeenCalled();
     expect(sdk.chatConfig?.credentials).toBe(sdk.iniCredentials);
   });
@@ -243,6 +250,32 @@ describe("BedrockLangChainModelProvider authentication", () => {
     });
   });
 
+  it("reuses the Mantle signer until provider configuration changes", async () => {
+    sdk.fromIni.mockReturnValue({
+      accessKeyId: "access-key",
+      secretAccessKey: "secret-key",
+    });
+    sdk.mantleFetch.mockImplementation(async () => new Response(JSON.stringify({
+      data: [{ id: "openai.gpt-5.6-sol", display_name: "GPT-5.6 Sol" }],
+    }), { status: 200 }));
+    const provider = new BedrockLangChainModelProvider({
+      profiles: ["production"],
+    });
+    provider.configure({ method: "aws-profile", values: { profile: "production" } });
+
+    await provider.listModels();
+    expect(sdk.fromIni).toHaveBeenCalledTimes(2);
+
+    await provider.buildModel("openai.gpt-5.6-sol");
+
+    expect(sdk.fromIni).toHaveBeenCalledTimes(2);
+
+    provider.configure({ method: "aws-profile", values: { profile: "production" } });
+    await provider.listModels();
+
+    expect(sdk.fromIni).toHaveBeenCalledTimes(4);
+  });
+
   it("clears credentials from the previously selected method", async () => {
     const provider = new BedrockLangChainModelProvider();
     provider.configure({
@@ -334,6 +367,7 @@ describe("BedrockLangChainModelProvider authentication", () => {
     await expect(provider.listModels()).resolves.toEqual([
       expect.objectContaining({
         id: "global.anthropic.claude-sonnet-5",
+        displayName: "Global Claude Sonnet 5 (Runtime)",
         contextWindow: 1_000_000,
         maxOutputTokens: 128_000,
         supportsVision: true,

--- a/packages/inference-providers/src/providers/bedrock/langchain.ts
+++ b/packages/inference-providers/src/providers/bedrock/langchain.ts
@@ -1,4 +1,4 @@
-/** Amazon Bedrock provider backed by lazy-loaded `ChatBedrockConverse`. */
+/** Amazon Bedrock provider with native Converse and Mantle protocol routing. */
 import type { BaseMessage } from "@langchain/core/messages";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type {
@@ -30,8 +30,19 @@ import {
 import { withContextWindow } from "../../model-profile.js";
 import {
   catalogConnectionError,
+  catalogHttpError,
   missingCatalogCredentials,
 } from "../../catalog-error.js";
+import { createAnthropicChatModel } from "../anthropic.js";
+import { createOpenAiChatModel } from "../openai.js";
+import { createSigV4Fetch, mantleEndpoint } from "./mantle.js";
+
+type BedrockProtocol = "converse" | "responses" | "messages";
+
+interface RoutedModel {
+  descriptor: ModelDescriptor;
+  protocol: BedrockProtocol;
+}
 
 class BedrockBuildError extends Error {
   constructor(
@@ -51,8 +62,12 @@ export class BedrockLangChainModelProvider implements ModelProvider {
   private readonly models: ModelDescriptor[] | undefined;
   private readonly maxTokens: number;
   private readonly client: { send(command: unknown): Promise<unknown> } | undefined;
+  private readonly fetchFn: typeof fetch;
   private readonly modelsDev: ModelsDevCatalogLoader;
   private readonly descriptors = new Map<string, ModelDescriptor>();
+  private readonly protocols = new Map<string, BedrockProtocol>();
+  private readonly learnedMaxTokens = new Map<string, number>();
+  private mantleFetchPromise: Promise<typeof fetch> | undefined;
   private region: string;
   private authMethod: "aws-profile" | "access-keys" | "bedrock-api-key" | undefined;
   private profile: string | undefined;
@@ -67,9 +82,11 @@ export class BedrockLangChainModelProvider implements ModelProvider {
     this.models = opts.models;
     this.maxTokens = resolveMaxTokens(opts.maxTokens);
     this.client = opts.client;
+    this.fetchFn = opts.fetch ?? fetch;
     this.modelsDev = resolveModelsDevCatalog(opts.modelsDev, opts.modelsDevFetch);
     for (const descriptor of opts.models ?? []) {
       this.descriptors.set(descriptor.id, descriptor);
+      this.protocols.set(descriptor.id, defaultProtocol(descriptor.id));
     }
     this.profile = opts.profile?.trim() || undefined;
     this.authMethod = this.profile ? "aws-profile" : undefined;
@@ -164,7 +181,9 @@ export class BedrockLangChainModelProvider implements ModelProvider {
     this.bedrockApiKey = cfg.method === "bedrock-api-key"
       ? cfg.values.apiKey?.trim() || undefined
       : undefined;
+    this.mantleFetchPromise = undefined;
     if (!this.models) this.descriptors.clear();
+    if (!this.models) this.protocols.clear();
   }
 
   async listModels(): Promise<ModelDescriptor[]> {
@@ -178,33 +197,49 @@ export class BedrockLangChainModelProvider implements ModelProvider {
         ListInferenceProfilesCommand,
       } = await import("@aws-sdk/client-bedrock");
       const client = this.client ?? new BedrockClient(await this.clientConfig());
-      const [foundationResult, profileResult] = await Promise.allSettled([
+      const [foundationResult, profileResult, mantleResult] = await Promise.allSettled([
         client.send(new ListFoundationModelsCommand({
           byInferenceType: "ON_DEMAND",
           byOutputModality: "TEXT",
         })),
         client.send(new ListInferenceProfilesCommand({ maxResults: 1000 })),
+        this.listMantleModels(),
       ]);
       const foundationModels = foundationResult.status === "fulfilled"
-        ? foundationDescriptors(foundationResult.value)
+        ? foundationDescriptors(foundationResult.value).map(withDefaultProtocol)
         : [];
       const inferenceProfiles = profileResult.status === "fulfilled"
-        ? profileDescriptors(profileResult.value)
+        ? profileDescriptors(profileResult.value).map(withConverseProtocol)
+        : [];
+      const mantleModels = mantleResult.status === "fulfilled"
+        ? mantleResult.value
         : [];
       if (
         foundationResult.status === "rejected" &&
-        profileResult.status === "rejected"
+        profileResult.status === "rejected" &&
+        mantleResult.status === "rejected"
       ) {
         throw foundationResult.reason;
       }
+      const routed = mergeRoutedModels([
+        ...inferenceProfiles,
+        ...foundationModels,
+        ...mantleModels,
+      ]);
       const descriptors = await enrichModelDescriptors(
-        dedupeModels([...inferenceProfiles, ...foundationModels]),
+        routed.map(({ descriptor, protocol }) => ({
+          ...descriptor,
+          displayName: protocolDisplayName(descriptor.displayName, protocol),
+        })),
         "amazon-bedrock",
         this.modelsDev,
       );
       this.descriptors.clear();
-      for (const descriptor of descriptors) {
+      this.protocols.clear();
+      for (const [index, descriptor] of descriptors.entries()) {
         this.descriptors.set(descriptor.id, descriptor);
+        const protocol = routed[index]?.protocol;
+        if (protocol) this.protocols.set(descriptor.id, protocol);
       }
       return descriptors;
     } catch (cause) {
@@ -234,12 +269,53 @@ export class BedrockLangChainModelProvider implements ModelProvider {
   }
 
   private async construct(modelId: string): Promise<BaseChatModel> {
-    const { ChatBedrockConverse } = await import("@langchain/aws");
-
     if (!this.descriptors.has(modelId)) {
       await this.listModels().catch(() => []);
     }
     const descriptor = this.descriptors.get(modelId);
+    const protocol = this.protocols.get(modelId) ?? defaultProtocol(modelId);
+    if (protocol === "responses") {
+      const configuredMax = Math.min(
+        this.maxTokens,
+        descriptor?.maxOutputTokens ?? Number.POSITIVE_INFINITY,
+      );
+      return createOpenAiChatModel({
+        modelId,
+        apiKey: this.bedrockApiKey ?? "bedrock-sigv4",
+        maxTokens: Math.min(
+          configuredMax,
+          this.learnedMaxTokens.get(modelId) ?? Number.POSITIVE_INFINITY,
+        ),
+        apiMode: "responses",
+        baseUrl: `${mantleEndpoint(this.region)}/openai/v1`,
+        fetch: await this.mantleFetch(),
+        learnedMaxTokens: this.learnedMaxTokens,
+        ...(descriptor ? { descriptor } : {}),
+      });
+    }
+    if (protocol === "messages") {
+      return createAnthropicChatModel({
+        modelId,
+        apiKey: this.bedrockApiKey ?? "bedrock-sigv4",
+        maxTokens: Math.min(
+          this.maxTokens,
+          descriptor?.maxOutputTokens ?? Number.POSITIVE_INFINITY,
+        ),
+        baseUrl: `${mantleEndpoint(this.region)}/anthropic`,
+        authMode: "api-key",
+        fetch: await this.mantleFetch(),
+        ...(descriptor ? { descriptor } : {}),
+      });
+    }
+
+    return this.constructConverse(modelId, descriptor);
+  }
+
+  private async constructConverse(
+    modelId: string,
+    descriptor: ModelDescriptor | undefined,
+  ): Promise<BaseChatModel> {
+    const { ChatBedrockConverse } = await import("@langchain/aws");
     const reasoning = supportsReasoning(modelId);
 
     // The base signatures use `this["ParsedCallOptions"]`, which cannot be named
@@ -310,6 +386,41 @@ export class BedrockLangChainModelProvider implements ModelProvider {
     });
   }
 
+  private async listMantleModels(): Promise<RoutedModel[]> {
+    const response = await (await this.mantleFetch())(
+      `${mantleEndpoint(this.region)}/v1/models`,
+      {
+        ...(this.bedrockApiKey
+          ? { headers: { authorization: `Bearer ${this.bedrockApiKey}` } }
+          : {}),
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+    if (!response.ok) throw catalogHttpError("Amazon Bedrock Mantle", response.status);
+    const body = (await response.json()) as MantleModelsResponse;
+    return (body.data ?? []).flatMap((model) => {
+      if (!model.id || !isConversationalModel(model.id)) return [];
+      return [{
+        descriptor: {
+          id: model.id,
+          provider: "bedrock",
+          displayName: `${model.display_name ?? model.id} (Bedrock)`,
+          supportsTools: true,
+        },
+        protocol: model.id.toLowerCase().startsWith("anthropic.")
+          ? "messages"
+          : "responses",
+      }];
+    });
+  }
+
+  private async mantleFetch(): Promise<typeof fetch> {
+    if (this.bedrockApiKey) return this.fetchFn;
+    this.mantleFetchPromise ??= (async () =>
+      createSigV4Fetch(this.region, await this.credentials(), this.fetchFn))();
+    return this.mantleFetchPromise;
+  }
+
   private async credentials() {
     if (this.accessKeyId && this.secretAccessKey) {
       return {
@@ -365,6 +476,13 @@ interface InferenceProfilesResponse {
   }>;
 }
 
+interface MantleModelsResponse {
+  data?: Array<{
+    id?: string;
+    display_name?: string;
+  }>;
+}
+
 function foundationDescriptors(raw: unknown): ModelDescriptor[] {
   const response = raw as FoundationModelsResponse;
   return (response.modelSummaries ?? []).flatMap((model) => {
@@ -415,6 +533,39 @@ function isConversationalModel(modelId: string): boolean {
   ].some((nonChat) => id.includes(nonChat));
 }
 
-function dedupeModels(models: ModelDescriptor[]): ModelDescriptor[] {
-  return [...new Map(models.map((model) => [model.id, model])).values()];
+function withConverseProtocol(descriptor: ModelDescriptor): RoutedModel {
+  return { descriptor, protocol: "converse" };
+}
+
+function withDefaultProtocol(descriptor: ModelDescriptor): RoutedModel {
+  return { descriptor, protocol: defaultProtocol(descriptor.id) };
+}
+
+function defaultProtocol(modelId: string): BedrockProtocol {
+  const id = modelId.toLowerCase();
+  if (id.startsWith("openai.")) return "responses";
+  if (id.startsWith("anthropic.")) return "messages";
+  return "converse";
+}
+
+function protocolDisplayName(
+  displayName: string,
+  protocol: BedrockProtocol,
+): string {
+  const name = displayName.replace(/ \(Bedrock\)$/, "");
+  return `${name} (${protocol === "converse" ? "Runtime" : "Mantle"})`;
+}
+
+function mergeRoutedModels(models: RoutedModel[]): RoutedModel[] {
+  const merged = new Map<string, RoutedModel>();
+  for (const model of models) {
+    const existing = merged.get(model.descriptor.id);
+    merged.set(model.descriptor.id, existing
+      ? {
+          descriptor: { ...existing.descriptor, ...model.descriptor },
+          protocol: model.protocol,
+        }
+      : model);
+  }
+  return [...merged.values()];
 }

--- a/packages/inference-providers/src/providers/bedrock/mantle.test.ts
+++ b/packages/inference-providers/src/providers/bedrock/mantle.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BedrockLangChainModelProvider } from "./langchain.js";
+import { createSigV4Fetch, mantleEndpoint } from "./mantle.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Bedrock Mantle discovery", () => {
+  it("unifies native and Mantle models under the Bedrock provider", async () => {
+    const client = {
+      send: vi.fn(async (command: unknown) =>
+        command?.constructor.name === "ListInferenceProfilesCommand"
+          ? { inferenceProfileSummaries: [] }
+          : {
+              modelSummaries: [{
+                modelId: "amazon.nova-pro-v1:0",
+                modelName: "Nova Pro",
+                inputModalities: ["TEXT"],
+              }],
+            }),
+    };
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({
+      data: [
+        { id: "openai.gpt-5.6-sol", display_name: "GPT-5.6 Sol" },
+        { id: "anthropic.claude-opus-5", display_name: "Claude Opus 5" },
+      ],
+    }), { status: 200 }));
+    const provider = new BedrockLangChainModelProvider({
+      region: "us-east-1",
+      client,
+      fetch: fetchFn,
+    });
+    provider.configure({
+      method: "bedrock-api-key",
+      values: { apiKey: "bedrock-key" },
+    });
+
+    await expect(provider.listModels()).resolves.toEqual([
+      expect.objectContaining({
+        id: "amazon.nova-pro-v1:0",
+        provider: "bedrock",
+        displayName: "Nova Pro (Runtime)",
+      }),
+      expect.objectContaining({
+        id: "openai.gpt-5.6-sol",
+        provider: "bedrock",
+        displayName: "GPT-5.6 Sol (Mantle)",
+      }),
+      expect.objectContaining({
+        id: "anthropic.claude-opus-5",
+        provider: "bedrock",
+        displayName: "Claude Opus 5 (Mantle)",
+      }),
+    ]);
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://bedrock-mantle.us-east-1.api.aws/v1/models",
+      expect.objectContaining({
+        headers: { authorization: "Bearer bedrock-key" },
+      }),
+    );
+  });
+
+  it("keeps native capabilities when Mantle supplies the same model", async () => {
+    const modelId = "openai.gpt-5.6-sol";
+    const client = {
+      send: vi.fn(async (command: unknown) =>
+        command?.constructor.name === "ListInferenceProfilesCommand"
+          ? { inferenceProfileSummaries: [] }
+          : {
+              modelSummaries: [{
+                modelId,
+                modelName: "GPT-5.6 Sol",
+                inputModalities: ["TEXT", "IMAGE"],
+              }],
+            }),
+    };
+    const provider = new BedrockLangChainModelProvider({
+      client,
+      fetch: vi.fn(async () => new Response(JSON.stringify({
+        data: [{ id: modelId, display_name: "GPT-5.6 Sol" }],
+      }), { status: 200 })),
+      modelsDevFetch: vi.fn(async () =>
+        new Response(JSON.stringify({}), { status: 200 })),
+    });
+    provider.configure({
+      method: "bedrock-api-key",
+      values: { apiKey: "bedrock-key" },
+    });
+
+    await expect(provider.listModels()).resolves.toEqual([
+      expect.objectContaining({
+        id: modelId,
+        displayName: "GPT-5.6 Sol (Mantle)",
+        supportsTools: true,
+        supportsVision: true,
+      }),
+    ]);
+  });
+});
+
+describe("Bedrock Mantle invocation", () => {
+  it("streams OpenAI-family models through the regional Responses endpoint", async () => {
+    const requests: Array<{
+      url: string;
+      authorization: string | null;
+      hasTool: boolean;
+    }> = [];
+    const fetchFn = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      requests.push({
+        url: String(input),
+        authorization: new Headers(init?.headers).get("authorization"),
+        hasTool: String(init?.body).includes("lookup"),
+      });
+      return eventStream([
+        {
+          type: "response.created",
+          response: {
+            id: "resp_1",
+            model: "openai.future-model",
+            status: "in_progress",
+            output: [],
+          },
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: {
+            id: "fc_1",
+            type: "function_call",
+            status: "in_progress",
+            arguments: "",
+            call_id: "call_1",
+            name: "lookup",
+          },
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          item_id: "fc_1",
+          output_index: 0,
+          delta: "{}",
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: {
+            id: "fc_1",
+            type: "function_call",
+            status: "completed",
+            arguments: "{}",
+            call_id: "call_1",
+            name: "lookup",
+          },
+        },
+      ]);
+    });
+    const provider = mantleProvider("openai.future-model", fetchFn);
+
+    const model = await provider.buildModel("openai.future-model");
+    const chunks = await collect(model.bindTools!([TEST_TOOL]).stream("hello"));
+    const toolChunks = chunks.flatMap(
+      (chunk) => (chunk as { tool_call_chunks?: Array<{ name?: string; args?: string }> })
+        .tool_call_chunks ?? [],
+    );
+
+    expect(requests).toEqual([{
+      url: "https://bedrock-mantle.eu-west-1.api.aws/openai/v1/responses",
+      authorization: "Bearer bedrock-key",
+      hasTool: true,
+    }]);
+    expect(toolChunks).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "lookup" }),
+      expect.objectContaining({ args: "{}" }),
+    ]));
+  });
+
+  it("streams Anthropic-family models through the regional Messages endpoint", async () => {
+    const requests: Array<{
+      url: string;
+      apiKey: string | null;
+      hasTool: boolean;
+    }> = [];
+    const fetchFn = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      requests.push({
+        url: String(input),
+        apiKey: headers.get("x-api-key"),
+        hasTool: String(init?.body).includes("lookup"),
+      });
+      return eventStream([
+        {
+          type: "message_start",
+          message: {
+            id: "msg_1",
+            type: "message",
+            role: "assistant",
+            model: "anthropic.future-model",
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 10, output_tokens: 1 },
+          },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "lookup",
+            input: {},
+          },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: "{}" },
+        },
+        { type: "content_block_stop", index: 0 },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "tool_use", stop_sequence: null },
+          usage: { output_tokens: 5 },
+        },
+        { type: "message_stop" },
+      ]);
+    });
+    const provider = mantleProvider("anthropic.future-model", fetchFn);
+
+    const model = await provider.buildModel("anthropic.future-model");
+    const chunks = await collect(model.bindTools!([TEST_TOOL]).stream("hello"));
+    const toolChunks = chunks.flatMap(
+      (chunk) => (chunk as { tool_call_chunks?: Array<{ name?: string; args?: string }> })
+        .tool_call_chunks ?? [],
+    );
+
+    expect(requests).toEqual([{
+      url: "https://bedrock-mantle.eu-west-1.api.aws/anthropic/v1/messages",
+      apiKey: "bedrock-key",
+      hasTool: true,
+    }]);
+    expect(toolChunks).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "lookup" }),
+      expect.objectContaining({ args: "{}" }),
+    ]));
+  });
+
+  it("signs Mantle requests when Bedrock uses AWS credentials", async () => {
+    let capturedInit: RequestInit | undefined;
+    const fetchFn = vi.fn(async (
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      capturedInit = init;
+      return new Response(null, { status: 200 });
+    });
+    const signedFetch = createSigV4Fetch(
+      "us-west-2",
+      {
+        accessKeyId: "AKIDEXAMPLE",
+        secretAccessKey: "secret",
+        sessionToken: "session",
+      },
+      fetchFn,
+    );
+
+    await signedFetch(`${mantleEndpoint("us-west-2")}/v1/models?limit=1`, {
+      headers: {
+        authorization: "Bearer placeholder",
+        "x-api-key": "placeholder",
+      },
+    });
+
+    const headers = new Headers(capturedInit?.headers);
+    expect(headers.get("authorization")).toMatch(
+      /^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\/\d{8}\/us-west-2\/bedrock\/aws4_request,/,
+    );
+    expect(headers.get("x-amz-security-token")).toBe("session");
+    expect(headers.get("x-api-key")).toBeNull();
+  });
+});
+
+function mantleProvider(modelId: string, fetchFn: typeof fetch) {
+  const provider = new BedrockLangChainModelProvider({
+    region: "eu-west-1",
+    fetch: fetchFn,
+    models: [{
+      id: modelId,
+      provider: "bedrock",
+      displayName: modelId,
+    }],
+  });
+  provider.configure({
+    method: "bedrock-api-key",
+    values: { apiKey: "bedrock-key" },
+  });
+  return provider;
+}
+
+const TEST_TOOL = {
+  type: "function" as const,
+  function: {
+    name: "lookup",
+    description: "Look up a value",
+    parameters: { type: "object", properties: {} },
+  },
+};
+
+async function collect<T>(stream: Promise<AsyncIterable<T>>): Promise<T[]> {
+  const chunks: T[] = [];
+  for await (const chunk of await stream) chunks.push(chunk);
+  return chunks;
+}
+
+function eventStream(events: Array<{ type: string } & Record<string, unknown>>): Response {
+  const body = events
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}

--- a/packages/inference-providers/src/providers/bedrock/mantle.ts
+++ b/packages/inference-providers/src/providers/bedrock/mantle.ts
@@ -1,0 +1,60 @@
+/** Bedrock Mantle endpoint construction and SigV4 fetch transport. */
+import { Sha256 } from "@smithy/core/checksum";
+import { HttpRequest, parseQueryString } from "@smithy/core/protocols";
+import { SignatureV4 } from "@smithy/signature-v4";
+
+export interface AwsCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+type CredentialProvider = AwsCredentials | (() => Promise<AwsCredentials>);
+
+export function mantleEndpoint(region: string): string {
+  return `https://bedrock-mantle.${region}.api.aws`;
+}
+
+export function createSigV4Fetch(
+  region: string,
+  credentials: CredentialProvider,
+  fetchFn: typeof fetch = fetch,
+): typeof fetch {
+  const signer = new SignatureV4({
+    service: "bedrock",
+    region,
+    credentials,
+    sha256: Sha256,
+  });
+
+  return async (input, init) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    const headers = Object.fromEntries(request.headers);
+    delete headers.authorization;
+    delete headers["x-api-key"];
+
+    const hasBody = request.method !== "GET" && request.method !== "HEAD";
+    const body = hasBody ? new Uint8Array(await request.arrayBuffer()) : undefined;
+    const signed = await signer.sign(new HttpRequest({
+      protocol: url.protocol,
+      hostname: url.hostname,
+      ...(url.port ? { port: Number(url.port) } : {}),
+      method: request.method,
+      path: url.pathname,
+      query: parseQueryString(url.search),
+      headers: {
+        ...headers,
+        host: url.host,
+      },
+      ...(body ? { body } : {}),
+    }));
+
+    return fetchFn(url, {
+      method: request.method,
+      headers: signed.headers,
+      ...(body ? { body } : {}),
+      signal: request.signal,
+    });
+  };
+}

--- a/packages/inference-providers/src/providers/bedrock/models.ts
+++ b/packages/inference-providers/src/providers/bedrock/models.ts
@@ -71,6 +71,7 @@ export interface BedrockProviderOptions {
   profile?: string;
   profiles?: readonly string[];
   client?: { send(command: unknown): Promise<unknown> };
+  fetch?: typeof fetch;
   modelsDev?: ModelsDevCatalogLoader;
   modelsDevFetch?: typeof fetch;
 }

--- a/packages/inference-providers/src/providers/openai.test.ts
+++ b/packages/inference-providers/src/providers/openai.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { HumanMessage } from "@langchain/core/messages";
 import {
   convertMessagesToCompletionsMessageParams,
   convertMessagesToResponsesInput,
 } from "@langchain/openai";
 import { isChatModel, OpenAiLangChainModelProvider, retryOutputCap } from "./openai.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("OpenAI model discovery", () => {
   it("lists chat models returned by the configured endpoint", async () => {
@@ -128,6 +132,96 @@ describe("OpenAI model construction", () => {
 
     expect(model.profile.maxInputTokens).toBe(40_960);
   });
+
+  it("uses Responses for the configured API mode, including output-cap retries", async () => {
+    const requests: Array<{
+      url: string;
+      authorization: string | null;
+      hasTool: boolean;
+    }> = [];
+    let requestCount = 0;
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      requests.push({
+        url: String(input),
+        authorization: new Headers(init?.headers).get("authorization"),
+        hasTool: String(init?.body).includes("lookup"),
+      });
+      requestCount += 1;
+      const message = requestCount <= 2
+        ? "max_tokens (8192) is greater than max_total_tokens: 4096"
+        : "stop";
+      return openAiError(message);
+    }));
+    const provider = new OpenAiLangChainModelProvider({
+      models: [{
+        id: "custom-responses-model",
+        provider: "openai",
+        displayName: "Custom Responses Model",
+      }],
+    });
+    provider.configure({
+      method: "api-key",
+      values: {
+        apiKey: "test-key",
+        baseUrl: "https://proxy.example/openai/v1",
+        apiMode: "responses",
+      },
+    });
+
+    const model = await provider.buildModel("custom-responses-model");
+    await expect(consume(model.bindTools!([TEST_TOOL]).stream("hello"))).rejects.toThrow("max_tokens");
+
+    expect(requests).toEqual([
+      {
+        url: "https://proxy.example/openai/v1/responses",
+        authorization: "Bearer test-key",
+        hasTool: true,
+      },
+      {
+        url: "https://proxy.example/openai/v1/responses",
+        authorization: "Bearer test-key",
+        hasTool: true,
+      },
+    ]);
+  });
+
+  it("can force Chat Completions for models LangChain would route to Responses", async () => {
+    const urls: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request) => {
+      urls.push(String(input));
+      return openAiError("stop");
+    }));
+    const provider = new OpenAiLangChainModelProvider({
+      apiKey: "test-key",
+      baseUrl: "https://proxy.example/v1",
+      apiMode: "chat-completions",
+      models: [{
+        id: "gpt-5.5-pro",
+        provider: "openai",
+        displayName: "GPT-5.5 Pro",
+      }],
+    });
+
+    const model = await provider.buildModel("gpt-5.5-pro");
+    await expect(consume(model.bindTools!([TEST_TOOL]).stream("hello"))).rejects.toThrow("stop");
+
+    expect(urls).toEqual(["https://proxy.example/v1/chat/completions"]);
+  });
+
+  it("exposes all supported API modes in provider settings", () => {
+    const provider = new OpenAiLangChainModelProvider();
+    const apiMode = provider.authSchema[0]?.fields.find((field) => field.key === "apiMode");
+
+    expect(apiMode).toMatchObject({
+      type: "select",
+      default: "auto",
+      options: [
+        { value: "auto" },
+        { value: "responses" },
+        { value: "chat-completions" },
+      ],
+    });
+  });
 });
 
 describe("OpenAI attachment conversion", () => {
@@ -171,3 +265,27 @@ describe("OpenAI attachment conversion", () => {
     }]);
   });
 });
+
+function openAiError(message: string): Response {
+  return new Response(JSON.stringify({
+    error: { message, type: "invalid_request_error" },
+  }), {
+    status: 400,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const TEST_TOOL = {
+  type: "function" as const,
+  function: {
+    name: "lookup",
+    description: "Look up a value",
+    parameters: { type: "object", properties: {} },
+  },
+};
+
+async function consume(stream: Promise<AsyncIterable<unknown>>): Promise<void> {
+  for await (const _chunk of await stream) {
+    // The test responses fail before producing a chunk.
+  }
+}

--- a/packages/inference-providers/src/providers/openai.ts
+++ b/packages/inference-providers/src/providers/openai.ts
@@ -4,6 +4,7 @@ import type { BaseMessage } from "@langchain/core/messages";
 import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import type { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
 import type { ChatModelStreamEvent } from "@langchain/core/language_models/event";
+import type { ChatOpenAIFields } from "@langchain/openai";
 import type { ModelProvider, ModelDescriptor, ResolvedProviderConfig, ProviderAuthMethod } from "@pizza-bot/core";
 import {
   enrichModelDescriptors,
@@ -20,6 +21,8 @@ import {
 const DEFAULT_BASE_URL = "https://api.openai.com/v1";
 const FETCH_TIMEOUT_MS = 5_000;
 const DEFAULT_MAX_TOKENS = 8_192;
+
+export type OpenAiApiMode = "auto" | "responses" | "chat-completions";
 
 interface OpenAiModelsResponse {
   data?: Array<{ id?: string }>;
@@ -63,6 +66,7 @@ export interface OpenAiProviderOptions {
   modelsDevFetch?: typeof fetch;
   catalogProvider?: string;
   maxTokens?: number;
+  apiMode?: OpenAiApiMode;
 }
 
 class OpenAiBuildError extends Error {
@@ -83,6 +87,18 @@ const AUTH_SCHEMA: readonly ProviderAuthMethod[] = [
     fields: [
       { key: "apiKey", label: "API key", type: "password", required: true },
       { key: "baseUrl", label: "Base URL", type: "text", required: false },
+      {
+        key: "apiMode",
+        label: "API",
+        type: "select",
+        required: false,
+        default: "auto",
+        options: [
+          { value: "auto", label: "Automatic" },
+          { value: "responses", label: "Responses" },
+          { value: "chat-completions", label: "Chat Completions" },
+        ],
+      },
       {
         key: "maxTokens",
         label: "Output token budget",
@@ -112,6 +128,7 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
   private baseUrl: string | undefined;
   private maxTokens: number;
   private catalogProvider: string | undefined;
+  private apiMode: OpenAiApiMode;
 
   constructor(opts: OpenAiProviderOptions = {}) {
     this.models = opts.models;
@@ -121,6 +138,7 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
     this.baseUrl = opts.baseUrl;
     this.maxTokens = positiveInteger(opts.maxTokens) ?? DEFAULT_MAX_TOKENS;
     this.catalogProvider = opts.catalogProvider;
+    this.apiMode = opts.apiMode ?? "auto";
     for (const descriptor of opts.models ?? []) {
       this.descriptors.set(descriptor.id, descriptor);
     }
@@ -129,10 +147,10 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
   configure(cfg: ResolvedProviderConfig): void {
     const key = cfg.values.apiKey?.trim();
     if (key) this.apiKey = key;
-    const base = cfg.values.baseUrl?.trim();
-    if (base) this.baseUrl = base;
+    this.baseUrl = cfg.values.baseUrl?.trim() || undefined;
     this.maxTokens = positiveInteger(cfg.values.maxTokens) ?? DEFAULT_MAX_TOKENS;
     this.catalogProvider = cfg.values.catalogProvider?.trim() || undefined;
+    this.apiMode = parseApiMode(cfg.values.apiMode);
     if (!this.models) this.descriptors.clear();
   }
 
@@ -140,7 +158,8 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
     if (this.models) return this.models;
     const apiKey = this.apiKey ?? process.env.OPENAI_API_KEY;
     if (!apiKey) throw missingCatalogCredentials("OpenAI");
-    const baseUrl = (this.baseUrl ?? process.env.OPENAI_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+    const baseUrl =
+      (this.baseUrl ?? process.env.OPENAI_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/$/, "");
 
     try {
       const response = await this.fetchFn(`${baseUrl}/models`, {
@@ -186,12 +205,11 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
   }
 
   private async construct(modelId: string): Promise<BaseChatModel> {
-    const { ChatOpenAI } = await import("@langchain/openai");
     const apiKey = this.apiKey ?? process.env.OPENAI_API_KEY;
     if (!apiKey) {
       throw new OpenAiBuildError("No OpenAI API key configured (set OPENAI_API_KEY).", "AUTH_EXPIRED");
     }
-    const baseUrl = this.baseUrl ?? process.env.OPENAI_BASE_URL;
+    const configuredBaseUrl = this.baseUrl ?? process.env.OPENAI_BASE_URL;
     if (!this.descriptors.has(modelId)) {
       await this.listModels().catch(() => []);
     }
@@ -205,79 +223,158 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
       configuredMax,
       learnedMaxTokens.get(modelId) ?? Number.POSITIVE_INFINITY,
     );
-
-    const fields = {
-      model: modelId,
+    return createOpenAiChatModel({
+      modelId,
       apiKey,
       maxTokens: initialMax,
-      ...(baseUrl ? { configuration: { baseURL: baseUrl } } : {}),
-    };
-    const retryModel = (error: unknown) => {
-      const retryCap = retryOutputCap(error, initialMax);
-      if (retryCap === undefined) return undefined;
-      learnedMaxTokens.set(modelId, retryCap);
-      return new ChatOpenAI({ ...fields, maxTokens: retryCap });
-    };
+      apiMode: this.apiMode,
+      learnedMaxTokens,
+      fetch: this.fetchFn,
+      ...(descriptor ? { descriptor } : {}),
+      ...(configuredBaseUrl ? { baseUrl: configuredBaseUrl } : {}),
+    });
+  }
+}
 
-    class AdaptiveChatOpenAI extends ChatOpenAI {
-      override get profile() {
-        return withContextWindow(super.profile, descriptor?.contextWindow);
-      }
+export interface OpenAiChatModelOptions {
+  modelId: string;
+  apiKey: string;
+  maxTokens: number;
+  apiMode: OpenAiApiMode;
+  descriptor?: ModelDescriptor;
+  learnedMaxTokens?: Map<string, number>;
+  baseUrl?: string;
+  fetch?: typeof fetch;
+}
 
-      override async _generate(
-        messages: BaseMessage[],
-        options: this["ParsedCallOptions"],
-        runManager?: CallbackManagerForLLMRun,
-      ): Promise<ChatResult> {
-        try {
-          return await super._generate(messages, options, runManager);
-        } catch (error) {
-          const retry = retryModel(error);
-          if (!retry) throw error;
-          return retry._generate(messages, options, runManager);
+export async function createOpenAiChatModel(
+  options: OpenAiChatModelOptions,
+): Promise<BaseChatModel> {
+  const { ChatOpenAI } = await import("@langchain/openai");
+  const {
+    modelId,
+    apiKey,
+    maxTokens,
+    apiMode,
+    descriptor,
+    learnedMaxTokens,
+    baseUrl,
+    fetch: fetchFn,
+  } = options;
+  const fields = {
+    model: modelId,
+    apiKey,
+    maxTokens,
+    useResponsesApi: apiMode === "responses",
+    ...((baseUrl || fetchFn)
+      ? {
+          configuration: {
+            ...(baseUrl ? { baseURL: baseUrl } : {}),
+            ...(fetchFn ? { fetch: fetchFn } : {}),
+          },
         }
-      }
+      : {}),
+  };
 
-      override async *_streamResponseChunks(
-        messages: BaseMessage[],
-        options: this["ParsedCallOptions"],
-        runManager?: CallbackManagerForLLMRun,
-      ): AsyncGenerator<ChatGenerationChunk> {
-        let emitted = false;
-        try {
-          for await (const chunk of super._streamResponseChunks(messages, options, runManager)) {
-            emitted = true;
-            yield chunk;
-          }
-        } catch (error) {
-          const retry = emitted ? undefined : retryModel(error);
-          if (!retry) throw error;
-          yield* retry._streamResponseChunks(messages, options, runManager);
-        }
-      }
+  class DialectChatOpenAI extends ChatOpenAI {
+    override get profile() {
+      return withContextWindow(super.profile, descriptor?.contextWindow);
+    }
 
-      override async *_streamChatModelEvents(
-        messages: BaseMessage[],
-        options: this["ParsedCallOptions"],
-        runManager?: CallbackManagerForLLMRun,
-      ): AsyncGenerator<ChatModelStreamEvent> {
-        let emitted = false;
-        try {
-          for await (const event of super._streamChatModelEvents(messages, options, runManager)) {
-            emitted = true;
-            yield event;
-          }
-        } catch (error) {
-          const retry = emitted ? undefined : retryModel(error);
-          if (!retry) throw error;
-          yield* retry._streamChatModelEvents(messages, options, runManager);
-        }
+    protected override _useResponsesApi(
+      callOptions: this["ParsedCallOptions"] | undefined,
+    ): boolean {
+      if (apiMode === "responses") return true;
+      if (apiMode === "chat-completions") return false;
+      return super._useResponsesApi(callOptions);
+    }
+
+    override withConfig(config: Partial<this["ParsedCallOptions"]>) {
+      const model = this.clone(this.fields);
+      model.defaultOptions = {
+        ...this.defaultOptions,
+        ...config,
+      };
+      return model;
+    }
+
+    protected clone(fields?: ChatOpenAIFields): DialectChatOpenAI {
+      return new DialectChatOpenAI(fields);
+    }
+  }
+
+  class AdaptiveChatOpenAI extends DialectChatOpenAI {
+    protected override clone(fields?: ChatOpenAIFields): AdaptiveChatOpenAI {
+      return new AdaptiveChatOpenAI(fields);
+    }
+
+    override async _generate(
+      messages: BaseMessage[],
+      callOptions: this["ParsedCallOptions"],
+      runManager?: CallbackManagerForLLMRun,
+    ): Promise<ChatResult> {
+      try {
+        return await super._generate(messages, callOptions, runManager);
+      } catch (error) {
+        const retry = retryModel(error);
+        if (!retry) throw error;
+        return retry._generate(messages, callOptions, runManager);
       }
     }
 
-    return new AdaptiveChatOpenAI(fields);
+    override async *_streamResponseChunks(
+      messages: BaseMessage[],
+      callOptions: this["ParsedCallOptions"],
+      runManager?: CallbackManagerForLLMRun,
+    ): AsyncGenerator<ChatGenerationChunk> {
+      let emitted = false;
+      try {
+        for await (const chunk of super._streamResponseChunks(
+          messages,
+          callOptions,
+          runManager,
+        )) {
+          emitted = true;
+          yield chunk;
+        }
+      } catch (error) {
+        const retry = emitted ? undefined : retryModel(error);
+        if (!retry) throw error;
+        yield* retry._streamResponseChunks(messages, callOptions, runManager);
+      }
+    }
+
+    override async *_streamChatModelEvents(
+      messages: BaseMessage[],
+      callOptions: this["ParsedCallOptions"],
+      runManager?: CallbackManagerForLLMRun,
+    ): AsyncGenerator<ChatModelStreamEvent> {
+      let emitted = false;
+      try {
+        for await (const event of super._streamChatModelEvents(
+          messages,
+          callOptions,
+          runManager,
+        )) {
+          emitted = true;
+          yield event;
+        }
+      } catch (error) {
+        const retry = emitted ? undefined : retryModel(error);
+        if (!retry) throw error;
+        yield* retry._streamChatModelEvents(messages, callOptions, runManager);
+      }
+    }
   }
 
+  const retryModel = (error: unknown) => {
+    const retryCap = retryOutputCap(error, maxTokens);
+    if (retryCap === undefined) return undefined;
+    learnedMaxTokens?.set(modelId, retryCap);
+    return new DialectChatOpenAI({ ...fields, maxTokens: retryCap });
+  };
+
+  return new AdaptiveChatOpenAI(fields);
 }
 
 /** The models API includes embeddings, image, audio, and moderation models. */
@@ -306,6 +403,10 @@ function inferCatalogProvider(baseUrl: string): string | undefined {
 function positiveInteger(value: number | string | undefined): number | undefined {
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseApiMode(value: string | undefined): OpenAiApiMode {
+  return value === "responses" || value === "chat-completions" ? value : "auto";
 }
 
 export function retryOutputCap(error: unknown, current: number): number | undefined {


### PR DESCRIPTION
## Summary

- unify native Bedrock Runtime and regional Bedrock Mantle discovery under the Bedrock provider
- route Converse models through `ChatBedrockConverse`, OpenAI-family Mantle models through Responses, and Anthropic-family Mantle models through Messages
- authenticate Mantle with either Bedrock API keys or AWS SigV4 credentials from profiles, access keys, or the ambient credential chain
- label catalog entries as `(Runtime)` or `(Mantle)` and preserve native capability metadata when catalogs overlap
- add custom endpoint and API-dialect controls to the standalone OpenAI and Anthropic providers, including configurable models.dev namespaces

## Implementation notes

Mantle routing is a property of the regional Mantle endpoint and protocol family, not a model-specific exception table. The Bedrock adapter owns endpoint construction and protocol selection while reusing the existing LangChain OpenAI and Anthropic protocol implementations.

The OpenAI wrapper preserves dialect, retry, fetch, and profile behavior across `withConfig()` and `bindTools()` clones. The SigV4 transport is cached per provider configuration and invalidated when authentication or region settings change.

Catalog discovery remains resilient: native and Mantle calls run concurrently, either source can supply models, and duplicate entries merge metadata while Mantle retains its required protocol route.

## Verification

- `npm run lint`
- `npx tsc --noEmit -p packages/inference-providers/tsconfig.json`
- `npx vitest run --dir packages/inference-providers` (`121` tests)
- `npx vitest run apps/api-server/src/routes-providers.test.ts` (`21` tests)
- `npm test` (`18/18` tasks)

Closes #17