### PR TITLE
Fix provider save state convergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ or Ollama in **Settings > Providers**. Bedrock accepts an AWS profile, AWS
 access keys, or a Bedrock API key, with an optional region override; otherwise
 `AWS_REGION` or `us-west-2` is used. Bedrock combines its native catalog with
 the regional Mantle catalog and routes models through Converse, OpenAI
-Responses, or Anthropic Messages according to their advertised API family.
+Responses or Chat Completions, or Anthropic Messages according to their
+advertised API family.
 OpenAI and Anthropic also accept custom Base URLs for compatible endpoints;
 OpenAI can explicitly select Responses or Chat Completions, and Anthropic
 supports `x-api-key` or bearer authentication. Select a model with

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -108,12 +108,20 @@ export function App() {
     () => Promise.all([refreshModels(), refreshAllModels()]),
     [refreshAllModels, refreshModels],
   );
-  const providersAdmin = useProvidersAdmin(client, refreshModelCatalogs);
+  const {
+    status: serverStatus,
+    reachable: serverReachable,
+    refresh: refreshStatus,
+  } = useStatus(client);
+  const providersAdmin = useProvidersAdmin(
+    client,
+    refreshModelCatalogs,
+    refreshStatus,
+  );
   const retryModelCatalogs = useCallback(
     () => Promise.all([retryModels(), retryAllModels()]),
     [retryAllModels, retryModels],
   );
-  const { status: serverStatus, reachable: serverReachable } = useStatus(client);
   const selectableModels = useMemo(
     () =>
       availableModels(
@@ -457,9 +465,8 @@ export function App() {
                 models={selectableModels}
                 allModels={allModels}
                 defaultModel={providersAdmin.defaultModel}
-                onProviderUpdate={providersAdmin.update}
+                onProviderSave={providersAdmin.save}
                 onProviderRemove={providersAdmin.remove}
-                onProviderModelsChange={providersAdmin.setModels}
                 onRetryModels={retryModelCatalogs}
                 onSetDefaultModel={providersAdmin.setDefault}
                 providerStatuses={serverStatus?.inference.providers}

--- a/apps/web/src/components/settings/ProvidersSettings.tsx
+++ b/apps/web/src/components/settings/ProvidersSettings.tsx
@@ -24,9 +24,12 @@ export interface ProvidersSettingsProps {
   models: ModelsInfo;
   allModels: ModelsInfo;
   defaultModel: string | null;
-  onUpdate: (id: string, config: { method: string; values: Record<string, string> }) => Promise<unknown>;
+  onSave: (
+    id: string,
+    config: { method: string; values: Record<string, string> },
+    preferences: ProviderModelPreferences,
+  ) => Promise<unknown>;
   onRemove: (id: string) => Promise<unknown>;
-  onSetModels: (id: string, preferences: ProviderModelPreferences) => Promise<unknown>;
   onRetryModels: () => Promise<unknown>;
   onSetDefault: (model: string | null) => Promise<unknown>;
   selectedProviderId: string | null;
@@ -66,9 +69,8 @@ export function ProvidersSettings({
   models,
   allModels,
   defaultModel,
-  onUpdate,
+  onSave,
   onRemove,
-  onSetModels,
   onRetryModels,
   onSetDefault,
   selectedProviderId,
@@ -109,9 +111,8 @@ export function ProvidersSettings({
             provider={p}
             models={allModels.models.filter((model) => model.provider === p.id)}
             catalog={allModels.providers?.find((catalog) => catalog.provider === p.id)}
-            onUpdate={onUpdate}
+            onSave={onSave}
             onRemove={onRemove}
-            onSetModels={onSetModels}
             onRetryModels={onRetryModels}
           />
         </div>
@@ -222,17 +223,19 @@ function ProviderRow({
   provider,
   models,
   catalog,
-  onUpdate,
+  onSave,
   onRemove,
-  onSetModels,
   onRetryModels,
 }: {
   provider: ProviderView;
   models: ModelsInfo["models"];
   catalog?: ModelCatalogStatus;
-  onUpdate: (id: string, config: { method: string; values: Record<string, string> }) => Promise<unknown>;
+  onSave: (
+    id: string,
+    config: { method: string; values: Record<string, string> },
+    preferences: ProviderModelPreferences,
+  ) => Promise<unknown>;
   onRemove: (id: string) => Promise<unknown>;
-  onSetModels: (id: string, preferences: ProviderModelPreferences) => Promise<unknown>;
   onRetryModels: () => Promise<unknown>;
 }) {
   const notify = useAppToast();
@@ -309,8 +312,11 @@ function ProviderRow({
           out[field.key] = raw;
         }
       }
-      await onUpdate(provider.id, { method: method.id, values: out });
-      await onSetModels(provider.id, modelPreferences);
+      await onSave(
+        provider.id,
+        { method: method.id, values: out },
+        modelPreferences,
+      );
       notify({ title: `${provider.id} saved`, tone: "success" });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Save failed");

--- a/apps/web/src/components/settings/SettingsModule.tsx
+++ b/apps/web/src/components/settings/SettingsModule.tsx
@@ -30,12 +30,12 @@ export interface SettingsModuleProps {
   models: ModelsInfo;
   allModels: ModelsInfo;
   defaultModel: string | null;
-  onProviderUpdate: (id: string, config: { method: string; values: Record<string, string> }) => Promise<unknown>;
-  onProviderRemove: (id: string) => Promise<unknown>;
-  onProviderModelsChange: (
+  onProviderSave: (
     id: string,
+    config: { method: string; values: Record<string, string> },
     preferences: import("@/api-client").ProviderModelPreferences,
   ) => Promise<unknown>;
+  onProviderRemove: (id: string) => Promise<unknown>;
   onRetryModels: () => Promise<unknown>;
   onSetDefaultModel: (model: string | null) => Promise<unknown>;
   enableMemories: boolean;
@@ -83,9 +83,8 @@ export function SettingsModule({
   models,
   allModels,
   defaultModel,
-  onProviderUpdate,
+  onProviderSave,
   onProviderRemove,
-  onProviderModelsChange,
   onRetryModels,
   onSetDefaultModel,
   enableMemories,
@@ -300,9 +299,8 @@ export function SettingsModule({
               models={models}
               allModels={allModels}
               defaultModel={defaultModel}
-              onUpdate={onProviderUpdate}
+              onSave={onProviderSave}
               onRemove={onProviderRemove}
-              onSetModels={onProviderModelsChange}
               onRetryModels={onRetryModels}
               onSetDefault={onSetDefaultModel}
               selectedProviderId={selectedProviderId}

--- a/apps/web/src/use-app-data.test.ts
+++ b/apps/web/src/use-app-data.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ApiClient, MemoryDoc, MemoryInfo, StatusInfo } from "@/api-client";
+import type {
+  ApiClient,
+  MemoryDoc,
+  MemoryInfo,
+  ProviderView,
+  StatusInfo,
+} from "@/api-client";
 
 const react = vi.hoisted(() => ({
   cleanups: [] as Array<() => void>,
@@ -21,7 +27,7 @@ vi.mock("react", () => ({
   },
 }));
 
-const { useMemoriesAdmin, useStatus } = await import("./use-app-data.js");
+const { useMemoriesAdmin, useProvidersAdmin, useStatus } = await import("./use-app-data.js");
 
 const memory = (id: string): MemoryInfo => ({
   id,
@@ -179,5 +185,149 @@ describe("useStatus polling", () => {
     await vi.advanceTimersByTimeAsync(10);
 
     expect(getStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let an older poll overwrite a manual refresh", async () => {
+    const initial = deferred<StatusInfo | undefined>();
+    const refreshed = deferred<StatusInfo | undefined>();
+    const stale = statusWithMcp([
+      { name: "mail", status: "loading", toolCount: 0 },
+    ]);
+    const current = statusWithMcp([
+      { name: "mail", status: "loaded", toolCount: 3 },
+    ]);
+    const getStatus = vi.fn<() => Promise<StatusInfo | undefined>>()
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(refreshed.promise);
+
+    const status = useStatus({ getStatus } as unknown as ApiClient, 100, 10);
+    const refresh = status.refresh();
+    refreshed.resolve(current);
+    await refresh;
+
+    initial.resolve(stale);
+    await Promise.resolve();
+
+    expect(getStatus).toHaveBeenCalledTimes(2);
+    expect(react.stateWrites[0]).toHaveLength(1);
+    const apply = react.stateWrites[0]![0] as (previous: {
+      status: StatusInfo | undefined;
+      reachable: boolean | undefined;
+    }) => {
+      status: StatusInfo | undefined;
+      reachable: boolean | undefined;
+    };
+    expect(apply({ status: undefined, reachable: undefined })).toEqual({
+      status: current,
+      reachable: true,
+    });
+  });
+});
+
+describe("useProvidersAdmin save", () => {
+  const configuredProvider: ProviderView = {
+    id: "anthropic",
+    configurable: true,
+    availableWithoutConfig: false,
+    modelPreferences: { mode: "selected", selected: ["claude-sonnet"] },
+  };
+
+  beforeEach(() => {
+    react.cleanups.splice(0).forEach((cleanup) => cleanup());
+    react.stateWrites = [];
+    react.stateIndex = 0;
+  });
+
+  afterEach(() => {
+    react.cleanups.splice(0).forEach((cleanup) => cleanup());
+  });
+
+  it("publishes one refresh only after both provider mutations succeed", async () => {
+    const events: string[] = [];
+    const client = {
+      listProviders: async () => {
+        events.push("providers");
+        return [configuredProvider];
+      },
+      getDefaultModel: async () => null,
+      updateProvider: async () => {
+        events.push("config");
+        return {};
+      },
+      updateProviderModels: async () => {
+        events.push("preferences");
+        return configuredProvider.modelPreferences;
+      },
+    } as unknown as ApiClient;
+    const admin = useProvidersAdmin(
+      client,
+      async () => {
+        events.push("catalogs");
+      },
+      async () => {
+        events.push("status");
+      },
+    );
+    await Promise.resolve();
+    events.length = 0;
+
+    await admin.save(
+      "anthropic",
+      { method: "api-key", values: { apiKey: "${ANTHROPIC_API_KEY}" } },
+      configuredProvider.modelPreferences,
+    );
+
+    expect(events).toEqual([
+      "config",
+      "preferences",
+      "providers",
+      "catalogs",
+      "status",
+    ]);
+  });
+
+  it("reloads authoritative state after the preference mutation fails", async () => {
+    const events: string[] = [];
+    const failure = new Error("preferences failed");
+    const client = {
+      listProviders: async () => {
+        events.push("providers");
+        return [configuredProvider];
+      },
+      getDefaultModel: async () => null,
+      updateProvider: async () => {
+        events.push("config");
+        return {};
+      },
+      updateProviderModels: async () => {
+        events.push("preferences");
+        throw failure;
+      },
+    } as unknown as ApiClient;
+    const admin = useProvidersAdmin(
+      client,
+      async () => {
+        events.push("catalogs");
+      },
+      async () => {
+        events.push("status");
+      },
+    );
+    await Promise.resolve();
+    events.length = 0;
+
+    await expect(admin.save(
+      "anthropic",
+      { method: "api-key", values: { apiKey: "${ANTHROPIC_API_KEY}" } },
+      configuredProvider.modelPreferences,
+    )).rejects.toBe(failure);
+
+    expect(events).toEqual([
+      "config",
+      "preferences",
+      "providers",
+      "catalogs",
+      "status",
+    ]);
   });
 });

--- a/apps/web/src/use-app-data.ts
+++ b/apps/web/src/use-app-data.ts
@@ -82,6 +82,18 @@ function refreshAfter<A extends unknown[], R>(
   };
 }
 
+async function settleRefreshes(
+  tasks: Array<Promise<unknown> | undefined>,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    tasks.filter((task): task is Promise<unknown> => task !== undefined),
+  );
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failure) throw failure.reason;
+}
+
 export function useSkillsAdmin(client: ApiClient, enabled = true) {
   const { data: skills, refresh } = useAdminData(
     useCallback(() => client.listSkills(), [client]),
@@ -185,9 +197,13 @@ export function useMcpServersAdmin(client: ApiClient, intervalMs = 5_000, enable
   };
 }
 
-// onModelsStale re-fetches the model catalog: configuring or removing a provider,
-// or changing the default, can change which models are available.
-export function useProvidersAdmin(client: ApiClient, onModelsStale?: () => Promise<unknown>) {
+// Provider changes can alter both model catalogs and live health, so callers
+// publish one authoritative refresh only after the related writes settle.
+export function useProvidersAdmin(
+  client: ApiClient,
+  onModelsStale?: () => Promise<unknown>,
+  onStatusStale?: () => Promise<unknown>,
+) {
   const { data: providers, loading, refresh } = useAdminData(
     useCallback(() => client.listProviders(), [client]),
     [] as ProviderView[],
@@ -197,28 +213,55 @@ export function useProvidersAdmin(client: ApiClient, onModelsStale?: () => Promi
     null as string | null,
   );
 
-  const refreshProviders = useCallback(
-    () => Promise.all([refresh(), onModelsStale?.()]),
-    [refresh, onModelsStale],
+  const refreshAuthoritative = useCallback(
+    () =>
+      settleRefreshes([
+        refresh(),
+        onModelsStale?.(),
+        onStatusStale?.(),
+      ]),
+    [refresh, onModelsStale, onStatusStale],
   );
   const refreshDefaultAndModels = useCallback(
-    () => Promise.all([refreshDefault(), onModelsStale?.()]),
-    [refreshDefault, onModelsStale],
+    () =>
+      settleRefreshes([
+        refreshDefault(),
+        onModelsStale?.(),
+        onStatusStale?.(),
+      ]),
+    [refreshDefault, onModelsStale, onStatusStale],
   );
 
-  const update = refreshAfter(
-    (id: string, config: { method: string; values: Record<string, string> }) => client.updateProvider(id, config),
-    refreshProviders,
+  const save = useCallback(async (
+    id: string,
+    config: { method: string; values: Record<string, string> },
+    preferences: import("@/api-client").ProviderModelPreferences,
+  ) => {
+    let mutationFailed = false;
+    let mutationError: unknown;
+    try {
+      await client.updateProvider(id, config);
+      await client.updateProviderModels(id, preferences);
+    } catch (cause) {
+      mutationFailed = true;
+      mutationError = cause;
+    }
+
+    try {
+      await refreshAuthoritative();
+    } catch (refreshError) {
+      if (!mutationFailed) throw refreshError;
+    }
+    if (mutationFailed) throw mutationError;
+  }, [client, refreshAuthoritative]);
+
+  const remove = refreshAfter(
+    (id: string) => client.deleteProvider(id),
+    refreshAuthoritative,
   );
-  const remove = refreshAfter((id: string) => client.deleteProvider(id), refreshProviders);
   const setDefault = refreshAfter((model: string | null) => client.setDefaultModel(model), refreshDefaultAndModels);
-  const setModels = refreshAfter(
-    (id: string, preferences: import("@/api-client").ProviderModelPreferences) =>
-      client.updateProviderModels(id, preferences),
-    refreshProviders,
-  );
 
-  return { providers, loading, defaultModel, refresh, update, remove, setDefault, setModels };
+  return { providers, loading, defaultModel, refresh, save, remove, setDefault };
 }
 
 export function useModels(
@@ -271,40 +314,75 @@ export interface ServerStatus {
   reachable: boolean | undefined;
 }
 
+export interface ServerStatusAdmin extends ServerStatus {
+  refresh: () => Promise<StatusInfo | undefined>;
+}
+
 export function useStatus(
   client: ApiClient,
   intervalMs = 15_000,
   loadingIntervalMs = 1_000,
-): ServerStatus {
+): ServerStatusAdmin {
   const [state, setState] = useState<ServerStatus>({ status: undefined, reachable: undefined });
+  const latestRequest = useRef(0);
+  const manualRefresh = useRef<() => Promise<StatusInfo | undefined>>(
+    () => Promise.resolve(undefined),
+  );
+
   useEffect(() => {
     let alive = true;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    const delayFor = (status: StatusInfo | undefined) => {
+      const mcpLoading =
+        status === undefined ||
+        status.mcp.servers.some(
+          (server) => server.status === "loading" || server.status === "retrying",
+        );
+      return mcpLoading ? loadingIntervalMs : intervalMs;
+    };
     const schedule = (delay: number) => {
       if (alive) timer = setTimeout(() => void tick(), delay);
     };
-    const tick = async () => {
+    const load = async () => {
+      const request = ++latestRequest.current;
       try {
         const status = await client.getStatus();
-        if (!alive) return;
-        setState((prev) => ({ status: status ?? prev.status, reachable: true }));
-        const mcpLoading =
-          status === undefined ||
-          status.mcp.servers.some(
-            (server) => server.status === "loading" || server.status === "retrying",
-          );
-        schedule(mcpLoading ? loadingIntervalMs : intervalMs);
-      } catch {
-        if (!alive) return;
-        setState((prev) => ({ ...prev, reachable: false }));
-        schedule(intervalMs);
+        const current = alive && request === latestRequest.current;
+        if (current) {
+          setState((prev) => ({ status: status ?? prev.status, reachable: true }));
+        }
+        return { status, current };
+      } catch (error) {
+        const current = alive && request === latestRequest.current;
+        if (current) setState((prev) => ({ ...prev, reachable: false }));
+        return { error, current };
       }
     };
+
+    const tick = async () => {
+      const result = await load();
+      if (!result.current) return;
+      schedule("status" in result ? delayFor(result.status) : intervalMs);
+    };
+
+    manualRefresh.current = async () => {
+      if (timer !== undefined) clearTimeout(timer);
+      const result = await load();
+      if (result.current) {
+        schedule("status" in result ? delayFor(result.status) : intervalMs);
+      }
+      if ("error" in result) throw result.error;
+      return result.status;
+    };
+
     void tick();
     return () => {
       alive = false;
+      latestRequest.current += 1;
       if (timer !== undefined) clearTimeout(timer);
     };
   }, [client, intervalMs, loadingIntervalMs]);
-  return state;
+
+  const refresh = useCallback(() => manualRefresh.current(), []);
+  return { ...state, refresh };
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -535,11 +535,11 @@ adapter (`inference-providers/providers/bedrock`) owns the `maxTokens` default
 reasoning-replay shim. It also combines native Bedrock discovery with Mantle's
 regional `/v1/models` catalog and records the protocol supplied by each source:
 inference profiles and other native models use Converse, raw OpenAI model
-families use Responses, raw Anthropic model families use Messages, and other
-Mantle model families use Chat Completions. Mantle catalog entries retain the
-protocol family exposed by that catalog. The regional Mantle host and protocol
-paths are Bedrock concerns, and its HTTP transport supports both Bedrock API keys
-and SigV4 credentials. The OpenAI adapter
+families and xAI use Responses, raw Anthropic model families use Messages, and
+other Mantle model families use Chat Completions. Mantle catalog entries retain
+the protocol family exposed by that catalog. The regional Mantle host and
+protocol paths are Bedrock concerns, and its HTTP transport supports both Bedrock
+API keys and SigV4 credentials. The OpenAI adapter
 independently selects Automatic, Responses, or Chat Completions for custom
 compatible endpoints. The Anthropic adapter likewise owns custom Messages API
 endpoints and `x-api-key` versus bearer authentication.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -542,7 +542,10 @@ host and protocol paths are Bedrock concerns, and its HTTP transport supports
 both Bedrock API keys and SigV4 credentials. The OpenAI adapter
 independently selects Automatic, Responses, or Chat Completions for custom
 compatible endpoints. The Anthropic adapter likewise owns custom Messages API
-endpoints and `x-api-key` versus bearer authentication.
+endpoints and `x-api-key` versus bearer authentication. OpenAI-compatible
+Responses models receive native `input_image` blocks because the upstream
+converter otherwise emits Chat Completions image content inside the Responses
+payload.
 
 Skill workers mark terminal responses whose provider metadata reports an
 output-token limit with an `OUTPUT_TRUNCATED` notice. DeepAgents carries that

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -535,11 +535,11 @@ adapter (`inference-providers/providers/bedrock`) owns the `maxTokens` default
 reasoning-replay shim. It also combines native Bedrock discovery with Mantle's
 regional `/v1/models` catalog and records the protocol supplied by each source:
 inference profiles and other native models use Converse, raw OpenAI model
-families and xAI use Responses, raw Anthropic model families use Messages, and
-other Mantle model families use Chat Completions. Mantle catalog entries retain
-the protocol family exposed by that catalog. The regional Mantle host and
-protocol paths are Bedrock concerns, and its HTTP transport supports both Bedrock
-API keys and SigV4 credentials. The OpenAI adapter
+families, xAI, and Gemma 4 use Responses, raw Anthropic model families use
+Messages, and other Mantle model families use Chat Completions. Mantle catalog
+entries retain the protocol family exposed by that catalog. The regional Mantle
+host and protocol paths are Bedrock concerns, and its HTTP transport supports
+both Bedrock API keys and SigV4 credentials. The OpenAI adapter
 independently selects Automatic, Responses, or Chat Completions for custom
 compatible endpoints. The Anthropic adapter likewise owns custom Messages API
 endpoints and `x-api-key` versus bearer authentication.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -535,10 +535,11 @@ adapter (`inference-providers/providers/bedrock`) owns the `maxTokens` default
 reasoning-replay shim. It also combines native Bedrock discovery with Mantle's
 regional `/v1/models` catalog and records the protocol supplied by each source:
 inference profiles and other native models use Converse, raw OpenAI model
-families use Responses, and raw Anthropic model families use Messages. Mantle
-catalog entries retain the protocol family exposed by that catalog. The regional
-Mantle host and protocol paths are Bedrock concerns, and its HTTP transport
-supports both Bedrock API keys and SigV4 credentials. The OpenAI adapter
+families use Responses, raw Anthropic model families use Messages, and other
+Mantle model families use Chat Completions. Mantle catalog entries retain the
+protocol family exposed by that catalog. The regional Mantle host and protocol
+paths are Bedrock concerns, and its HTTP transport supports both Bedrock API keys
+and SigV4 credentials. The OpenAI adapter
 independently selects Automatic, Responses, or Chat Completions for custom
 compatible endpoints. The Anthropic adapter likewise owns custom Messages API
 endpoints and `x-api-key` versus bearer authentication.

--- a/packages/inference-providers/src/providers/anthropic.test.ts
+++ b/packages/inference-providers/src/providers/anthropic.test.ts
@@ -3,6 +3,7 @@ import { AnthropicLangChainModelProvider, normalizeBaseUrl } from "./anthropic.j
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
 });
 
 describe("Anthropic model discovery", () => {
@@ -65,6 +66,26 @@ describe("Anthropic model discovery", () => {
     });
   });
 
+  it("replaces a cleared custom endpoint with the environment fallback", async () => {
+    vi.stubEnv("ANTHROPIC_BASE_URL", "https://anthropic-fallback.example");
+    const fetchFn = vi.fn(async () => Response.json({ data: [] }));
+    const provider = new AnthropicLangChainModelProvider({
+      apiKey: "test-key",
+      baseUrl: "https://anthropic-custom.example",
+      fetch: fetchFn,
+    });
+
+    provider.configure({
+      method: "api-key",
+      values: { apiKey: "test-key" },
+    });
+    await provider.listModels();
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://anthropic-fallback.example/v1/models?limit=1000",
+      expect.any(Object),
+    );
+  });
 });
 
 describe("Anthropic model construction", () => {

--- a/packages/inference-providers/src/providers/bedrock/langchain.ts
+++ b/packages/inference-providers/src/providers/bedrock/langchain.ts
@@ -549,6 +549,7 @@ function defaultProtocol(modelId: string): BedrockProtocol {
 }
 
 function mantleProtocol(modelId: string): BedrockProtocol {
+  if (modelId.toLowerCase().startsWith("xai.")) return "responses";
   const protocol = defaultProtocol(modelId);
   return protocol === "converse" ? "chat-completions" : protocol;
 }

--- a/packages/inference-providers/src/providers/bedrock/langchain.ts
+++ b/packages/inference-providers/src/providers/bedrock/langchain.ts
@@ -549,7 +549,10 @@ function defaultProtocol(modelId: string): BedrockProtocol {
 }
 
 function mantleProtocol(modelId: string): BedrockProtocol {
-  if (modelId.toLowerCase().startsWith("xai.")) return "responses";
+  const id = modelId.toLowerCase();
+  if (id.startsWith("xai.") || id.startsWith("google.gemma-4-")) {
+    return "responses";
+  }
   const protocol = defaultProtocol(modelId);
   return protocol === "converse" ? "chat-completions" : protocol;
 }

--- a/packages/inference-providers/src/providers/bedrock/langchain.ts
+++ b/packages/inference-providers/src/providers/bedrock/langchain.ts
@@ -37,7 +37,7 @@ import { createAnthropicChatModel } from "../anthropic.js";
 import { createOpenAiChatModel } from "../openai.js";
 import { createSigV4Fetch, mantleEndpoint } from "./mantle.js";
 
-type BedrockProtocol = "converse" | "responses" | "messages";
+type BedrockProtocol = "converse" | "responses" | "chat-completions" | "messages";
 
 interface RoutedModel {
   descriptor: ModelDescriptor;
@@ -274,7 +274,7 @@ export class BedrockLangChainModelProvider implements ModelProvider {
     }
     const descriptor = this.descriptors.get(modelId);
     const protocol = this.protocols.get(modelId) ?? defaultProtocol(modelId);
-    if (protocol === "responses") {
+    if (protocol === "responses" || protocol === "chat-completions") {
       const configuredMax = Math.min(
         this.maxTokens,
         descriptor?.maxOutputTokens ?? Number.POSITIVE_INFINITY,
@@ -286,8 +286,10 @@ export class BedrockLangChainModelProvider implements ModelProvider {
           configuredMax,
           this.learnedMaxTokens.get(modelId) ?? Number.POSITIVE_INFINITY,
         ),
-        apiMode: "responses",
-        baseUrl: `${mantleEndpoint(this.region)}/openai/v1`,
+        apiMode: protocol,
+        baseUrl: protocol === "responses"
+          ? `${mantleEndpoint(this.region)}/openai/v1`
+          : `${mantleEndpoint(this.region)}/v1`,
         fetch: await this.mantleFetch(),
         learnedMaxTokens: this.learnedMaxTokens,
         ...(descriptor ? { descriptor } : {}),
@@ -407,9 +409,7 @@ export class BedrockLangChainModelProvider implements ModelProvider {
           displayName: `${model.display_name ?? model.id} (Bedrock)`,
           supportsTools: true,
         },
-        protocol: model.id.toLowerCase().startsWith("anthropic.")
-          ? "messages"
-          : "responses",
+        protocol: mantleProtocol(model.id),
       }];
     });
   }
@@ -546,6 +546,11 @@ function defaultProtocol(modelId: string): BedrockProtocol {
   if (id.startsWith("openai.")) return "responses";
   if (id.startsWith("anthropic.")) return "messages";
   return "converse";
+}
+
+function mantleProtocol(modelId: string): BedrockProtocol {
+  const protocol = defaultProtocol(modelId);
+  return protocol === "converse" ? "chat-completions" : protocol;
 }
 
 function protocolDisplayName(

--- a/packages/inference-providers/src/providers/bedrock/mantle.test.ts
+++ b/packages/inference-providers/src/providers/bedrock/mantle.test.ts
@@ -100,6 +100,60 @@ describe("Bedrock Mantle discovery", () => {
 });
 
 describe("Bedrock Mantle invocation", () => {
+  it("streams xAI models through the OpenAI-namespaced Responses endpoint", async () => {
+    const requests: Array<{
+      url: string;
+      authorization: string | null;
+      hasTool: boolean;
+    }> = [];
+    const fetchFn = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/models")) {
+        return new Response(JSON.stringify({
+          data: [{ id: "xai.grok-4.3", display_name: "Grok 4.3" }],
+        }), { status: 200 });
+      }
+      requests.push({
+        url,
+        authorization: new Headers(init?.headers).get("authorization"),
+        hasTool: String(init?.body).includes("lookup"),
+      });
+      return new Response(JSON.stringify({
+        error: { message: "stop", type: "invalid_request_error" },
+      }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const provider = new BedrockLangChainModelProvider({
+      region: "us-west-2",
+      client: {
+        send: vi.fn(async (command: unknown) =>
+          command?.constructor.name === "ListInferenceProfilesCommand"
+            ? { inferenceProfileSummaries: [] }
+            : { modelSummaries: [] }),
+      },
+      fetch: fetchFn,
+      modelsDevFetch: vi.fn(async () =>
+        new Response(JSON.stringify({}), { status: 200 })),
+    });
+    provider.configure({
+      method: "bedrock-api-key",
+      values: { apiKey: "bedrock-key" },
+    });
+    await provider.listModels();
+
+    const model = await provider.buildModel("xai.grok-4.3");
+    await expect(collect(model.bindTools!([TEST_TOOL]).stream("hello")))
+      .rejects.toThrow("stop");
+
+    expect(requests).toEqual([{
+      url: "https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses",
+      authorization: "Bearer bedrock-key",
+      hasTool: true,
+    }]);
+  });
+
   it("streams other model families through the regional Chat Completions endpoint", async () => {
     const requests: Array<{
       url: string;

--- a/packages/inference-providers/src/providers/bedrock/mantle.test.ts
+++ b/packages/inference-providers/src/providers/bedrock/mantle.test.ts
@@ -100,7 +100,24 @@ describe("Bedrock Mantle discovery", () => {
 });
 
 describe("Bedrock Mantle invocation", () => {
-  it("streams xAI models through the OpenAI-namespaced Responses endpoint", async () => {
+  it.each([
+    {
+      family: "xAI",
+      modelId: "xai.grok-4.3",
+      displayName: "Grok 4.3",
+      region: "us-west-2",
+    },
+    {
+      family: "Gemma 4",
+      modelId: "google.gemma-4-31b",
+      displayName: "Gemma 4 31B",
+      region: "us-east-1",
+    },
+  ])("streams $family models through the OpenAI-namespaced Responses endpoint", async ({
+    modelId,
+    displayName,
+    region,
+  }) => {
     const requests: Array<{
       url: string;
       authorization: string | null;
@@ -110,7 +127,7 @@ describe("Bedrock Mantle invocation", () => {
       const url = String(input);
       if (url.endsWith("/v1/models")) {
         return new Response(JSON.stringify({
-          data: [{ id: "xai.grok-4.3", display_name: "Grok 4.3" }],
+          data: [{ id: modelId, display_name: displayName }],
         }), { status: 200 });
       }
       requests.push({
@@ -126,7 +143,7 @@ describe("Bedrock Mantle invocation", () => {
       });
     });
     const provider = new BedrockLangChainModelProvider({
-      region: "us-west-2",
+      region,
       client: {
         send: vi.fn(async (command: unknown) =>
           command?.constructor.name === "ListInferenceProfilesCommand"
@@ -143,12 +160,12 @@ describe("Bedrock Mantle invocation", () => {
     });
     await provider.listModels();
 
-    const model = await provider.buildModel("xai.grok-4.3");
+    const model = await provider.buildModel(modelId);
     await expect(collect(model.bindTools!([TEST_TOOL]).stream("hello")))
       .rejects.toThrow("stop");
 
     expect(requests).toEqual([{
-      url: "https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses",
+      url: `https://bedrock-mantle.${region}.api.aws/openai/v1/responses`,
       authorization: "Bearer bedrock-key",
       hasTool: true,
     }]);

--- a/packages/inference-providers/src/providers/bedrock/mantle.test.ts
+++ b/packages/inference-providers/src/providers/bedrock/mantle.test.ts
@@ -100,6 +100,60 @@ describe("Bedrock Mantle discovery", () => {
 });
 
 describe("Bedrock Mantle invocation", () => {
+  it("streams other model families through the regional Chat Completions endpoint", async () => {
+    const requests: Array<{
+      url: string;
+      authorization: string | null;
+      hasTool: boolean;
+    }> = [];
+    const fetchFn = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/models")) {
+        return new Response(JSON.stringify({
+          data: [{ id: "zai.glm-4.7-flash", display_name: "GLM 4.7 Flash" }],
+        }), { status: 200 });
+      }
+      requests.push({
+        url,
+        authorization: new Headers(init?.headers).get("authorization"),
+        hasTool: String(init?.body).includes("lookup"),
+      });
+      return new Response(JSON.stringify({
+        error: { message: "stop", type: "invalid_request_error" },
+      }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const provider = new BedrockLangChainModelProvider({
+      region: "eu-west-1",
+      client: {
+        send: vi.fn(async (command: unknown) =>
+          command?.constructor.name === "ListInferenceProfilesCommand"
+            ? { inferenceProfileSummaries: [] }
+            : { modelSummaries: [] }),
+      },
+      fetch: fetchFn,
+      modelsDevFetch: vi.fn(async () =>
+        new Response(JSON.stringify({}), { status: 200 })),
+    });
+    provider.configure({
+      method: "bedrock-api-key",
+      values: { apiKey: "bedrock-key" },
+    });
+    await provider.listModels();
+
+    const model = await provider.buildModel("zai.glm-4.7-flash");
+    await expect(collect(model.bindTools!([TEST_TOOL]).stream("hello")))
+      .rejects.toThrow("stop");
+
+    expect(requests).toEqual([{
+      url: "https://bedrock-mantle.eu-west-1.api.aws/v1/chat/completions",
+      authorization: "Bearer bedrock-key",
+      hasTool: true,
+    }]);
+  });
+
   it("streams OpenAI-family models through the regional Responses endpoint", async () => {
     const requests: Array<{
       url: string;

--- a/packages/inference-providers/src/providers/ollama.test.ts
+++ b/packages/inference-providers/src/providers/ollama.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { OllamaLangChainModelProvider } from "./ollama.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("Ollama model discovery", () => {
   it("reports an unavailable daemon as a retryable network failure", async () => {
@@ -53,5 +57,22 @@ describe("Ollama model discovery", () => {
 
     const model = await provider.buildModel("small:latest");
     expect(model.profile.maxInputTokens).toBe(8_192);
+  });
+
+  it("replaces a cleared custom host with the environment fallback", async () => {
+    vi.stubEnv("OLLAMA_HOST", "http://ollama-fallback.example");
+    const fetchFn = vi.fn(async () => Response.json({ models: [] }));
+    const provider = new OllamaLangChainModelProvider({
+      host: "http://ollama-custom.example",
+      fetch: fetchFn,
+    });
+
+    provider.configure({ method: "local", values: {} });
+    await provider.listModels();
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "http://ollama-fallback.example/api/tags",
+      expect.any(Object),
+    );
   });
 });

--- a/packages/inference-providers/src/providers/ollama.ts
+++ b/packages/inference-providers/src/providers/ollama.ts
@@ -87,8 +87,9 @@ export class OllamaLangChainModelProvider implements ModelProvider {
   }
 
   configure(cfg: ResolvedProviderConfig): void {
-    const host = cfg.values.host?.trim();
-    if (host) this.host = normalizeHost(host);
+    this.host = normalizeHost(
+      cfg.values.host?.trim() || process.env.OLLAMA_HOST || DEFAULT_HOST,
+    );
     this.contextLength = positiveInteger(cfg.values.contextLength) ?? DEFAULT_CONTEXT_LENGTH;
     this.thinking = thinkingMode(cfg.values.thinking);
   }

--- a/packages/inference-providers/src/providers/openai.test.ts
+++ b/packages/inference-providers/src/providers/openai.test.ts
@@ -247,6 +247,56 @@ describe("OpenAI model construction", () => {
 });
 
 describe("OpenAI attachment conversion", () => {
+  it("projects base64 images into native Responses input blocks", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const provider = new OpenAiLangChainModelProvider({
+      fetch: vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+        requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return openAiError("stop");
+      }),
+      models: [{
+        id: "responses-vision-model",
+        provider: "openai",
+        displayName: "Responses Vision Model",
+      }],
+    });
+    provider.configure({
+      method: "api-key",
+      values: {
+        apiKey: "test-key",
+        baseUrl: "https://proxy.example/openai/v1",
+        apiMode: "responses",
+      },
+    });
+    const message = new HumanMessage({
+      content: [
+        { type: "text", text: "what is this?" },
+        {
+          type: "image",
+          source_type: "base64",
+          mime_type: "image/png",
+          data: "QUJD",
+        },
+      ] as unknown as string,
+    });
+
+    const model = await provider.buildModel("responses-vision-model");
+    await expect(consume(model.stream([message]))).rejects.toThrow("stop");
+
+    expect(requestBody?.input).toEqual([{
+      type: "message",
+      role: "user",
+      content: [
+        { type: "input_text", text: "what is this?" },
+        {
+          type: "input_image",
+          image_url: "data:image/png;base64,QUJD",
+          detail: "auto",
+        },
+      ],
+    }]);
+  });
+
   it("preserves the original filename and extension in both request formats", () => {
     const filename = "✍️ Blogs Blog ideas.md";
     const message = new HumanMessage({

--- a/packages/inference-providers/src/providers/openai.test.ts
+++ b/packages/inference-providers/src/providers/openai.test.ts
@@ -8,6 +8,7 @@ import { isChatModel, OpenAiLangChainModelProvider, retryOutputCap } from "./ope
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
 });
 
 describe("OpenAI model discovery", () => {
@@ -89,6 +90,27 @@ describe("OpenAI model discovery", () => {
       }),
     ]);
     expect(modelsDevFetch).toHaveBeenCalledOnce();
+  });
+
+  it("replaces a cleared custom endpoint with the environment fallback", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://openai-fallback.example/v1");
+    const fetchFn = vi.fn(async () => Response.json({ data: [] }));
+    const provider = new OpenAiLangChainModelProvider({
+      apiKey: "test-key",
+      baseUrl: "https://openai-custom.example/v1",
+      fetch: fetchFn,
+    });
+
+    provider.configure({
+      method: "api-key",
+      values: { apiKey: "test-key" },
+    });
+    await provider.listModels();
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://openai-fallback.example/v1/models",
+      expect.any(Object),
+    );
   });
 });
 

--- a/packages/inference-providers/src/providers/openai.ts
+++ b/packages/inference-providers/src/providers/openai.ts
@@ -247,6 +247,54 @@ export interface OpenAiChatModelOptions {
   fetch?: typeof fetch;
 }
 
+interface ResponsesImageBlock {
+  type?: string;
+  source_type?: string;
+  mime_type?: string;
+  data?: string;
+  url?: string;
+  metadata?: { detail?: unknown };
+}
+
+// @langchain/openai@1.5.5 emits Chat Completions image blocks inside Responses input.
+function projectImagesForResponses(messages: BaseMessage[]): BaseMessage[] {
+  let changed = false;
+  const projected = messages.map((message) => {
+    if (typeof message.getType !== "function" || message.getType() !== "human") {
+      return message;
+    }
+    if (!Array.isArray(message.content)) return message;
+
+    let contentChanged = false;
+    const content = message.content.map((item) => {
+      if (!item || typeof item !== "object") return item;
+      const block = item as ResponsesImageBlock;
+      if (block.type !== "image") return item;
+      const imageUrl = block.source_type === "base64" && typeof block.data === "string"
+        ? `data:${block.mime_type ?? "image/png"};base64,${block.data}`
+        : block.source_type === "url" && typeof block.url === "string"
+        ? block.url
+        : undefined;
+      if (!imageUrl) return item;
+
+      contentChanged = true;
+      const detail = block.metadata?.detail;
+      return {
+        type: "input_image",
+        image_url: imageUrl,
+        detail: detail === "low" || detail === "high" ? detail : "auto",
+      };
+    });
+    if (!contentChanged) return message;
+
+    changed = true;
+    const clone = Object.create(Object.getPrototypeOf(message));
+    Object.assign(clone, message, { content });
+    return clone as BaseMessage;
+  });
+  return changed ? projected : messages;
+}
+
 export async function createOpenAiChatModel(
   options: OpenAiChatModelOptions,
 ): Promise<BaseChatModel> {
@@ -281,12 +329,50 @@ export async function createOpenAiChatModel(
       return withContextWindow(super.profile, descriptor?.contextWindow);
     }
 
+    private outbound(messages: BaseMessage[]): BaseMessage[] {
+      return apiMode === "responses"
+        ? projectImagesForResponses(messages)
+        : messages;
+    }
+
     protected override _useResponsesApi(
       callOptions: this["ParsedCallOptions"] | undefined,
     ): boolean {
       if (apiMode === "responses") return true;
       if (apiMode === "chat-completions") return false;
       return super._useResponsesApi(callOptions);
+    }
+
+    override _generate(
+      messages: BaseMessage[],
+      callOptions: this["ParsedCallOptions"],
+      runManager?: CallbackManagerForLLMRun,
+    ) {
+      return super._generate(this.outbound(messages), callOptions, runManager);
+    }
+
+    override _streamResponseChunks(
+      messages: BaseMessage[],
+      callOptions: this["ParsedCallOptions"],
+      runManager?: CallbackManagerForLLMRun,
+    ) {
+      return super._streamResponseChunks(
+        this.outbound(messages),
+        callOptions,
+        runManager,
+      );
+    }
+
+    override async *_streamChatModelEvents(
+      messages: BaseMessage[],
+      callOptions: this["ParsedCallOptions"],
+      runManager?: CallbackManagerForLLMRun,
+    ) {
+      yield* super._streamChatModelEvents(
+        this.outbound(messages),
+        callOptions,
+        runManager,
+      );
     }
 
     override withConfig(config: Partial<this["ParsedCallOptions"]>) {


### PR DESCRIPTION
## Summary
- combine provider configuration and model-preference writes behind one frontend save action, then refresh providers, both catalogs, and status once
- make manual status refreshes latest-request-wins so stale polls cannot overwrite post-save health
- reload authoritative state after partial failures and reset omitted Ollama host configuration to its environment/default fallback
- route Mantle models through their supported API families: OpenAI and selected OpenAI-namespaced families through Responses, Anthropic through Messages, and other families through Chat Completions
- handle the `/openai/v1` Responses requirements for xAI Grok 4.3 and Google Gemma 4 while keeping GLM 4.7 Flash on `/v1/chat/completions`
- serialize image attachments as native Responses `input_image` blocks for OpenAI-compatible vision models

## Verification
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- browser smoke test with Ollama confirming PUT/refresh ordering and stable model preferences
- browser smoke tests with Bedrock Mantle covering GLM 4.7 Flash, Grok 4.3, and Gemma 4 text/image requests

Fixes #22