### PR TITLE
fix: make Playwright browser provisioning optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,30 @@ jobs:
       - name: Build backend container
         run: docker build --file deploy/linux/Dockerfile --tag pizza-bot-backend:ci .
 
+      - name: Smoke backend container
+        run: >-
+          docker run --rm
+          --volume "$PWD/scripts:/smoke:ro"
+          pizza-bot-backend:ci
+          node /smoke/smoke-remote-backend.mjs
+          --expect-playwright-unavailable
+          /opt/pizza-bot
+
+      - name: Build browser-enabled backend container
+        run: >-
+          docker build
+          --file deploy/linux/Dockerfile
+          --target runtime-with-browser
+          --tag pizza-bot-backend-browser:ci
+          .
+
+      - name: Smoke Playwright in browser-enabled container
+        run: >-
+          docker run --rm
+          --volume "$PWD/scripts:/smoke:ro"
+          pizza-bot-backend-browser:ci
+          node /smoke/smoke-playwright-mcp.mjs /opt/pizza-bot
+
       # Keep the network-dependent registry check last so it cannot hide
       # deterministic code, test, or build failures.
       - name: Audit production dependencies

--- a/deploy/linux/Dockerfile
+++ b/deploy/linux/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN npm ci
 RUN npm run backend:bundle
 
-FROM node:24-bookworm-slim AS runtime
+FROM node:24-bookworm-slim AS runtime-base
 
 ENV NODE_ENV=production \
     PIZZA_DATA_ROOT=/var/lib/pizza-bot \
@@ -26,7 +26,6 @@ RUN groupadd --gid 10001 pizza-bot \
 WORKDIR /opt/pizza-bot
 COPY --from=build /src/dist/backend/ ./
 
-USER pizza-bot
 VOLUME ["/var/lib/pizza-bot"]
 EXPOSE 8080
 
@@ -34,3 +33,15 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD ["node", "-e", "fetch('http://127.0.0.1:' + (process.env.PORT || 8080) + '/ping').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
 
 CMD ["node", "start.mjs"]
+
+FROM runtime-base AS runtime-with-browser
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends --yes chromium \
+    && rm -rf /var/lib/apt/lists/*
+
+USER pizza-bot
+
+FROM runtime-base AS runtime
+
+USER pizza-bot

--- a/deploy/linux/pizza-bot.env.example
+++ b/deploy/linux/pizza-bot.env.example
@@ -8,6 +8,9 @@ PIZZA_API_TOKEN=replace-with-a-random-token
 # Packaged Electron sends Origin: null. Add exact browser origins, comma-separated.
 PIZZA_ALLOWED_ORIGINS=null
 
+# Optional browser executable for the bundled Playwright MCP plugin.
+# PIZZA_PLAYWRIGHT_BROWSER_PATH=/usr/bin/chromium
+
 # Provider credentials belong on the backend host.
 # ANTHROPIC_API_KEY=
 # OPENAI_API_KEY=

--- a/docs/STANDALONE_BACKEND.md
+++ b/docs/STANDALONE_BACKEND.md
@@ -18,6 +18,9 @@ SQLite databases and is not a horizontally scalable service.
 - A source checkout and npm are required only to build it.
 - A deployed artifact needs Node.js, its environment, and a writable data
   directory; it does not need the repository or an `npm install`.
+- The bundled Browser Automation Plugin needs Chrome, Edge, or Chromium on the
+  backend host. The default container image omits a browser; the backend reports
+  the plugin as unavailable without affecting its other capabilities.
 
 For source development, install and build the workspace first:
 
@@ -228,6 +231,15 @@ Build the multi-stage image from the repository root:
 docker build -f deploy/linux/Dockerfile -t pizza-bot-backend .
 ```
 
+The default image omits Chromium. To include it for the Browser Automation
+Plugin, build the optional target:
+
+```bash
+docker build -f deploy/linux/Dockerfile \
+  --target runtime-with-browser \
+  -t pizza-bot-backend-browser .
+```
+
 Finch can build the same image on macOS. Initialize its VM once, then build the
 native Linux architecture or cross-build an AMD64 server image:
 
@@ -269,9 +281,9 @@ origin allowlist.
 
 ### systemd
 
-Build and transfer `dist/backend`, then install Node.js 24 on the server. The
-provided unit expects `/usr/bin/node`; edit `ExecStart` if the host installs it
-elsewhere.
+Build and transfer `dist/backend`, then install Node.js 24. Install Chrome,
+Edge, or Chromium when the Browser Automation Plugin is needed. The provided
+unit expects `/usr/bin/node`; edit `ExecStart` if the host installs it elsewhere.
 
 Create the service account and directories:
 
@@ -297,6 +309,13 @@ sudoedit /etc/pizza-bot/pizza-bot.env
 Replace `PIZZA_API_TOKEN` with `openssl rand -hex 32` output before enabling the
 service. A loopback listener cannot detect that Caddy will expose it, so the
 systemd configuration does not provide the non-loopback startup guard.
+
+The launcher checks common browser locations outside the service `PATH`. Set an
+explicit path in `/etc/pizza-bot/pizza-bot.env` when needed:
+
+```bash
+PIZZA_PLAYWRIGHT_BROWSER_PATH=/opt/google/chrome/chrome
+```
 
 Start and inspect the service:
 
@@ -398,5 +417,6 @@ private network, or use an SSH tunnel. See [SECURITY.md](../SECURITY.md).
 | Desktop rejects the URL | Use HTTPS outside loopback, or connect through a loopback SSH tunnel. |
 | Runs or sidebar updates stall | Disable reverse-proxy buffering for both SSE endpoints. |
 | Backend green, provider red | Configure a model provider and credentials on the backend. |
+| Playwright reports `browser_not_found` | Install a browser where the backend runs, or set `PIZZA_PLAYWRIGHT_BROWSER_PATH`; a host browser is not visible inside a container. |
 | Skill unavailable | Configure the required server-side MCP server and tools. |
 | systemd cannot write a path | Add the trusted path to `ReadWritePaths` or keep it under the data root. |

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -62,7 +62,17 @@ Pizza Bot installers do not include Chrome for Testing or another browser. A
 packaged app uses Chrome, Edge, or Chromium already installed on the machine
 (or the matching Chrome for Testing revision if it already exists in
 Playwright's cache). If none is available, install one of those supported
-browsers and reconnect the Playwright MCP server.
+browsers and reconnect the Playwright MCP server. Set
+`PIZZA_PLAYWRIGHT_BROWSER_PATH` when the browser is outside the backend
+process's `PATH`; the launcher also checks conventional Linux Chrome, Edge,
+Chromium, and Snap locations. It selects headless mode when Linux has no display
+server.
+
+The default Linux backend image does not include a browser. Build its
+`runtime-with-browser` target when browser automation must be self-contained.
+Browsers installed on the container host are not visible inside the container.
+When no supported browser is visible, the server reports an actionable
+`browser_not_found` status and the rest of the backend remains available.
 
 Playwright's npm packages do not download browsers from an install or
 postinstall script. The root `allowScripts` policy and the packager's

--- a/plugins/playwright-mcp/.mcp.json
+++ b/plugins/playwright-mcp/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "playwright": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/launch.mjs"]
+      "args": ["${CLAUDE_PLUGIN_ROOT}/launch.mjs"],
+      "env": {
+        "PIZZA_PLAYWRIGHT_BROWSER_PATH": "${PIZZA_PLAYWRIGHT_BROWSER_PATH}"
+      }
     }
   }
 }

--- a/plugins/playwright-mcp/browser-selection.mjs
+++ b/plugins/playwright-mcp/browser-selection.mjs
@@ -1,6 +1,19 @@
 import { existsSync } from "node:fs";
 import { delimiter, join } from "node:path";
 
+const LINUX_BROWSER_PATHS = [
+  "/opt/google/chrome/chrome",
+  "/opt/google/chrome/google-chrome",
+  "/opt/microsoft/msedge/msedge",
+  "/snap/bin/chromium",
+  "/usr/bin/google-chrome-stable",
+  "/usr/bin/google-chrome",
+  "/usr/bin/chromium",
+  "/usr/bin/chromium-browser",
+  "/usr/bin/microsoft-edge-stable",
+  "/usr/bin/microsoft-edge",
+];
+
 const BROWSER_SELECTION_FLAGS = [
   "--browser",
   "--executable-path",
@@ -23,6 +36,10 @@ export function installedBrowser({
   exists = existsSync,
   managedExecutablePath,
 } = {}) {
+  const configuredPath = env.PIZZA_PLAYWRIGHT_BROWSER_PATH?.trim();
+  if (configuredPath) {
+    return exists(configuredPath) ? { executablePath: configuredPath } : undefined;
+  }
   if (platform === "darwin") {
     if (exists("/Applications/Google Chrome.app")) {
       return { channel: "chrome" };
@@ -64,11 +81,22 @@ export function installedBrowser({
       exists,
     );
     if (executablePath) return { executablePath };
+    const conventionalPath = LINUX_BROWSER_PATHS.find((candidate) =>
+      exists(candidate),
+    );
+    if (conventionalPath) return { executablePath: conventionalPath };
   }
   if (managedExecutablePath && exists(managedExecutablePath)) {
     return { executablePath: managedExecutablePath };
   }
   return undefined;
+}
+
+export function needsHeadlessMode({
+  platform = process.platform,
+  env = process.env,
+} = {}) {
+  return platform === "linux" && !env.DISPLAY && !env.WAYLAND_DISPLAY;
 }
 
 function findOnPath(names, pathValue, exists) {

--- a/plugins/playwright-mcp/browser-selection.test.mjs
+++ b/plugins/playwright-mcp/browser-selection.test.mjs
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { fileURLToPath } from "node:url";
+import { createInterface } from "node:readline";
 import test from "node:test";
 import {
   hasBrowserSelection,
   installedBrowser,
+  needsHeadlessMode,
 } from "./browser-selection.mjs";
 
 test("recognizes explicit browser selection flags", () => {
@@ -27,6 +32,51 @@ test("prefers a supported system browser over the managed cache", () => {
   );
 });
 
+test("uses an explicit browser path before automatic discovery", () => {
+  const existing = new Set([
+    "/configured/browser",
+    "/usr/bin/google-chrome",
+    "/cache/chrome-for-testing",
+  ]);
+
+  assert.deepEqual(
+    installedBrowser({
+      platform: "linux",
+      env: {
+        PATH: "/usr/bin",
+        PIZZA_PLAYWRIGHT_BROWSER_PATH: "/configured/browser",
+      },
+      exists: (candidate) => existing.has(candidate),
+      managedExecutablePath: "/cache/chrome-for-testing",
+    }),
+    { executablePath: "/configured/browser" },
+  );
+
+  assert.equal(
+    installedBrowser({
+      platform: "linux",
+      env: {
+        PATH: "/usr/bin",
+        PIZZA_PLAYWRIGHT_BROWSER_PATH: "/configured/missing",
+      },
+      exists: (candidate) => existing.has(candidate),
+      managedExecutablePath: "/cache/chrome-for-testing",
+    }),
+    undefined,
+  );
+});
+
+test("checks conventional Linux locations outside the service PATH", () => {
+  assert.deepEqual(
+    installedBrowser({
+      platform: "linux",
+      env: { PATH: "/restricted/bin" },
+      exists: (candidate) => candidate === "/opt/google/chrome/chrome",
+    }),
+    { executablePath: "/opt/google/chrome/chrome" },
+  );
+});
+
 test("uses the managed browser only when its executable exists", () => {
   assert.deepEqual(
     installedBrowser({
@@ -45,4 +95,68 @@ test("uses the managed browser only when its executable exists", () => {
     }),
     undefined,
   );
+});
+
+test("uses headless mode on Linux without a display server", () => {
+  assert.equal(
+    needsHeadlessMode({ platform: "linux", env: { PATH: "/usr/bin" } }),
+    true,
+  );
+  assert.equal(
+    needsHeadlessMode({
+      platform: "linux",
+      env: { DISPLAY: ":0", PATH: "/usr/bin" },
+    }),
+    false,
+  );
+  assert.equal(
+    needsHeadlessMode({
+      platform: "linux",
+      env: { WAYLAND_DISPLAY: "wayland-0", PATH: "/usr/bin" },
+    }),
+    false,
+  );
+  assert.equal(needsHeadlessMode({ platform: "darwin", env: {} }), false);
+});
+
+test("reports a missing configured browser through MCP initialization", { timeout: 10_000 }, async (t) => {
+  const child = spawn(process.execPath, [fileURLToPath(new URL("./launch.mjs", import.meta.url))], {
+    env: {
+      ...process.env,
+      PIZZA_PLAYWRIGHT_BROWSER_PATH: "/browser/does/not/exist",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  t.after(() => {
+    if (child.exitCode === null) child.kill("SIGKILL");
+  });
+
+  let stderr = "";
+  child.stderr.setEncoding("utf8").on("data", (chunk) => {
+    stderr += chunk;
+  });
+  const lines = createInterface({ input: child.stdout });
+  const response = new Promise((resolve) => {
+    lines.once("line", (line) => resolve(JSON.parse(line)));
+  });
+  child.stdin.write(
+    `${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    })}\n`,
+  );
+
+  const startupError = await response;
+  assert.equal(startupError.jsonrpc, "2.0");
+  assert.equal(startupError.id, 1);
+  assert.equal(startupError.error.code, -32603);
+  assert.match(startupError.error.message, /browser_not_found/);
+  assert.match(startupError.error.message, /PIZZA_PLAYWRIGHT_BROWSER_PATH/);
+  child.stdin.end();
+  const [code] = await once(child, "exit");
+  assert.equal(code, 1);
+  assert.match(stderr, /browser_not_found/);
+  assert.match(stderr, /PIZZA_PLAYWRIGHT_BROWSER_PATH/);
 });

--- a/plugins/playwright-mcp/launch.mjs
+++ b/plugins/playwright-mcp/launch.mjs
@@ -1,9 +1,11 @@
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
+import { createInterface } from "node:readline";
 import { pathToFileURL } from "node:url";
 import {
   hasBrowserSelection,
   installedBrowser,
+  needsHeadlessMode,
 } from "./browser-selection.mjs";
 
 const require = createRequire(import.meta.url);
@@ -14,17 +16,53 @@ if (!hasBrowserSelection(process.argv)) {
     managedExecutablePath: chromium.executablePath(),
   });
   if (!browser) {
-    throw new Error(
-      "Playwright Browser Automation could not find Chrome, Edge, Chromium, " +
-        "or the required Chrome for Testing revision. Pizza Bot installers do " +
-        "not include a browser. Install Chrome, Edge, or Chromium, then reconnect " +
-        "the Playwright MCP server. When running from source, run " +
-        "`npm run browser:install` first.",
-    );
+    const configuredPath = process.env.PIZZA_PLAYWRIGHT_BROWSER_PATH?.trim();
+    const detail = configuredPath
+      ? `PIZZA_PLAYWRIGHT_BROWSER_PATH does not point to an existing browser executable: ${configuredPath}`
+      : "Chrome, Edge, Chromium, or the required Chrome for Testing revision was not found";
+    const message =
+      `browser_not_found: ${detail}. Install a browser on the backend host or ` +
+      "set PIZZA_PLAYWRIGHT_BROWSER_PATH, then reconnect the Playwright MCP server. " +
+      "A host browser is not visible inside a container. When running from source, " +
+      "run `npm run browser:install` first.";
+    process.stderr.write(`[playwright-mcp] ${message}\n`);
+    await reportStartupError(message);
+  } else {
+    if (browser.channel) process.argv.push("--browser", browser.channel);
+    if (browser.executablePath) process.argv.push("--executable-path", browser.executablePath);
+    if (needsHeadlessMode()) process.argv.push("--headless");
+
+    const packageJson = require.resolve("@playwright/mcp/package.json");
+    await import(pathToFileURL(join(dirname(packageJson), "cli.js")).href);
   }
-  if (browser.channel) process.argv.push("--browser", browser.channel);
-  if (browser.executablePath) process.argv.push("--executable-path", browser.executablePath);
+} else {
+  const packageJson = require.resolve("@playwright/mcp/package.json");
+  await import(pathToFileURL(join(dirname(packageJson), "cli.js")).href);
 }
 
-const packageJson = require.resolve("@playwright/mcp/package.json");
-await import(pathToFileURL(join(dirname(packageJson), "cli.js")).href);
+async function reportStartupError(message) {
+  const lines = createInterface({ input: process.stdin });
+  await new Promise((resolve) => {
+    lines.on("line", (line) => {
+      let request;
+      try {
+        request = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (request.method !== "initialize" || request.id === undefined) return;
+      const response = {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: { code: -32603, message },
+      };
+      process.stdout.write(`${JSON.stringify(response)}\n`, () => {
+        lines.close();
+        process.stdin.unref?.();
+        resolve();
+      });
+    });
+    lines.on("close", resolve);
+  });
+  process.exitCode = 1;
+}

--- a/scripts/smoke-playwright-mcp.mjs
+++ b/scripts/smoke-playwright-mcp.mjs
@@ -1,0 +1,110 @@
+/** Launches the packaged Playwright MCP server and performs a real navigation. */
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import path from "node:path";
+import { createInterface } from "node:readline";
+
+const artifactRoot = path.resolve(process.argv[2] ?? "dist/backend");
+const launcher = path.join(
+  artifactRoot,
+  "plugins",
+  "playwright-mcp",
+  "launch.mjs",
+);
+const pageServer = createServer((_request, response) => {
+  response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+  response.end("<!doctype html><title>Pizza Bot browser smoke</title><main>Browser ready</main>");
+});
+await new Promise((resolve, reject) => {
+  pageServer.once("error", reject);
+  pageServer.listen(0, "127.0.0.1", resolve);
+});
+const address = pageServer.address();
+assert(address && typeof address === "object");
+
+const child = spawn(process.execPath, [launcher], {
+  cwd: artifactRoot,
+  env: process.env,
+  stdio: ["pipe", "pipe", "pipe"],
+});
+let stderr = "";
+child.stderr.setEncoding("utf8").on("data", (chunk) => {
+  stderr = (stderr + chunk).slice(-50_000);
+});
+
+const pending = new Map();
+const lines = createInterface({ input: child.stdout });
+lines.on("line", (line) => {
+  const message = JSON.parse(line);
+  const request = pending.get(message.id);
+  if (!request) return;
+  pending.delete(message.id);
+  clearTimeout(request.timer);
+  if (message.error) request.reject(new Error(message.error.message));
+  else request.resolve(message.result);
+});
+
+let nextId = 1;
+const request = (method, params = {}) => {
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error(`${method} timed out\n${stderr}`));
+    }, 30_000);
+    pending.set(id, { resolve, reject, timer });
+    child.stdin.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`,
+    );
+  });
+};
+
+try {
+  await request("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "pizza-bot-browser-smoke", version: "1.0.0" },
+  });
+  child.stdin.write(
+    `${JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    })}\n`,
+  );
+
+  const listed = await request("tools/list");
+  assert.ok(
+    listed.tools.some((tool) => tool.name === "browser_navigate"),
+    "browser_navigate tool was not packaged",
+  );
+  const navigated = await request("tools/call", {
+    name: "browser_navigate",
+    arguments: { url: `http://127.0.0.1:${address.port}` },
+  });
+  assert.notEqual(navigated.isError, true, JSON.stringify(navigated));
+  assert.match(JSON.stringify(navigated.content), /Pizza Bot browser smoke/);
+  await request("tools/call", {
+    name: "browser_close",
+    arguments: {},
+  });
+  console.log("packaged Playwright MCP browser smoke passed");
+} catch (error) {
+  process.stderr.write(stderr);
+  throw error;
+} finally {
+  for (const request of pending.values()) clearTimeout(request.timer);
+  const childExited =
+    child.exitCode === null
+      ? new Promise((resolve) => child.once("exit", resolve))
+      : Promise.resolve();
+  child.stdin.end();
+  if (child.exitCode === null) child.kill("SIGTERM");
+  await Promise.all([
+    childExited,
+    new Promise((resolve, reject) =>
+      pageServer.close((error) => (error ? reject(error) : resolve())),
+    ),
+  ]);
+}

--- a/scripts/smoke-remote-backend.mjs
+++ b/scripts/smoke-remote-backend.mjs
@@ -7,7 +7,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const sourceDir = path.join(repoRoot, "dist", "backend");
+const expectPlaywrightUnavailable = process.argv.includes(
+  "--expect-playwright-unavailable",
+);
+const forcePlaywrightUnavailable = process.argv.includes(
+  "--force-playwright-unavailable",
+);
+const artifactArg = process.argv.slice(2).find((arg) => !arg.startsWith("--"));
+const sourceDir = artifactArg
+  ? path.resolve(artifactArg)
+  : path.join(repoRoot, "dist", "backend");
 if (!existsSync(path.join(sourceDir, "start.mjs"))) {
   throw new Error("missing dist/backend/start.mjs; run npm run backend:bundle first");
 }
@@ -33,6 +42,9 @@ const child = fork(entry, [], {
     PIZZA_DATA_ROOT: dataRoot,
     PIZZA_HOST: "127.0.0.1",
     PIZZA_MODEL: "ollama:smoke",
+    ...(forcePlaywrightUnavailable
+      ? { PIZZA_PLAYWRIGHT_BROWSER_PATH: "/browser/does/not/exist" }
+      : {}),
     PORT: "0",
   },
   stdio: ["ignore", "pipe", "pipe", "ipc"],
@@ -110,14 +122,15 @@ try {
     ["playwright-mcp"],
   );
 
-  const mcpServers = await waitForMcpLoaded(baseUrl, authHeaders);
-  assert.deepEqual(
-    mcpServers
-      .filter((server) => server.name === "playwright")
-      .map((server) => ({ name: server.name, status: server.status }))
-      .sort((a, b) => a.name.localeCompare(b.name)),
-    [{ name: "playwright", status: "loaded" }],
+  const playwright = await waitForPlaywright(
+    baseUrl,
+    authHeaders,
+    expectPlaywrightUnavailable ? "error" : "loaded",
   );
+  if (expectPlaywrightUnavailable) {
+    assert.match(playwright.detail ?? "", /browser_not_found/);
+    assert.match(playwright.detail ?? "", /PIZZA_PLAYWRIGHT_BROWSER_PATH/);
+  }
 
   const skills = await fetch(`${baseUrl}/skills`, { headers: authHeaders });
   assert.equal(skills.status, 200);
@@ -126,8 +139,8 @@ try {
   );
   assert.equal(
     browserAutomation?.status,
-    "ready",
-    `bundled browser skill must be ready: ${browserAutomation?.statusDetail ?? "not found"}`,
+    expectPlaywrightUnavailable ? "unavailable" : "ready",
+    `unexpected browser skill state: ${browserAutomation?.statusDetail ?? "not found"}`,
   );
 
   streamAbort = new AbortController();
@@ -255,20 +268,20 @@ async function waitForHealthy(baseUrl, origin) {
   throw new Error(`backend did not become healthy: ${lastStatus}`);
 }
 
-async function waitForMcpLoaded(baseUrl, headers) {
+async function waitForPlaywright(baseUrl, headers, expectedStatus) {
   const deadline = Date.now() + 15_000;
   let servers = [];
   while (Date.now() < deadline) {
     const response = await fetch(`${baseUrl}/status`, { headers });
     assert.equal(response.status, 200);
     servers = (await response.json()).mcp.servers;
-    const shipped = servers.filter((server) => server.name === "playwright");
-    if (shipped.length === 1 && shipped[0].status === "loaded") {
-      return servers;
-    }
+    const shipped = servers.find((server) => server.name === "playwright");
+    if (shipped?.status === expectedStatus) return shipped;
     await delay(100);
   }
-  throw new Error(`packaged MCP servers did not load: ${JSON.stringify(servers)}`);
+  throw new Error(
+    `Playwright MCP did not reach ${expectedStatus}: ${JSON.stringify(servers)}`,
+  );
 }
 
 function createSseReader(body) {


### PR DESCRIPTION
# What and why

Closes #32.

Keep Playwright browser automation as an optional capability without adding
Chromium's roughly 700 MB installed footprint to every backend image.

- Detect browsers from `PIZZA_PLAYWRIGHT_BROWSER_PATH`, `PATH`, Playwright's
  managed cache, and conventional Linux installation locations.
- Select headless mode automatically on Linux without X11 or Wayland.
- Return an actionable `browser_not_found` MCP initialization error instead of
  collapsing startup failure into `-32000 Connection closed`.
- Keep the default backend image browser-free and provide a
  `runtime-with-browser` target.
- Exercise both deployment modes in CI, including a real Chromium navigation.
- Document browser visibility across bare processes, systemd, and containers.

## Gates

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

## Verified how

- [x] Drove the change in a real app (web/desktop/CLI) - built the production
  backend artifact and both Linux image targets in a native ARM64 Finch VM.
  The 315 MB default image stayed healthy while reporting
  `browser_not_found`; the 1.03 GB browser target launched Chromium headlessly
  and navigated to a local test page through `browser_navigate`.
- [ ] Tests only (explain why that is sufficient here)

Additional checks:

- `npm run backend:bundle`
- `npm run backend:smoke`
- Forced missing-browser artifact smoke
- Browser-free container backend smoke without a forced override
- Packaged Playwright MCP real-navigation smoke

## Layering

- [x] `packages/core` gained no `node:*`, DOM, `deepagents`, or `@langchain/langgraph` import
- [x] Only `packages/runtime-langgraph` imports the graph engine
- [x] `apps/web` imports no runtime and no model binding
- [x] Docs touched by this change were updated (README / AGENTS.md / docs/ARCHITECTURE.md)
