### PR TITLE
fix: recover context overflows and cleanly stop runs

### DIFF
--- a/apps/api-server/src/protocol-run-manager.test.ts
+++ b/apps/api-server/src/protocol-run-manager.test.ts
@@ -395,8 +395,8 @@ describe("ProtocolRunManager", () => {
       (e) => e.method === "lifecycle" && e.params.namespace.length === 0 && (e.params.data as { event?: string }).event === "failed",
     );
     expect(failed).toBeDefined();
-    const data = failed!.params.data as { message?: string; code?: string };
-    expect(data.message).toContain("rate limit");
+    const data = failed!.params.data as { error?: string; code?: string };
+    expect(data.error).toContain("rate limit");
     expect(data.code).toBe("RATE_LIMIT");
   });
 
@@ -419,9 +419,9 @@ describe("ProtocolRunManager", () => {
       (e) => e.method === "lifecycle" && e.params.namespace.length === 0 && (e.params.data as { event?: string }).event === "failed",
     );
     expect(failed).toBeDefined();
-    const data = failed!.params.data as { message?: string; code?: string };
+    const data = failed!.params.data as { error?: string; code?: string };
     expect(data.code).toBe("MODEL_UNAVAILABLE");
-    expect(data.message).toContain("could not be built");
+    expect(data.error).toContain("could not be built");
   });
 
   it("onEnd reports status=cancelled when a run is superseded/cancelled", async () => {
@@ -597,7 +597,7 @@ describe("ProtocolRunManager", () => {
     release();
   });
 
-  it("an explicit cancel emits a terminal root lifecycle:failed(CANCELLED) frame", async () => {
+  it("an explicit cancel emits a completed terminal without surfacing an SDK error", async () => {
     const streamFn = (_i: RunInput, opts: RunOptions): AsyncIterable<ProtocolEvent> => ({
       async *[Symbol.asyncIterator]() {
         yield frame("messages", []);
@@ -616,7 +616,7 @@ describe("ProtocolRunManager", () => {
     await tick();
     const frames = await drainAll((sig) => mgr.observe("t8b", { channels: ["lifecycle"] }, sig));
     const terminal = frames.find(
-      (e) => e.method === "lifecycle" && e.params.namespace.length === 0 && (e.params.data as { event?: string }).event === "failed",
+      (e) => e.method === "lifecycle" && e.params.namespace.length === 0 && (e.params.data as { event?: string }).event === "completed",
     );
     expect(terminal).toBeDefined();
     expect((terminal!.params.data as { code?: string }).code).toBe("CANCELLED");

--- a/apps/api-server/src/protocol-run-manager.ts
+++ b/apps/api-server/src/protocol-run-manager.ts
@@ -362,7 +362,7 @@ export class ProtocolRunManager {
           state,
           this.stamp(
             makeLifecycleFrame("failed", {
-              message: err instanceof Error ? err.message : String(err),
+              error: err instanceof Error ? err.message : String(err),
               code: classifyError(err),
             }),
             state.runId,
@@ -382,13 +382,12 @@ export class ProtocolRunManager {
       failed,
     });
     if (synthesize === "cancelled") {
-      // The SDK has no cancelled lifecycle and only clears loading on a terminal
-      // completed/failed frame. The CANCELLED code preserves the actual outcome.
+      // The protocol has no cancelled lifecycle; a requested stop is successful
+      // for clients while the run registry retains the cancelled outcome.
       this.append(
         state,
         this.stamp(
-          makeLifecycleFrame("failed", {
-            message: "Run cancelled",
+          makeLifecycleFrame("completed", {
             code: "CANCELLED",
           }),
           state.runId,

--- a/apps/web/src/protocol-stream-store.ts
+++ b/apps/web/src/protocol-stream-store.ts
@@ -349,9 +349,7 @@ export class ProtocolStreamStore {
       };
     }
 
-    // Cancellation has no error payload and intentionally resolves to idle.
-    // Temporary SDK compatibility path. Exit criteria: remove when a successful
-    // StreamController hydration clears the preceding root error.
+    // A successful hydration can briefly retain the error that triggered it.
     const rootError =
       root.error && root.error !== e.resolvedHydrationError ? root.error : undefined;
     const status: StreamStatus = e.hydrationStatus === "error" || rootError

--- a/packages/core/src/classify-error.test.ts
+++ b/packages/core/src/classify-error.test.ts
@@ -28,6 +28,13 @@ describe("classifyError", () => {
     expect(classifyError(new Error("This model's maximum context length is 200000 tokens"))).toBe(
       "CONTEXT_LENGTH",
     );
+    expect(
+      classifyError(
+        new Error(
+          "400 request (43448 tokens) exceeds the available context size (32768 tokens)",
+        ),
+      ),
+    ).toBe("CONTEXT_LENGTH");
   });
 
   it("maps timeouts to TIMEOUT", () => {

--- a/packages/core/src/classify-error.ts
+++ b/packages/core/src/classify-error.ts
@@ -57,6 +57,7 @@ export function classifyError(err: unknown): ErrorCode {
   if (
     m.includes("context length") ||
     m.includes("context window") ||
+    (m.includes("context size") && m.includes("exceed")) ||
     m.includes("prompt is too long") ||
     m.includes("input is too long") ||
     m.includes("too many tokens") ||

--- a/packages/inference-providers/src/providers/openai.test.ts
+++ b/packages/inference-providers/src/providers/openai.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ContextOverflowError } from "@langchain/core/errors";
 import { HumanMessage } from "@langchain/core/messages";
 import {
   convertMessagesToCompletionsMessageParams,
@@ -139,20 +140,57 @@ describe("OpenAI model construction", () => {
     await expect(provider.buildModel("private-deployment")).resolves.toBeDefined();
   });
 
-  it("projects catalog context into the model profile", async () => {
+  it("keeps catalog context windows model-specific", async () => {
     const provider = new OpenAiLangChainModelProvider({
       apiKey: "test-key",
+      models: [
+        {
+          id: "custom-chat-model",
+          provider: "openai",
+          displayName: "Custom Chat Model",
+          contextWindow: 40_960,
+        },
+        {
+          id: "small-chat-model",
+          provider: "openai",
+          displayName: "Small Chat Model",
+          contextWindow: 16_384,
+        },
+      ],
+    });
+
+    const [custom, small] = await Promise.all([
+      provider.buildModel("custom-chat-model"),
+      provider.buildModel("small-chat-model"),
+    ]);
+
+    expect(custom.profile.maxInputTokens).toBe(40_960);
+    expect(small.profile.maxInputTokens).toBe(16_384);
+  });
+
+  it("normalizes compatible endpoint context errors for summarization recovery", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      openAiError(
+        "request (43448 tokens) exceeds the available context size (32768 tokens)",
+      ),
+    ));
+    const provider = new OpenAiLangChainModelProvider({
+      apiKey: "test-key",
+      baseUrl: "https://proxy.example/v1",
+      apiMode: "chat-completions",
       models: [{
         id: "custom-chat-model",
         provider: "openai",
         displayName: "Custom Chat Model",
-        contextWindow: 40_960,
       }],
     });
 
     const model = await provider.buildModel("custom-chat-model");
+    const failure = consume(model.stream("hello")).catch((error: unknown) => error);
 
-    expect(model.profile.maxInputTokens).toBe(40_960);
+    await expect(failure).resolves.toSatisfy((error: unknown) =>
+      ContextOverflowError.isInstance(error),
+    );
   });
 
   it("uses Responses for the configured API mode, including output-cap retries", async () => {

--- a/packages/inference-providers/src/providers/openai.ts
+++ b/packages/inference-providers/src/providers/openai.ts
@@ -2,10 +2,17 @@
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type { BaseMessage } from "@langchain/core/messages";
 import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
+import { ContextOverflowError } from "@langchain/core/errors";
 import type { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
 import type { ChatModelStreamEvent } from "@langchain/core/language_models/event";
 import type { ChatOpenAIFields } from "@langchain/openai";
-import type { ModelProvider, ModelDescriptor, ResolvedProviderConfig, ProviderAuthMethod } from "@pizza-bot/core";
+import {
+  classifyError,
+  type ModelProvider,
+  type ModelDescriptor,
+  type ResolvedProviderConfig,
+  type ProviderAuthMethod,
+} from "@pizza-bot/core";
 import {
   enrichModelDescriptors,
   resolveModelsDevCatalog,
@@ -139,7 +146,7 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
     this.maxTokens = positiveInteger(opts.maxTokens) ?? DEFAULT_MAX_TOKENS;
     this.catalogProvider = opts.catalogProvider;
     this.apiMode = opts.apiMode ?? "auto";
-    for (const descriptor of opts.models ?? []) {
+    for (const descriptor of this.models ?? []) {
       this.descriptors.set(descriptor.id, descriptor);
     }
   }
@@ -247,6 +254,13 @@ export interface OpenAiChatModelOptions {
   fetch?: typeof fetch;
 }
 
+function normalizeOpenAIModelError(error: unknown): unknown {
+  if (ContextOverflowError.isInstance(error)) return error;
+  if (classifyError(error) !== "CONTEXT_LENGTH") return error;
+  const cause = error instanceof Error ? error : new Error(String(error));
+  return ContextOverflowError.fromError(cause);
+}
+
 interface ResponsesImageBlock {
   type?: string;
   source_type?: string;
@@ -343,24 +357,32 @@ export async function createOpenAiChatModel(
       return super._useResponsesApi(callOptions);
     }
 
-    override _generate(
+    override async _generate(
       messages: BaseMessage[],
       callOptions: this["ParsedCallOptions"],
       runManager?: CallbackManagerForLLMRun,
-    ) {
-      return super._generate(this.outbound(messages), callOptions, runManager);
+    ): Promise<ChatResult> {
+      try {
+        return await super._generate(this.outbound(messages), callOptions, runManager);
+      } catch (error) {
+        throw normalizeOpenAIModelError(error);
+      }
     }
 
-    override _streamResponseChunks(
+    override async *_streamResponseChunks(
       messages: BaseMessage[],
       callOptions: this["ParsedCallOptions"],
       runManager?: CallbackManagerForLLMRun,
-    ) {
-      return super._streamResponseChunks(
-        this.outbound(messages),
-        callOptions,
-        runManager,
-      );
+    ): AsyncGenerator<ChatGenerationChunk> {
+      try {
+        yield* super._streamResponseChunks(
+          this.outbound(messages),
+          callOptions,
+          runManager,
+        );
+      } catch (error) {
+        throw normalizeOpenAIModelError(error);
+      }
     }
 
     override async *_streamChatModelEvents(
@@ -368,11 +390,15 @@ export async function createOpenAiChatModel(
       callOptions: this["ParsedCallOptions"],
       runManager?: CallbackManagerForLLMRun,
     ) {
-      yield* super._streamChatModelEvents(
-        this.outbound(messages),
-        callOptions,
-        runManager,
-      );
+      try {
+        yield* super._streamChatModelEvents(
+          this.outbound(messages),
+          callOptions,
+          runManager,
+        );
+      } catch (error) {
+        throw normalizeOpenAIModelError(error);
+      }
     }
 
     override withConfig(config: Partial<this["ParsedCallOptions"]>) {


### PR DESCRIPTION
# What and why

OpenAI-compatible endpoints can report context overflow as a generic 400 response instead of LangChain `ContextOverflowError`. DeepAgents therefore skipped emergency summarization and surfaced the provider error. This change recognizes the compatible endpoint wording and normalizes generation and streaming failures so summarization middleware can recover. Catalog context windows remain model-specific.

Explicit user cancellation was also synthesized as `lifecycle:failed` with a `message` field. The SDK reads `error`, so it displayed `Run failed with no error message`. Requested stops now terminate as successful protocol completion while the internal run registry retains `cancelled`; genuine failures use the protocol-standard `error` field.

Related: #27 tracks model-specific context-window overrides for custom deployments that lack catalog metadata.

## Gates

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

## Verified how

- [ ] Drove the change in a real app (web/desktop/CLI) - describe what you saw
- [x] Tests only: provider tests exercise model-specific profiles and normalize the observed endpoint response; protocol-manager tests cover SDK-facing failure and cancellation frames. A live reproduction requires credentials for the affected private endpoint.

## Layering

- [x] `packages/core` gained no `node:*`, DOM, `deepagents`, or `@langchain/langgraph` import
- [x] Only `packages/runtime-langgraph` imports the graph engine
- [x] `apps/web` imports no runtime and no model binding
- [x] Docs touched by this change were updated (no documentation change was required)