### PR TITLE
Fix skill worker access to bundled files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,3 +197,17 @@ checkout. Run `npm run build` before starting any application entrypoint:
 and `test` build only their task dependencies. Keep the affected tests and
 typecheck green, and run the full CI checks before opening a PR. Do not merge to
 `main` or push a branch unless the repository owner asks.
+
+After a PR is merged, clean up from the main checkout by removing the worktree
+before deleting its local branch:
+
+```bash
+git worktree remove .worktrees/<kebab-case-description>
+git branch -d <type>/<kebab-case-description>
+git fetch --prune
+```
+
+If GitHub did not delete the remote head branch, remove it with
+`git push origin --delete <type>/<kebab-case-description>`. Use
+`git worktree prune` only to clear stale metadata for worktree directories that
+were already removed; it does not remove a valid worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,12 @@ Name branches `<type>/<kebab-case-description>` using an intent such as `fix`,
 `feat`, `refactor`, `docs`, `test`, or `chore`. Branch names MUST describe the
 change, not the implementation tool, agent, author, or worktree.
 
+Create worktrees under the main checkout's repo-local
+`.worktrees/<kebab-case-description>` directory. The worktree directory MUST
+match the description portion of its branch name; omit the `<type>/` prefix.
+For example:
+`git worktree add .worktrees/skill-worker-bundled-files -b fix/skill-worker-bundled-files main`.
+
 A fresh worktree needs its own `npm install` before building or testing;
 otherwise workspace imports can resolve against stale output from another
 checkout. Run `npm run build` before starting any application entrypoint:

--- a/packages/runtime-langgraph/src/index.ts
+++ b/packages/runtime-langgraph/src/index.ts
@@ -1,6 +1,8 @@
 /** DeepAgents/LangGraph runtime implementation. */
 import {
   createDeepAgent,
+  createFilesystemMiddleware,
+  createSkillsMiddleware,
   createSubAgent,
   registerHarnessProfile,
   type CompiledSubAgent,
@@ -329,10 +331,18 @@ async function assemblePizzaBot(systemPrompt: string, deps: RuntimeDeps): Promis
       name: subagent.name,
       description: subagent.description,
       runnable: isolateSubagentLocalState(
+        // Compiled workers bypass createDeepAgent's declarative filesystem/skills normalization.
         createSubAgent({
           ...subagent,
           model,
           tools: subagent.tools ?? [],
+          middleware: [
+            createFilesystemMiddleware({ backend }),
+            ...(subagent.skills?.length
+              ? [createSkillsMiddleware({ backend, sources: subagent.skills })]
+              : []),
+            ...(subagent.middleware ?? []),
+          ],
         }),
       ),
     };

--- a/packages/runtime-langgraph/src/skill-file-access.test.ts
+++ b/packages/runtime-langgraph/src/skill-file-access.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+  AIMessage,
+  BaseMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import type { SkillCatalog } from "@pizza-bot/core";
+import { createPizzaBotAgent } from "./index.js";
+
+const REFERENCE_CONTENT = "The reference oven temperature is 500 F.";
+const HIDDEN_MARKER = "hidden-skill-only-marker";
+
+class SkillFileReadingModel extends BaseChatModel<Record<string, never>> {
+  private call = 0;
+  delegationResult = "";
+  readResult = "";
+  workerSystemPrompt = "";
+
+  _llmType(): string {
+    return "skill-file-reading";
+  }
+
+  override bindTools(): this {
+    return this;
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+  ): Promise<{ generations: Array<{ message: AIMessage; text: string }> }> {
+    const call = this.call++;
+    let message: AIMessage;
+
+    if (call === 0) {
+      message = new AIMessage({
+        content: "",
+        tool_calls: [{
+          id: "delegate-reader",
+          name: "task",
+          args: {
+            description: "Read the bundled oven reference and return its contents.",
+            subagent_type: "reader",
+          },
+          type: "tool_call",
+        }],
+      });
+    } else if (call === 1) {
+      this.workerSystemPrompt = messages
+        .filter(SystemMessage.isInstance)
+        .map((item) => typeof item.content === "string"
+          ? item.content
+          : JSON.stringify(item.content))
+        .join("\n");
+      message = new AIMessage({
+        content: "",
+        tool_calls: [{
+          id: "read-reference",
+          name: "read_file",
+          args: { path: "/skills/reader/references/oven.txt" },
+          type: "tool_call",
+        }],
+      });
+    } else {
+      const toolMessage = [...messages].reverse().find(ToolMessage.isInstance);
+      const toolContent = toolMessage?.content ?? "";
+      const content = typeof toolContent === "string"
+        ? toolContent
+        : JSON.stringify(toolContent);
+      if (call === 2) this.readResult = content;
+      if (call === 3) this.delegationResult = content;
+      message = new AIMessage({ content });
+    }
+
+    return { generations: [{ message, text: String(message.content) }] };
+  }
+}
+
+const skills: SkillCatalog = new Map([
+  [
+    "reader",
+    {
+      id: "reader",
+      name: "Reader",
+      description: "Reads its bundled oven reference.",
+      source: "user",
+      declaredTools: [],
+      interruptOn: {},
+      files: [
+        {
+          path: "/skills/reader/SKILL.md",
+          content: [
+            "---",
+            "name: reader",
+            "description: Reads its bundled oven reference.",
+            "---",
+            "",
+            "Read /skills/reader/references/oven.txt before answering.",
+          ].join("\n"),
+        },
+        {
+          path: "/skills/reader/references/oven.txt",
+          content: REFERENCE_CONTENT,
+        },
+      ],
+    },
+  ],
+  [
+    "hidden",
+    {
+      id: "hidden",
+      name: "Hidden",
+      description: HIDDEN_MARKER,
+      source: "user",
+      declaredTools: [],
+      interruptOn: {},
+      files: [{
+        path: "/skills/hidden/SKILL.md",
+        content: [
+          "---",
+          "name: hidden",
+          `description: ${HIDDEN_MARKER}`,
+          "---",
+          "",
+          HIDDEN_MARKER,
+        ].join("\n"),
+      }],
+    },
+  ],
+]);
+
+describe("skill worker files", () => {
+  it("reads its sibling reference without exposing another skill", async () => {
+    const model = new SkillFileReadingModel({});
+    const agent = await createPizzaBotAgent("Delegate this request.", { model, skills });
+
+    for await (const _ of agent.streamProtocol(
+      {
+        messages: [{
+          id: "u1",
+          role: "user",
+          parts: [{ type: "text", text: "What oven temperature should I use?" }],
+        }],
+      },
+      { threadId: `skill_file_${Math.random().toString(36).slice(2)}` },
+    )) {
+      // Drain the stream so delegated work completes.
+    }
+
+    expect(model.readResult).toContain(REFERENCE_CONTENT);
+    expect(model.delegationResult).toContain(REFERENCE_CONTENT);
+    expect(model.workerSystemPrompt).toContain("/skills/reader/references/oven.txt");
+    expect(model.workerSystemPrompt).toContain("Reads its bundled oven reference.");
+    expect(model.workerSystemPrompt).not.toContain(HIDDEN_MARKER);
+  });
+});

--- a/tests/langgraph-compat/protocol-stream-conformance.test.ts
+++ b/tests/langgraph-compat/protocol-stream-conformance.test.ts
@@ -301,9 +301,10 @@ describe("createPizzaBotAgent().streamProtocol() yields SDK-decodable ProtocolEv
       .join("");
     expect(text).toContain("Subagent completed.");
     expect(text).toContain("Delegation completed.");
-    expect(model.boundToolSets).toContainEqual([
-      "filesystem-mcp-server__read_file",
-    ]);
+    expect(model.boundToolSets.some((tools) =>
+      tools.includes("filesystem-mcp-server__read_file") &&
+      tools.includes("read_file")
+    )).toBe(true);
     expect(events.some(
       (e) =>
         channelOf(e) === "lifecycle" &&


### PR DESCRIPTION
## Summary

- install StateBackend filesystem and worker-scoped skills middleware on compiled skill workers
- preserve invocation-local run-limit state isolation
- add integration coverage for sibling reference reads and cross-skill metadata isolation
- update protocol conformance expectations for worker filesystem tools

## Testing

- `npm run build`
- `npm test`
- `npm run typecheck`
- `npm run lint`

Closes #30.