### PR TITLE
Improve the mobile inbox experience

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>🍕 Pizza Bot</title>
     <!-- Apply the stored theme BEFORE first paint to avoid a flash of the wrong
          theme. Mirrors use-theme.ts (key "pizza-theme"); <html> defaults to

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -33,6 +33,7 @@ import { protocolStreamStore } from "../protocol-stream-store.js";
 import { createConversationSearch } from "../conversation-search.js";
 import { ConfirmationDialog } from "./ConfirmationDialog.js";
 import { useAppToast } from "./AppToast.js";
+import { SwipeToDelete } from "./SwipeToDelete.js";
 
 export interface SidebarProps {
   client: ApiClient;
@@ -77,6 +78,7 @@ export function Sidebar({
     () => new Set<string>(["Last Week", "This Month", "Older"]),
   );
   const [confirmDelete, setConfirmDelete] = useState<ThreadInfo | null>(null);
+  const [swipedThreadId, setSwipedThreadId] = useState<string | null>(null);
   const threadListRef = useRef<HTMLDivElement | null>(null);
   const sidebarScrollRef = useRef<HTMLDivElement | null>(null);
   const deleteDialogWasOpen = useRef(false);
@@ -488,56 +490,65 @@ export function Sidebar({
                             aria-selected={t.threadId === activeThreadId}
                             onClick={() => listNavigation.selectItem(t.threadId)}
                           >
-                            {/* A div permits sibling pin/delete buttons without invalid button nesting. */}
-                            <div
-                              className={`thread-row${t.threadId === activeThreadId ? " active" : ""}${unread ? " unread" : ""}`}
+                            <SwipeToDelete
+                              open={swipedThreadId === t.threadId}
+                              label={t.title}
+                              onOpenChange={(open) =>
+                                setSwipedThreadId(open ? t.threadId : null)
+                              }
+                              onDelete={() => setConfirmDelete(t)}
                             >
-                              <span className="thread-main">
-                                <span className="thread-line1">
-                                  {running && <Pen size={13} className="thread-running-icon" />}
-                                  {unread && !running && (
-                                    <span className="thread-unread-dot" aria-label="Unread" />
-                                  )}
-                                  <span className="thread-title">{t.title}</span>
-                                  <span className="thread-time">
-                                    {running ? "now" : relativeTime(t.lastActivityAt)}
+                              {/* A div permits sibling pin/delete buttons without invalid button nesting. */}
+                              <div
+                                className={`thread-row${t.threadId === activeThreadId ? " active" : ""}${unread ? " unread" : ""}`}
+                              >
+                                <span className="thread-main">
+                                  <span className="thread-line1">
+                                    {running && <Pen size={13} className="thread-running-icon" />}
+                                    {unread && !running && (
+                                      <span className="thread-unread-dot" aria-label="Unread" />
+                                    )}
+                                    <span className="thread-title">{t.title}</span>
+                                    <span className="thread-time">
+                                      {running ? "now" : relativeTime(t.lastActivityAt)}
+                                    </span>
                                   </span>
+                                  {t.lastMessage && (
+                                    <span className="thread-preview">{t.lastMessage}</span>
+                                  )}
                                 </span>
-                                {t.lastMessage && (
-                                  <span className="thread-preview">{t.lastMessage}</span>
+                                {needsAction && (
+                                  <span className="thread-action-pill" title="Awaiting your response">
+                                    Action
+                                  </span>
                                 )}
-                              </span>
-                              {needsAction && (
-                                <span className="thread-action-pill" title="Awaiting your response">
-                                  Action
+                                {t.source === "fork" && <span className="thread-badge">⑂</span>}
+                                <span className="thread-actions">
+                                  <button
+                                    className={`thread-action${t.pinned ? " pinned" : ""}`}
+                                    aria-label={t.pinned ? "Unpin conversation" : "Pin conversation"}
+                                    title={t.pinned ? "Unpin" : "Pin"}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      void onPinToggle(t);
+                                    }}
+                                  >
+                                    {t.pinned ? <PinOff size={14} /> : <Pin size={14} />}
+                                  </button>
+                                  <button
+                                    className="thread-action danger"
+                                    aria-label="Delete conversation"
+                                    title="Delete"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setConfirmDelete(t);
+                                    }}
+                                  >
+                                    <Trash2 size={14} />
+                                  </button>
                                 </span>
-                              )}
-                              {t.source === "fork" && <span className="thread-badge">⑂</span>}
-                              <span className="thread-actions">
-                                <button
-                                  className={`thread-action${t.pinned ? " pinned" : ""}`}
-                                  aria-label={t.pinned ? "Unpin conversation" : "Pin conversation"}
-                                  title={t.pinned ? "Unpin" : "Pin"}
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    void onPinToggle(t);
-                                  }}
-                                >
-                                  {t.pinned ? <PinOff size={14} /> : <Pin size={14} />}
-                                </button>
-                                <button
-                                  className="thread-action danger"
-                                  aria-label="Delete conversation"
-                                  title="Delete"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    setConfirmDelete(t);
-                                  }}
-                                >
-                                  <Trash2 size={14} />
-                                </button>
-                              </span>
-                            </div>
+                              </div>
+                            </SwipeToDelete>
                           </li>
                         );
                       })}

--- a/apps/web/src/components/SwipeToDelete.test.ts
+++ b/apps/web/src/components/SwipeToDelete.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { swipeDeleteOutcome } from "./SwipeToDelete.js";
+
+describe("swipeDeleteOutcome", () => {
+  it("ignores short drags", () => {
+    expect(swipeDeleteOutcome(-31)).toBe("closed");
+  });
+
+  it("reveals the delete action after a partial swipe", () => {
+    expect(swipeDeleteOutcome(-32)).toBe("open");
+    expect(swipeDeleteOutcome(-95)).toBe("open");
+  });
+
+  it("requests deletion after a deliberate full swipe", () => {
+    expect(swipeDeleteOutcome(-96)).toBe("delete");
+  });
+});

--- a/apps/web/src/components/SwipeToDelete.tsx
+++ b/apps/web/src/components/SwipeToDelete.tsx
@@ -1,0 +1,155 @@
+import {
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
+import { Trash2 } from "lucide-react";
+
+const ACTION_WIDTH = 76;
+const OPEN_THRESHOLD = 32;
+const DELETE_THRESHOLD = 96;
+const DIRECTION_THRESHOLD = 8;
+const MAX_DRAG = 120;
+
+export type SwipeDeleteOutcome = "closed" | "open" | "delete";
+
+export function swipeDeleteOutcome(offset: number): SwipeDeleteOutcome {
+  if (offset <= -DELETE_THRESHOLD) return "delete";
+  if (offset <= -OPEN_THRESHOLD) return "open";
+  return "closed";
+}
+
+interface SwipeState {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  startOffset: number;
+  direction: "pending" | "horizontal" | "vertical";
+}
+
+export function SwipeToDelete({
+  open,
+  label,
+  children,
+  onOpenChange,
+  onDelete,
+}: {
+  open: boolean;
+  label: string;
+  children: ReactNode;
+  onOpenChange: (open: boolean) => void;
+  onDelete: () => void;
+}) {
+  const [dragOffset, setDragOffset] = useState<number | null>(null);
+  const dragOffsetRef = useRef<number | null>(null);
+  const swipe = useRef<SwipeState | null>(null);
+  const suppressClick = useRef(false);
+  const restingOffset = open ? -ACTION_WIDTH : 0;
+  const offset = dragOffset ?? restingOffset;
+
+  const resetSwipe = () => {
+    swipe.current = null;
+    dragOffsetRef.current = null;
+    setDragOffset(null);
+  };
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.pointerType !== "touch" || event.button !== 0) return;
+    swipe.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startOffset: restingOffset,
+      direction: "pending",
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const current = swipe.current;
+    if (!current || current.pointerId !== event.pointerId) return;
+
+    const deltaX = event.clientX - current.startX;
+    const deltaY = event.clientY - current.startY;
+    if (current.direction === "pending") {
+      if (
+        Math.abs(deltaX) < DIRECTION_THRESHOLD &&
+        Math.abs(deltaY) < DIRECTION_THRESHOLD
+      ) {
+        return;
+      }
+      current.direction =
+        Math.abs(deltaX) > Math.abs(deltaY) ? "horizontal" : "vertical";
+    }
+    if (current.direction === "vertical") return;
+
+    event.preventDefault();
+    const nextOffset = Math.max(-MAX_DRAG, Math.min(0, current.startOffset + deltaX));
+    dragOffsetRef.current = nextOffset;
+    setDragOffset(nextOffset);
+  };
+
+  const finishSwipe = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const current = swipe.current;
+    if (!current || current.pointerId !== event.pointerId) return;
+
+    const finalOffset = dragOffsetRef.current ?? current.startOffset;
+    const wasHorizontal = current.direction === "horizontal";
+    resetSwipe();
+    if (!wasHorizontal) return;
+
+    suppressClick.current = true;
+    window.setTimeout(() => {
+      suppressClick.current = false;
+    }, 0);
+
+    const outcome = swipeDeleteOutcome(finalOffset);
+    if (outcome === "delete") {
+      onOpenChange(false);
+      onDelete();
+    } else {
+      onOpenChange(outcome === "open");
+    }
+  };
+
+  return (
+    <div
+      className={`thread-swipe${open ? " open" : ""}${
+        dragOffset !== null ? " dragging" : ""
+      }`}
+      onClickCapture={(event) => {
+        if (!suppressClick.current) return;
+        event.preventDefault();
+        event.stopPropagation();
+        suppressClick.current = false;
+      }}
+    >
+      <button
+        type="button"
+        className="thread-swipe-delete"
+        aria-label={`Delete ${label}`}
+        aria-hidden={!open}
+        tabIndex={open ? 0 : -1}
+        onClick={(event) => {
+          event.stopPropagation();
+          onOpenChange(false);
+          onDelete();
+        }}
+      >
+        <Trash2 size={18} />
+        <span>Delete</span>
+      </button>
+      <div
+        className="thread-swipe-content"
+        style={{ transform: `translate3d(${offset}px, 0, 0)` }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={finishSwipe}
+        onPointerCancel={resetSwipe}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -27,9 +27,11 @@ export type ConversationContentProps = ComponentProps<
 
 export const ConversationContent = ({
   className,
+  scrollClassName,
   ...props
 }: ConversationContentProps) => (
   <StickToBottom.Content
+    scrollClassName={cn("conversation-scroll", scrollClassName)}
     className={cn("flex flex-col gap-8 p-4", className)}
     {...props}
   />

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -136,6 +136,11 @@ body,
   height: 100%;
   margin: 0;
 }
+html,
+body {
+  overscroll-behavior: none;
+  overflow: hidden;
+}
 body {
   background: var(--background);
   color: var(--foreground);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4,13 +4,16 @@
   scrollbar-width: thin;
 }
 html, body, #root { height: 100%; margin: 0; }
+@supports (height: 100dvh) {
+  html, body, #root { height: 100dvh; }
+}
 body {
   background: var(--bg);
   color: var(--text);
   font: 14px/1.5 -apple-system, BlinkMacSystemFont, ui-sans-serif, system-ui, "Segoe UI", Roboto, sans-serif;
 }
 
-.app { display: flex; flex-direction: column; height: 100%; overflow: hidden; }
+.app { display: flex; flex-direction: column; height: 100%; overflow: hidden; overscroll-behavior: none; }
 
 .body { display: flex; flex: 1; min-height: 0; }
 
@@ -110,7 +113,10 @@ body {
   font-size: 10px; font-weight: 700; letter-spacing: .02em; text-transform: uppercase;
 }
 
-.sidebar-scroll { flex: 1; min-height: 0; overflow-y: auto; padding: 0 8px 8px; }
+.sidebar-scroll {
+  flex: 1; min-height: 0; overflow-y: auto; overscroll-behavior-y: none;
+  padding: 0 8px 8px;
+}
 
 .sidebar-empty {
   padding: 40px 24px; text-align: center; color: var(--dim);
@@ -160,6 +166,31 @@ body {
 }
 .thread-row:hover { background: var(--panel-2); }
 .thread-row.active { background: var(--panel-2); border-right-color: var(--brand); }
+
+.thread-swipe {
+  position: relative; overflow: hidden;
+  background: transparent;
+}
+.thread-swipe-content {
+  position: relative; z-index: 1; background: var(--sidebar-bg);
+  border-radius: 8px; overflow: hidden;
+  touch-action: pan-y; transition: transform .18s ease-out;
+}
+.thread-swipe .thread-row { border-radius: 0; }
+.thread-swipe.dragging .thread-swipe-content { transition: none; }
+.thread-swipe-delete {
+  position: absolute; z-index: 0; top: 0; right: 0; bottom: 0;
+  width: 76px; padding: 0; border: 0;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px;
+  border-radius: 0 8px 8px 0;
+  background: transparent; color: var(--destructive-foreground);
+  font: inherit; font-size: 11px; font-weight: 700; cursor: pointer;
+  visibility: hidden;
+}
+.thread-swipe.open .thread-swipe-delete,
+.thread-swipe.dragging .thread-swipe-delete {
+  visibility: visible; background: var(--danger);
+}
 
 .thread-actions {
   position: absolute; top: 6px; right: 10px;
@@ -359,7 +390,9 @@ body {
 .chat-header-title-input.error {
   border-color: var(--error); outline-color: color-mix(in srgb, var(--error) 20%, transparent);
 }
-.feed-scroll { flex: 1; min-height: 0; overflow-y: auto; }
+.feed-scroll {
+  flex: 1; min-height: 0; overflow-y: auto; overscroll-behavior-y: none;
+}
 
 .welcome {
   display: flex; flex-direction: column; align-items: center;
@@ -487,7 +520,11 @@ body {
 }
 .transcript-tool-io.error { color: var(--danger, #f87171); }
 
-.feed { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 14px; }
+.feed {
+  flex: 1; overflow-y: auto; overscroll-behavior-y: none;
+  padding: 16px; display: flex; flex-direction: column; gap: 14px;
+}
+.conversation-scroll { overscroll-behavior-y: none; }
 .feed.empty { align-items: center; justify-content: center; color: var(--dim); text-align: center; }
 .msg { display: flex; flex-direction: column; gap: 4px; max-width: 760px; }
 .msg-user { align-self: flex-end; align-items: flex-end; }
@@ -1487,6 +1524,13 @@ textarea.field-input { resize: vertical; line-height: 1.5; }
 
 /* Keep this breakpoint synchronized with MOBILE_BREAKPOINT in use-is-mobile.ts. */
 @media (max-width: 768px) {
+  /* iOS zooms focused text-entry controls whose computed font is below 16px. */
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+
   .body { flex-direction: column; }
   .iconrail { display: none; }
   .mobile-nav {


### PR DESCRIPTION
## Summary

- contain root, inbox, and chat overscroll so the mobile bottom navigation remains anchored
- use the dynamic viewport and iOS-safe text-entry sizing to avoid focus zoom
- add partial and full swipe-to-delete gestures that reuse the existing confirmation flow

## Testing

- `npx vitest run --dir apps/web`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- `npx eslint apps/web/src/components/SwipeToDelete.tsx apps/web/src/components/SwipeToDelete.test.ts apps/web/src/components/Sidebar.tsx apps/web/src/components/ai-elements/conversation.tsx`
- `npm run build -w @pizza-bot/web`
- mobile headless Chrome verification at 390x844 with trusted touch input

Closes #24