### PR TITLE
Add folders for organizing conversation threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Pizza Bot was developed at Amazon and is released under the Apache 2.0 license.
 - **Work asynchronously.** Switch conversations without stopping their runs.
 - **Return to the right queue.** Completed work lands in Unread; durable approval
   requests land in Action.
+- **Organize conversations.** Group threads into folders without hiding matching
+  work from the global Unread and Action queues.
 - **Resume real work.** Checkpointed runs survive client disconnects, and cron or
   webhook triggers can start work without an open conversation.
 - **Delegate to specialists.** Skills become tool-scoped workers whose progress

--- a/apps/api-server/src/agent-host.ts
+++ b/apps/api-server/src/agent-host.ts
@@ -31,6 +31,7 @@ import {
   resolveLayout,
   TriggerStore,
   ThreadStore,
+  FolderStore,
   SearchStore,
   SettingsStore,
   ProviderConfigStore,
@@ -321,6 +322,7 @@ export class AgentHost {
   readonly triggerService: TriggerService;
 
   readonly threadStore: ThreadStore;
+  readonly folderStore: FolderStore;
   readonly search: SearchStore;
   readonly settings: SettingsStore;
   readonly providerConfigs: ProviderConfigStore;
@@ -379,6 +381,7 @@ export class AgentHost {
     this.appDb = openAppDatabase(appDbPath, attachmentsDir || undefined);
     this.triggers = this.appDb.triggers;
     this.threadStore = this.appDb.threadStore;
+    this.folderStore = this.appDb.folders;
     this.search = this.appDb.search;
     this.settings = this.appDb.settings;
     this.providerConfigs = this.appDb.providerConfigs;

--- a/apps/api-server/src/index.ts
+++ b/apps/api-server/src/index.ts
@@ -24,6 +24,7 @@ import { statusRoutes } from "./routes-status.js";
 import { toolsRoutes } from "./routes-tools.js";
 import { protocolRoutes } from "./routes-protocol.js";
 import { attachmentRoutes } from "./routes-attachments.js";
+import { folderRoutes } from "./routes-folders.js";
 import { logRoutes } from "./routes-logs.js";
 import { limitJsonBody, MAX_JSON_BODY_BYTES } from "./request-limits.js";
 import {
@@ -180,6 +181,7 @@ export function buildApp(
   // Literal thread routes and protocol endpoints must precede parameterized
   // LangGraph routes that could otherwise capture the same paths.
   app.route("/", threadRoutes(host));
+  app.route("/", folderRoutes(host));
   app.route("/", protocolRoutes(host));
   app.route("/", langGraphRoutes(host));
   app.route("/", triggerRoutes(host.triggers, host.triggerService));

--- a/apps/api-server/src/routes-folders.test.ts
+++ b/apps/api-server/src/routes-folders.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openAppDatabase } from "@pizza-bot/storage";
+import { folderRoutes } from "./routes-folders.js";
+
+const apps: ReturnType<typeof openAppDatabase>[] = [];
+const directories: string[] = [];
+
+function testApp() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "pizza-folder-routes-"));
+  directories.push(directory);
+  const appDb = openAppDatabase(path.join(directory, "app.sqlite"));
+  apps.push(appDb);
+  const host = {
+    folderStore: appDb.folders,
+  } as unknown as import("./agent-host.js").AgentHost;
+  return { routes: folderRoutes(host), appDb };
+}
+
+afterEach(() => {
+  for (const app of apps.splice(0)) app.close();
+  for (const directory of directories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("folderRoutes", () => {
+  it("creates, lists, renames, and deletes folders", async () => {
+    const { routes } = testApp();
+    const created = await routes.request("/folders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "  Projects  " }),
+    });
+    expect(created.status).toBe(201);
+    const folder = (await created.json()) as { folderId: string; name: string };
+    expect(folder.name).toBe("Projects");
+
+    expect(await (await routes.request("/folders")).json()).toEqual([
+      expect.objectContaining({ folderId: folder.folderId, name: "Projects" }),
+    ]);
+
+    const renamed = await routes.request(`/folders/${folder.folderId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Research" }),
+    });
+    expect(await renamed.json()).toEqual(
+      expect.objectContaining({ folderId: folder.folderId, name: "Research" }),
+    );
+
+    const deleted = await routes.request(`/folders/${folder.folderId}`, {
+      method: "DELETE",
+    });
+    expect(await deleted.json()).toEqual({ deleted: true });
+  });
+
+  it("rejects invalid and duplicate names", async () => {
+    const { routes } = testApp();
+    const blank = await routes.request("/folders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: " " }),
+    });
+    expect(blank.status).toBe(400);
+
+    await routes.request("/folders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Projects" }),
+    });
+    const duplicate = await routes.request("/folders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "projects" }),
+    });
+    expect(duplicate.status).toBe(409);
+  });
+
+  it("preserves threads as unfiled when deleting a folder", async () => {
+    const { routes, appDb } = testApp();
+    appDb.folders.create({ folderId: "folder-1", name: "Projects" });
+    appDb.threadStore.create({ threadId: "thread-1", folderId: "folder-1" });
+
+    await routes.request("/folders/folder-1", { method: "DELETE" });
+    expect(appDb.threadStore.get("thread-1")?.folderId).toBeUndefined();
+  });
+});

--- a/apps/api-server/src/routes-folders.ts
+++ b/apps/api-server/src/routes-folders.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from "node:crypto";
+import { Hono } from "hono";
+import type { AgentHost } from "./agent-host.js";
+
+const MAX_FOLDER_NAME_LENGTH = 80;
+
+export function folderRoutes(host: AgentHost): Hono {
+  const app = new Hono();
+
+  app.get("/folders", (c) => c.json(host.folderStore.list()));
+
+  app.post("/folders", async (c) => {
+    const body = (await c.req.json().catch(() => ({}))) as { name?: unknown };
+    const name = validName(body.name);
+    if (!name) {
+      return c.json(
+        { error: `name must contain 1-${MAX_FOLDER_NAME_LENGTH} characters` },
+        400,
+      );
+    }
+    try {
+      return c.json(host.folderStore.create({ folderId: randomUUID(), name }), 201);
+    } catch (error) {
+      if (isUniqueConstraint(error)) {
+        return c.json({ error: "a folder with that name already exists" }, 409);
+      }
+      throw error;
+    }
+  });
+
+  app.patch("/folders/:folder_id", async (c) => {
+    const folderId = c.req.param("folder_id");
+    const body = (await c.req.json().catch(() => ({}))) as {
+      name?: unknown;
+      sortOrder?: unknown;
+    };
+    const patch: { name?: string; sortOrder?: number } = {};
+    if ("name" in body) {
+      const name = validName(body.name);
+      if (!name) {
+        return c.json(
+          { error: `name must contain 1-${MAX_FOLDER_NAME_LENGTH} characters` },
+          400,
+        );
+      }
+      patch.name = name;
+    }
+    if ("sortOrder" in body) {
+      if (
+        typeof body.sortOrder !== "number" ||
+        !Number.isSafeInteger(body.sortOrder) ||
+        body.sortOrder < 0
+      ) {
+        return c.json({ error: "sortOrder must be a non-negative integer" }, 400);
+      }
+      patch.sortOrder = body.sortOrder;
+    }
+    try {
+      const folder = host.folderStore.update(folderId, patch);
+      if (!folder) return c.json({ error: "folder not found" }, 404);
+      return c.json(folder);
+    } catch (error) {
+      if (isUniqueConstraint(error)) {
+        return c.json({ error: "a folder with that name already exists" }, 409);
+      }
+      throw error;
+    }
+  });
+
+  app.delete("/folders/:folder_id", (c) =>
+    c.json({ deleted: host.folderStore.delete(c.req.param("folder_id")) }),
+  );
+
+  return app;
+}
+
+function validName(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const name = value.trim();
+  return name.length > 0 && name.length <= MAX_FOLDER_NAME_LENGTH ? name : undefined;
+}
+
+function isUniqueConstraint(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as Error & { code?: string }).code === "SQLITE_CONSTRAINT_UNIQUE"
+  );
+}

--- a/apps/api-server/src/routes-langgraph-folder.test.ts
+++ b/apps/api-server/src/routes-langgraph-folder.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentHost } from "./agent-host.js";
+import { langGraphRoutes } from "./routes-langgraph.js";
+
+describe("langGraphRoutes: folder metadata", () => {
+  it("persists a requested folder when creating a thread", async () => {
+    const ensure = vi.fn();
+    const host = {
+      folderStore: {
+        get: (folderId: string) =>
+          folderId === "projects" ? { folderId, name: "Projects" } : undefined,
+      },
+      threadStore: { ensure },
+    } as unknown as AgentHost;
+
+    const response = await langGraphRoutes(host).request("/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        thread_id: "thread-1",
+        metadata: { folder_id: "projects" },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      thread_id: "thread-1",
+      metadata: { folder_id: "projects" },
+    });
+    expect(ensure).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      folderId: "projects",
+    });
+  });
+
+  it("rejects an unknown folder without creating a thread", async () => {
+    const ensure = vi.fn();
+    const host = {
+      folderStore: { get: () => undefined },
+      threadStore: { ensure },
+    } as unknown as AgentHost;
+
+    const response = await langGraphRoutes(host).request("/threads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        thread_id: "thread-1",
+        metadata: { folder_id: "missing" },
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    expect(ensure).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api-server/src/routes-langgraph.ts
+++ b/apps/api-server/src/routes-langgraph.ts
@@ -9,10 +9,29 @@ export function langGraphRoutes(host: AgentHost): Hono {
   const app = new Hono();
 
   app.post("/threads", async (c) => {
-    const body = await c.req.json().catch(() => ({}));
-    const threadId = (body as { thread_id?: string }).thread_id ?? newThreadId();
+    const body = (await c.req.json().catch(() => ({}))) as {
+      thread_id?: string;
+      metadata?: { folder_id?: unknown };
+    };
+    const threadId = body.thread_id ?? newThreadId();
+    const folderId = body.metadata?.folder_id;
+    if (folderId !== undefined) {
+      if (typeof folderId !== "string") {
+        return c.json({ error: "metadata.folder_id must be a string" }, 400);
+      }
+      if (!host.folderStore.get(folderId)) {
+        return c.json({ error: "folder not found" }, 404);
+      }
+      host.threadStore.ensure({ threadId, folderId });
+    }
     const now = new Date().toISOString();
-    return c.json({ thread_id: threadId, status: "idle", metadata: {}, created_at: now, updated_at: now });
+    return c.json({
+      thread_id: threadId,
+      status: "idle",
+      metadata: folderId === undefined ? {} : { folder_id: folderId },
+      created_at: now,
+      updated_at: now,
+    });
   });
 
   app.post("/threads/:thread_id/state", async (c) => {

--- a/apps/api-server/src/routes-threads.test.ts
+++ b/apps/api-server/src/routes-threads.test.ts
@@ -111,11 +111,12 @@ afterEach(() => {
 function fakeHost(history: ForkMessage[], runningThreads: Set<string> = new Set()) {
   const app = openAppDatabase(tmpDb());
   openApps.push(app);
-  const { threadStore, search, threadActivity } = app;
+  const { threadStore, search, threadActivity, folders: folderStore } = app;
   let updated: { threadId: string; values: unknown } | undefined;
   const purgedCheckpoints: string[] = [];
   const host = {
     threadStore,
+    folderStore,
     search,
     threadActivity,
     persistence: {
@@ -170,6 +171,7 @@ describe("threadRoutes: fork", () => {
       threadId: "src",
       title: "Order",
       modelId: "bedrock:claude-sonnet-5",
+      folderId: "projects",
     });
 
     const res = await threadRoutes(host).request("/threads/src/fork", {
@@ -185,12 +187,14 @@ describe("threadRoutes: fork", () => {
       parentCheckpointId: string;
       title: string;
       modelId: string;
+      folderId: string;
     };
     expect(rec.source).toBe("fork");
     expect(rec.parentThreadId).toBe("src");
     expect(rec.parentCheckpointId).toBe("chk_src");
     expect(rec.title).toBe("Order (fork)");
     expect(rec.modelId).toBe("bedrock:claude-sonnet-5");
+    expect(rec.folderId).toBe("projects");
 
     const upd = getUpdated()!;
     expect(upd.threadId).toBe(rec.threadId);
@@ -478,6 +482,42 @@ describe("threadRoutes: patch (pin / rename)", () => {
     const rec = (await res.json()) as { threadId: string; unread: boolean };
     expect(rec).toMatchObject({ threadId: "t1", unread: false });
     expect(host.threadStore.get("t1")?.unread).toBe(false);
+  });
+
+  it("moves a thread into a folder and back to unfiled", async () => {
+    const { host } = fakeHost([]);
+    host.folderStore.create({ folderId: "projects", name: "Projects" });
+    host.threadStore.create({ threadId: "t1" });
+
+    const moved = await threadRoutes(host).request("/threads/t1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ folderId: "projects" }),
+    });
+    expect((await moved.json()) as { folderId?: string }).toMatchObject({
+      folderId: "projects",
+    });
+
+    const cleared = await threadRoutes(host).request("/threads/t1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ folderId: null }),
+    });
+    expect((await cleared.json()) as { folderId?: string }).not.toHaveProperty(
+      "folderId",
+    );
+  });
+
+  it("rejects moves into unknown folders", async () => {
+    const { host } = fakeHost([]);
+    host.threadStore.create({ threadId: "t1" });
+    const response = await threadRoutes(host).request("/threads/t1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ folderId: "missing" }),
+    });
+    expect(response.status).toBe(404);
+    expect(host.threadStore.get("t1")?.folderId).toBeUndefined();
   });
 });
 

--- a/apps/api-server/src/routes-threads.ts
+++ b/apps/api-server/src/routes-threads.ts
@@ -197,10 +197,12 @@ export function threadRoutes(host: AgentHost): Hono {
           const timer = setTimeout(done, 15_000);
           (timer as { unref?: () => void }).unref?.();
         });
-      const unsubscribe = host.threadStore.subscribe(() => {
+      const onChange = () => {
         changed = true;
         wake?.();
-      });
+      };
+      const unsubscribeThreads = host.threadStore.subscribe(onChange);
+      const unsubscribeFolders = host.folderStore.subscribe(onChange);
       const onAbort = () => wake?.();
       signal.addEventListener("abort", onAbort, { once: true });
 
@@ -222,7 +224,8 @@ export function threadRoutes(host: AgentHost): Hono {
         }
       } finally {
         signal.removeEventListener("abort", onAbort);
-        unsubscribe();
+        unsubscribeThreads();
+        unsubscribeFolders();
       }
     });
   });
@@ -242,15 +245,26 @@ export function threadRoutes(host: AgentHost): Hono {
       pinned?: boolean;
       title?: string;
       unread?: boolean;
+      folderId?: string | null;
     };
     const patch: {
       pinned?: boolean;
       title?: string;
       unread?: boolean;
+      folderId?: string | null;
     } = {};
     if (typeof body.pinned === "boolean") patch.pinned = body.pinned;
     if (typeof body.title === "string") patch.title = body.title;
     if (typeof body.unread === "boolean") patch.unread = body.unread;
+    if ("folderId" in body) {
+      if (body.folderId !== null && typeof body.folderId !== "string") {
+        return c.json({ error: "folderId must be a string or null" }, 400);
+      }
+      if (typeof body.folderId === "string" && !host.folderStore.get(body.folderId)) {
+        return c.json({ error: "folder not found" }, 404);
+      }
+      patch.folderId = body.folderId;
+    }
     const record = host.threadStore.update(c.req.param("thread_id"), patch);
     if (!record) return c.json({ error: "thread not found" }, 404);
     return c.json(record);
@@ -314,6 +328,7 @@ export function threadRoutes(host: AgentHost): Hono {
       parentThreadId: sourceThreadId,
       parentCheckpointId: state.checkpointId,
       ...(source?.modelId ? { modelId: source.modelId } : {}),
+      ...(source?.folderId ? { folderId: source.folderId } : {}),
     });
     // Make the fork searchable before its first run triggers normal maintenance.
     host.search.reindexThread(forkId, slice as import("@pizza-bot/storage").IndexableMessage[]);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -260,12 +260,20 @@ export function App() {
     }
   }, [view, features.enableAutomations, features.enableMemories]);
 
-  const onNewChat = useCallback(() => {
+  const onNewChat = useCallback(async (folderId?: string) => {
     shouldFocusComposerRef.current = true;
     setSearchTarget(null);
     setView("inbox");
-    openThread(freshThreadId(), false);
-  }, [openThread]);
+    const threadId = freshThreadId();
+    if (folderId) {
+      try {
+        await client.createThread(threadId, folderId);
+      } catch (error) {
+        console.error("create thread in folder failed", error);
+      }
+    }
+    openThread(threadId, false);
+  }, [client, openThread]);
 
   const onOpenSearchHit = useCallback(
     (hit: SearchHit) => {
@@ -326,7 +334,7 @@ export function App() {
     setView("settings");
   }, []);
   useHotkey("app.toggleRail", useCallback(() => setShowRail((v) => !v), []));
-  useHotkey("app.newChat", onNewChat);
+  useHotkey("app.newChat", useCallback(() => void onNewChat(), [onNewChat]));
   useHotkey("app.toggleHelp", useCallback(() => setHelpOpen((v) => !v), []));
   useHotkey("app.openSettings", openSettings);
   const onRename = useCallback(

--- a/apps/web/src/api-client.test.ts
+++ b/apps/web/src/api-client.test.ts
@@ -223,6 +223,68 @@ describe("ApiClient", () => {
     expect(captured.body).toEqual({ title: "A better title" });
   });
 
+  it("creates a thread in a folder through protocol metadata", async () => {
+    const captured: { url?: string; method?: string; body?: unknown } = {};
+    const client = new ApiClient({
+      baseUrl: "http://x",
+      fetch: (async (url: string, init?: RequestInit) => {
+        captured.url = url;
+        captured.method = init?.method;
+        captured.body = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(
+          JSON.stringify({
+            thread_id: "thread-1",
+            status: "idle",
+            metadata: { folder_id: "projects" },
+          }),
+          { status: 200 },
+        );
+      }) as unknown as typeof fetch,
+    });
+
+    await client.createThread("thread-1", "projects");
+    expect(captured).toMatchObject({
+      url: "http://x/threads",
+      method: "POST",
+      body: {
+        thread_id: "thread-1",
+        metadata: { folder_id: "projects" },
+      },
+    });
+  });
+
+  it("moves a thread back to Unfiled with an explicit null folder", async () => {
+    const captured: { url?: string; method?: string; body?: unknown } = {};
+    const client = new ApiClient({
+      baseUrl: "http://x",
+      fetch: (async (url: string, init?: RequestInit) => {
+        captured.url = url;
+        captured.method = init?.method;
+        captured.body = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(
+          JSON.stringify({
+            threadId: "thread-1",
+            title: "First",
+            source: "user",
+            pinned: false,
+            unread: false,
+            awaitingAction: false,
+            createdAt: "",
+            lastActivityAt: "",
+          }),
+          { status: 200 },
+        );
+      }) as unknown as typeof fetch,
+    });
+
+    await client.setThreadFolder("thread-1", null);
+    expect(captured).toMatchObject({
+      url: "http://x/threads/thread-1",
+      method: "PATCH",
+      body: { folderId: null },
+    });
+  });
+
   it("markThreadRead PATCHes unread:false and returns the updated ThreadInfo", async () => {
     const captured: { url?: string; method?: string | undefined; body?: unknown } = {};
     const client = new ApiClient({

--- a/apps/web/src/api-client.ts
+++ b/apps/web/src/api-client.ts
@@ -144,6 +144,42 @@ export class ApiClient {
     return this.json("list threads", "/threads/list");
   }
 
+  async createThread(threadId: string, folderId?: string): Promise<void> {
+    await this.send("create thread", "/threads", {
+      method: "POST",
+      body: {
+        thread_id: threadId,
+        ...(folderId ? { metadata: { folder_id: folderId } } : {}),
+      },
+    });
+  }
+
+  async listFolders(): Promise<FolderInfo[]> {
+    return this.json("list folders", "/folders");
+  }
+
+  async createFolder(name: string): Promise<FolderInfo> {
+    return this.json("create folder", "/folders", {
+      method: "POST",
+      body: { name },
+    });
+  }
+
+  async renameFolder(folderId: string, name: string): Promise<FolderInfo> {
+    return this.json("rename folder", `/folders/${encodeURIComponent(folderId)}`, {
+      method: "PATCH",
+      body: { name },
+    });
+  }
+
+  async deleteFolder(folderId: string): Promise<boolean> {
+    return deletedFlag(
+      await this.json("delete folder", `/folders/${encodeURIComponent(folderId)}`, {
+        method: "DELETE",
+      }),
+    );
+  }
+
   async watchThreadChanges(
     signal: AbortSignal,
     handlers: { onReady: () => void; onChange: () => void },
@@ -403,6 +439,13 @@ export class ApiClient {
     return this.json("rename thread", `/threads/${encodeURIComponent(threadId)}`, { method: "PATCH", body: { title } });
   }
 
+  async setThreadFolder(threadId: string, folderId: string | null): Promise<ThreadInfo> {
+    return this.json("move thread", `/threads/${encodeURIComponent(threadId)}`, {
+      method: "PATCH",
+      body: { folderId },
+    });
+  }
+
   async markThreadRead(threadId: string): Promise<ThreadInfo> {
     return this.json("mark thread read", `/threads/${encodeURIComponent(threadId)}`, {
       method: "PATCH",
@@ -622,6 +665,7 @@ export interface ThreadInfo {
   threadId: string;
   title: string;
   source: "user" | "trigger" | "fork";
+  folderId?: string;
   pinned: boolean;
   /**
    * Server-managed unread state is independent of client-only running state.
@@ -635,6 +679,13 @@ export interface ThreadInfo {
   modelId?: string;
   lastMessage?: string;
   lastMessageRole?: string;
+}
+
+export interface FolderInfo {
+  folderId: string;
+  name: string;
+  sortOrder: number;
+  createdAt: string;
 }
 
 export interface StatusInfo {

--- a/apps/web/src/components/FolderNameDialog.tsx
+++ b/apps/web/src/components/FolderNameDialog.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+
+export interface FolderNameDialogProps {
+  title: string;
+  confirmLabel: string;
+  initialName?: string;
+  busy?: boolean;
+  error?: string | null;
+  onCancel: () => void;
+  onConfirm: (name: string) => void;
+}
+
+export function FolderNameDialog({
+  title,
+  confirmLabel,
+  initialName = "",
+  busy = false,
+  error,
+  onCancel,
+  onConfirm,
+}: FolderNameDialogProps) {
+  const [name, setName] = useState(initialName);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.select();
+  }, []);
+
+  const submit = () => {
+    const trimmed = name.trim();
+    if (trimmed) onConfirm(trimmed);
+  };
+
+  return (
+    <DialogPrimitive.Root
+      open
+      onOpenChange={(open) => {
+        if (!open && !busy) onCancel();
+      }}
+    >
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="sidebar-modal-backdrop" />
+        <DialogPrimitive.Content className="sidebar-modal" aria-busy={busy}>
+          <DialogPrimitive.Title className="sidebar-modal-title">
+            {title}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Enter a folder name.
+          </DialogPrimitive.Description>
+          <input
+            ref={inputRef}
+            className="sidebar-modal-input"
+            value={name}
+            maxLength={80}
+            disabled={busy}
+            aria-label="Folder name"
+            onChange={(event) => setName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key !== "Enter" || event.nativeEvent.isComposing || busy) return;
+              event.preventDefault();
+              submit();
+            }}
+          />
+          {error && (
+            <div className="sidebar-modal-error" role="alert">
+              {error}
+            </div>
+          )}
+          <div className="sidebar-modal-actions">
+            <DialogPrimitive.Close asChild>
+              <button type="button" className="sidebar-modal-btn" disabled={busy}>
+                Cancel
+              </button>
+            </DialogPrimitive.Close>
+            <button
+              type="button"
+              className="sidebar-modal-btn primary"
+              disabled={busy || !name.trim()}
+              onClick={submit}
+            >
+              {busy ? `${confirmLabel}…` : confirmLabel}
+            </button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -9,8 +9,16 @@ import {
   Pin,
   PinOff,
   Trash2,
+  Folder,
+  FolderOpen,
+  FolderPlus,
+  FolderInput,
+  MoreHorizontal,
+  Pencil,
+  Check,
+  SlidersHorizontal,
 } from "lucide-react";
-import type { ApiClient, ThreadInfo, SearchHit } from "@/api-client";
+import type { ApiClient, FolderInfo, ThreadInfo, SearchHit } from "@/api-client";
 import { useKnownThreadIds, useRunningThreadIds } from "../use-thread-slice.js";
 import { datePeriod, PERIOD_ORDER, relativeTime, type DatePeriod } from "../lib/conversation.js";
 import { selectionAfterDelete } from "../lib/list-nav.js";
@@ -34,13 +42,22 @@ import { createConversationSearch } from "../conversation-search.js";
 import { ConfirmationDialog } from "./ConfirmationDialog.js";
 import { useAppToast } from "./AppToast.js";
 import { SwipeToDelete } from "./SwipeToDelete.js";
+import { FolderNameDialog } from "./FolderNameDialog.js";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu.js";
 
 export interface SidebarProps {
   client: ApiClient;
   openedThreads: ReadonlySet<string>;
   activeThreadId: string | null;
   onSelect: (threadId: string) => void;
-  onNewChat: () => void;
+  onNewChat: (folderId?: string) => void | Promise<void>;
   onOpenThread: (threadId: string) => void;
   onOpenSearchHit?: (hit: SearchHit) => void;
   onDeleted: (threadId: string) => void;
@@ -50,7 +67,11 @@ export interface SidebarProps {
   onFocusComposer?: () => void;
 }
 
-type Filter = "all" | "unread" | "action";
+type Filter = "all" | "unread" | "action" | "unfiled" | `folder:${string}`;
+
+type FolderEditor =
+  | { mode: "create" }
+  | { mode: "rename"; folder: FolderInfo };
 
 export function Sidebar({
   client,
@@ -70,14 +91,20 @@ export function Sidebar({
   const localKnown = useKnownThreadIds();
   const localRunning = useRunningThreadIds();
   const [threads, setThreads] = useState<ThreadInfo[]>([]);
+  const [folders, setFolders] = useState<FolderInfo[]>([]);
   const [query, setQuery] = useState("");
   const [hits, setHits] = useState<SearchHit[]>([]);
   const [searching, setSearching] = useState(false);
   const [filter, setFilter] = useState<Filter>("all");
+  const [foldersVisible, setFoldersVisible] = useState(true);
   const [collapsed, setCollapsed] = useState<Set<string>>(
     () => new Set<string>(["Last Week", "This Month", "Older"]),
   );
   const [confirmDelete, setConfirmDelete] = useState<ThreadInfo | null>(null);
+  const [folderEditor, setFolderEditor] = useState<FolderEditor | null>(null);
+  const [confirmFolderDelete, setConfirmFolderDelete] = useState<FolderInfo | null>(null);
+  const [folderBusy, setFolderBusy] = useState(false);
+  const [folderError, setFolderError] = useState<string | null>(null);
   const [swipedThreadId, setSwipedThreadId] = useState<string | null>(null);
   const threadListRef = useRef<HTMLDivElement | null>(null);
   const sidebarScrollRef = useRef<HTMLDivElement | null>(null);
@@ -91,7 +118,7 @@ export function Sidebar({
     [listRef],
   );
 
-  const refresh = useMemo(
+  const refreshThreads = useMemo(
     () =>
       createSidebarRefresh(client, {
         onThreads: (list) => {
@@ -101,6 +128,15 @@ export function Sidebar({
       }),
     [client, onThreadsLoaded],
   );
+
+  const refresh = useCallback(async () => {
+    const [threadList, folderList] = await Promise.all([
+      refreshThreads(),
+      client.listFolders(),
+    ]);
+    setFolders(folderList);
+    return threadList;
+  }, [client, refreshThreads]);
 
   const completionRefresh = useMemo(
     () =>
@@ -153,10 +189,76 @@ export function Sidebar({
     [client, notify, refresh],
   );
 
+  const onMoveThread = useCallback(
+    async (thread: ThreadInfo, folderId: string | null) => {
+      try {
+        const updated = await client.setThreadFolder(thread.threadId, folderId);
+        setThreads((current) =>
+          current.map((candidate) =>
+            candidate.threadId === updated.threadId ? updated : candidate,
+          ),
+        );
+      } catch (error) {
+        console.error("move thread failed", error);
+        notify({
+          title: "Could not move conversation",
+          description: error instanceof Error ? error.message : undefined,
+          tone: "error",
+        });
+      }
+    },
+    [client, notify],
+  );
+
+  const saveFolder = useCallback(
+    async (name: string) => {
+      const editor = folderEditor;
+      if (!editor) return;
+      setFolderBusy(true);
+      setFolderError(null);
+      try {
+        const folder =
+          editor.mode === "create"
+            ? await client.createFolder(name)
+            : await client.renameFolder(editor.folder.folderId, name);
+        setFolderEditor(null);
+        await refresh();
+        if (editor.mode === "create") setFilter(`folder:${folder.folderId}`);
+      } catch (error) {
+        setFolderError(error instanceof Error ? error.message : "Folder update failed");
+      } finally {
+        setFolderBusy(false);
+      }
+    },
+    [client, folderEditor, refresh],
+  );
+
+  const deleteFolder = useCallback(async () => {
+    const folder = confirmFolderDelete;
+    if (!folder) return;
+    setFolderBusy(true);
+    setFolderError(null);
+    try {
+      await client.deleteFolder(folder.folderId);
+      setConfirmFolderDelete(null);
+      if (filter === `folder:${folder.folderId}`) setFilter("unfiled");
+      await refresh();
+    } catch (error) {
+      setFolderError(error instanceof Error ? error.message : "Folder deletion failed");
+    } finally {
+      setFolderBusy(false);
+    }
+  }, [client, confirmFolderDelete, filter, refresh]);
+
   // The dialog layer keeps Enter and Escape from reaching list/global bindings.
   useLayer("sidebar-delete", {
-    active: !!confirmDelete,
-    onEscape: () => setConfirmDelete(null),
+    active: !!confirmDelete || !!folderEditor || !!confirmFolderDelete,
+    onEscape: () => {
+      setConfirmDelete(null);
+      setFolderEditor(null);
+      setConfirmFolderDelete(null);
+      setFolderError(null);
+    },
   });
 
   useEffect(() => {
@@ -229,11 +331,19 @@ export function Sidebar({
     [activeThreadId],
   );
 
+  const selectedFolderId = filter.startsWith("folder:")
+    ? filter.slice("folder:".length)
+    : undefined;
+
   const visibleRows =
     filter === "unread"
       ? rows.filter(isUnread)
       : filter === "action"
         ? rows.filter((t) => t.awaitingAction)
+        : filter === "unfiled"
+          ? rows.filter((t) => !t.folderId)
+          : selectedFolderId
+            ? rows.filter((t) => t.folderId === selectedFolderId)
         : rows;
 
   const unreadCount = useMemo(() => rows.filter(isUnread).length, [rows, isUnread]);
@@ -241,6 +351,23 @@ export function Sidebar({
     () => rows.filter((t) => t.awaitingAction).length,
     [rows],
   );
+  const folderCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const thread of rows) {
+      if (thread.folderId) {
+        counts.set(thread.folderId, (counts.get(thread.folderId) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }, [rows]);
+  const unfiledCount = useMemo(
+    () => rows.filter((thread) => !thread.folderId).length,
+    [rows],
+  );
+  const toggleFolders = useCallback(() => {
+    if (foldersVisible) setFilter("all");
+    setFoldersVisible((visible) => !visible);
+  }, [foldersVisible]);
 
   const groups = useMemo(() => {
     const pinned = visibleRows.filter((t) => t.pinned);
@@ -364,7 +491,10 @@ export function Sidebar({
   return (
     <div className="sidebar">
       <div className="sidebar-header">
-        <button className="new-chat" onClick={onNewChat}>
+        <button
+          className="new-chat"
+          onClick={() => void onNewChat(selectedFolderId)}
+        >
           <Plus size={16} /> New
         </button>
         <div className="sidebar-search-wrap">
@@ -413,7 +543,92 @@ export function Sidebar({
             {actionCount > 0 && <span className="segmented-count">{actionCount}</span>}
           </button>
         </div>
+        <button
+          className={`sidebar-filter-more${foldersVisible ? " active" : ""}`}
+          title={foldersVisible ? "Hide folder filters" : "Show folder filters"}
+          aria-label={foldersVisible ? "Hide folder filters" : "Show folder filters"}
+          aria-pressed={foldersVisible}
+          onClick={toggleFolders}
+        >
+          <SlidersHorizontal size={15} />
+        </button>
       </div>
+
+      {foldersVisible && (
+        <div className="sidebar-folders">
+          <div className="sidebar-folders-head">
+            <span>Folders</span>
+            <button
+              className="sidebar-folder-add"
+              aria-label="Create folder"
+              title="Create folder"
+              onClick={() => {
+                setFolderError(null);
+                setFolderEditor({ mode: "create" });
+              }}
+            >
+              <FolderPlus size={15} />
+            </button>
+          </div>
+          <div className="sidebar-folder-list">
+            <button
+              className={`sidebar-folder-row${filter === "unfiled" ? " active" : ""}`}
+              onClick={() => setFilter("unfiled")}
+            >
+              <FolderOpen size={15} />
+              <span className="sidebar-folder-name">Inbox</span>
+              <span className="sidebar-folder-count">{unfiledCount}</span>
+            </button>
+            {folders.map((folder) => (
+              <div
+                className={`sidebar-folder-row${filter === `folder:${folder.folderId}` ? " active" : ""}`}
+                key={folder.folderId}
+              >
+                <button
+                  className="sidebar-folder-select"
+                  onClick={() => setFilter(`folder:${folder.folderId}`)}
+                >
+                  <Folder size={15} />
+                  <span className="sidebar-folder-name">{folder.name}</span>
+                </button>
+                <span className="sidebar-folder-count">
+                  {folderCounts.get(folder.folderId) ?? 0}
+                </span>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      className="sidebar-folder-actions"
+                      aria-label={`Manage ${folder.name}`}
+                      title="Folder actions"
+                    >
+                      <MoreHorizontal size={15} />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="thread-folder-menu">
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        setFolderError(null);
+                        setFolderEditor({ mode: "rename", folder });
+                      }}
+                    >
+                      <Pencil /> Rename
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      variant="destructive"
+                      onSelect={() => {
+                        setFolderError(null);
+                        setConfirmFolderDelete(folder);
+                      }}
+                    >
+                      <Trash2 /> Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="sidebar-scroll" ref={sidebarScrollRef}>
         {searchActive ? (
@@ -524,6 +739,47 @@ export function Sidebar({
                                 )}
                                 {t.source === "fork" && <span className="thread-badge">⑂</span>}
                                 <span className="thread-actions">
+                                  <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                      <button
+                                        className="thread-action"
+                                        aria-label="Move conversation"
+                                        title="Move to folder"
+                                        onClick={(event) => event.stopPropagation()}
+                                      >
+                                        <FolderInput size={14} />
+                                      </button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent
+                                      align="end"
+                                      className="thread-folder-menu"
+                                      onClick={(event) => event.stopPropagation()}
+                                    >
+                                      <DropdownMenuLabel>Move to</DropdownMenuLabel>
+                                      <DropdownMenuItem
+                                        onSelect={() => void onMoveThread(t, null)}
+                                      >
+                                        {!t.folderId ? <Check /> : <FolderOpen />}
+                                        Inbox
+                                      </DropdownMenuItem>
+                                      {folders.length > 0 && <DropdownMenuSeparator />}
+                                      {folders.map((folder) => (
+                                        <DropdownMenuItem
+                                          key={folder.folderId}
+                                          onSelect={() =>
+                                            void onMoveThread(t, folder.folderId)
+                                          }
+                                        >
+                                          {t.folderId === folder.folderId ? (
+                                            <Check />
+                                          ) : (
+                                            <Folder />
+                                          )}
+                                          {folder.name}
+                                        </DropdownMenuItem>
+                                      ))}
+                                    </DropdownMenuContent>
+                                  </DropdownMenu>
                                   <button
                                     className={`thread-action${t.pinned ? " pinned" : ""}`}
                                     aria-label={t.pinned ? "Unpin conversation" : "Pin conversation"}
@@ -569,6 +825,37 @@ export function Sidebar({
           destructive
           onCancel={() => setConfirmDelete(null)}
           onConfirm={() => void onDeleteConfirm()}
+        />
+      )}
+      {folderEditor && (
+        <FolderNameDialog
+          title={folderEditor.mode === "create" ? "Create folder" : "Rename folder"}
+          confirmLabel={folderEditor.mode === "create" ? "Create" : "Rename"}
+          {...(folderEditor.mode === "rename"
+            ? { initialName: folderEditor.folder.name }
+            : {})}
+          busy={folderBusy}
+          error={folderError}
+          onCancel={() => {
+            setFolderEditor(null);
+            setFolderError(null);
+          }}
+          onConfirm={(name) => void saveFolder(name)}
+        />
+      )}
+      {confirmFolderDelete && (
+        <ConfirmationDialog
+          title="Delete folder?"
+          message={`Conversations in “${confirmFolderDelete.name}” will move to Inbox. No conversations will be deleted.`}
+          confirmLabel="Delete"
+          destructive
+          busy={folderBusy}
+          error={folderError}
+          onCancel={() => {
+            setConfirmFolderDelete(null);
+            setFolderError(null);
+          }}
+          onConfirm={() => void deleteFolder()}
         />
       )}
     </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -106,6 +106,81 @@ body {
   color: var(--brand);
 }
 
+.sidebar-filter-more {
+  width: 32px; height: 32px; flex: 0 0 32px; padding: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid var(--border); border-radius: 8px;
+  background: var(--panel-2); color: var(--dim); cursor: pointer;
+  transition: background .15s, border-color .15s, color .15s;
+}
+.sidebar-filter-more:hover {
+  background: var(--panel-3, var(--border)); color: var(--text);
+}
+.sidebar-filter-more.active {
+  border-color: color-mix(in oklch, var(--brand) 45%, var(--border));
+  background: color-mix(in oklch, var(--brand) 12%, var(--panel-2));
+  color: var(--brand);
+}
+
+.sidebar-folders {
+  flex: 0 1 auto; max-height: 190px; padding: 8px 8px 10px;
+  border-bottom: 1px solid var(--border); overflow-y: auto;
+}
+.sidebar-folders-head {
+  height: 28px; padding: 0 6px 0 10px;
+  display: flex; align-items: center; justify-content: space-between;
+  color: var(--dim); font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .04em;
+}
+.sidebar-folder-add,
+.sidebar-folder-actions {
+  width: 26px; height: 26px; padding: 0; border: 0; border-radius: 6px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: transparent; color: var(--dim); cursor: pointer;
+}
+.sidebar-folder-add:hover,
+.sidebar-folder-actions:hover { background: var(--panel-2); color: var(--text); }
+.sidebar-folder-list { display: flex; flex-direction: column; gap: 2px; }
+.sidebar-folder-row {
+  position: relative;
+  width: 100%; min-width: 0; height: 32px; padding: 0 8px 0 10px;
+  display: flex; align-items: center; gap: 8px;
+  border: 0; border-radius: 7px;
+  background: transparent; color: var(--dim);
+  font: inherit; font-size: 13px; text-align: left; cursor: pointer;
+}
+button.sidebar-folder-row:hover,
+.sidebar-folder-row:has(.sidebar-folder-select:hover) {
+  background: var(--panel-2); color: var(--text);
+}
+.sidebar-folder-row.active {
+  background: color-mix(in oklch, var(--brand) 12%, transparent);
+  color: var(--text);
+}
+.sidebar-folder-select {
+  flex: 1; min-width: 0; height: 100%; padding: 0;
+  display: flex; align-items: center; gap: 8px;
+  border: 0; background: transparent; color: inherit;
+  font: inherit; text-align: left; cursor: pointer;
+}
+.sidebar-folder-name {
+  flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.sidebar-folder-count {
+  flex: 0 0 24px; width: 24px; color: var(--dim);
+  font-size: 11px; text-align: right;
+}
+.sidebar-folder-actions {
+  position: absolute; right: 5px; flex: 0 0 auto;
+  opacity: 0; background: var(--panel-2);
+}
+.sidebar-folder-row:hover .sidebar-folder-actions,
+.sidebar-folder-actions:focus { opacity: 1; }
+.sidebar-folder-row:has(.sidebar-folder-actions):hover .sidebar-folder-count,
+.sidebar-folder-row:has(.sidebar-folder-actions:focus) .sidebar-folder-count {
+  opacity: 0;
+}
+
 .thread-action-pill {
   flex: 0 0 auto; align-self: center;
   padding: 2px 8px; border-radius: 999px;
@@ -210,6 +285,12 @@ body {
 .thread-action:hover { background: var(--panel-3, var(--border)); color: var(--text); }
 .thread-action.pinned { color: var(--brand); }
 .thread-action.danger:hover { color: var(--danger, #e5484d); }
+.thread-folder-menu {
+  min-width: 180px; padding: 4px;
+  border: 1px solid var(--border);
+  background: var(--panel); color: var(--text);
+  box-shadow: 0 8px 24px color-mix(in srgb, #000 30%, transparent);
+}
 
 .sidebar-modal-backdrop {
   position: fixed; inset: 0; z-index: 50;
@@ -229,6 +310,12 @@ body {
 .sidebar-modal-error {
   margin-top: 12px; color: var(--danger, #e5484d); font-size: 12.5px; line-height: 1.4;
 }
+.sidebar-modal-input {
+  width: 100%; height: 38px; margin-top: 8px; padding: 0 10px;
+  border: 1px solid var(--border); border-radius: 7px;
+  background: var(--panel-2); color: var(--text); font: inherit;
+}
+.sidebar-modal-input:focus { outline: none; border-color: var(--brand); }
 .sidebar-modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 18px; }
 .sidebar-modal-btn {
   padding: 7px 14px; border: 1px solid var(--border); border-radius: 8px;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -218,9 +218,9 @@ Two systems, injected as `RuntimeDeps` (`packages/storage`):
 - **Store** — `SqliteStore extends BaseStore` → `store.sqlite` (cross-thread
   long-term memory; durable analog to the in-memory store).
 
-Everything the platform itself owns — thread metadata, triggers, terminal run
-activity, capability enablement preferences, the FTS message index, and
-attachment metadata — lives in one
+Everything the platform itself owns — thread metadata, user-defined thread
+folders, triggers, terminal run activity, capability enablement preferences, the
+FTS message index, and attachment metadata — lives in one
 `app.sqlite`, opened once via `openAppDatabase()`: a **single**
 `better-sqlite3` handle (one WAL lock) shared by the stores, rather than one
 handle per store on the same file. The data-root layout
@@ -298,8 +298,8 @@ ready/heartbeat/changed stream that refreshes the inbox, plus
 outcomes used by desktop notifications. This is not the LangGraph Agent Server
 API: assistants, standard runs, stores, and crons are absent, and standard
 Agent Server clients are not a compatibility target. Platform routes provide
-list/search/fork/PATCH/DELETE behavior, and `GET /ping` is the desktop-sidecar
-health probe.
+thread list/search/fork/PATCH/DELETE behavior plus folder CRUD, and `GET /ping`
+is the desktop-sidecar health probe.
 
 **`ProtocolRunManager`** (`protocol-run-manager.ts`) is the in-process run
 registry: it tracks the current run for each thread, assigns each generation a
@@ -422,6 +422,12 @@ map to AI Elements' `Confirmation` and `Reasoning`; source parts render as
 linked source annotations. The
 Activity panel renders observed subagent delegations and transcript drill-downs,
 not model-maintained progress state.
+
+The inbox sidebar treats `All`, `Unread`, and `Action` as global smart views.
+User folders are an orthogonal, single-folder organization layer over thread
+metadata; deleting a folder moves its threads to `Inbox`. The filter control
+shows or hides the folder panel and resets the active view to `All` when hidden,
+so a folder scope is never applied without a visible explanation.
 
 **Concurrent streams, only while active.** Several threads can stream at once, but
 an idle thread holds no live connection. Each thread's `StreamController` lives in

--- a/packages/storage/src/app-db.ts
+++ b/packages/storage/src/app-db.ts
@@ -10,12 +10,14 @@ import { AttachmentStore } from "./attachments.js";
 import { ThreadActivityStore } from "./thread-activity.js";
 import { CapabilityPreferencesStore } from "./capability-preferences.js";
 import { ensurePrivateDirectory, ensurePrivateFile } from "./private-files.js";
+import { FolderStore } from "./folders.js";
 
 /** `close()` is the sole owner of the shared handle's lifecycle. */
 export interface AppDatabase {
   db: Database.Database;
   triggers: TriggerStore;
   threadStore: ThreadStore;
+  folders: FolderStore;
   search: SearchStore;
   settings: SettingsStore;
   providerConfigs: ProviderConfigStore;
@@ -38,8 +40,10 @@ export function openAppDatabase(dbPath: string, attachmentsDir?: string): AppDat
   if (!isMemory) ensurePrivateFile(dbPath);
   // Configure WAL once on the shared handle.
   db.pragma("journal_mode = WAL");
+  const folders = new FolderStore(db);
   return {
     db,
+    folders,
     triggers: new TriggerStore(db),
     threadStore: new ThreadStore(db),
     search: new SearchStore(db),

--- a/packages/storage/src/folders.test.ts
+++ b/packages/storage/src/folders.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openAppDatabase } from "./app-db.js";
+
+const apps: ReturnType<typeof openAppDatabase>[] = [];
+const directories: string[] = [];
+
+function openApp() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "pizza-folders-"));
+  directories.push(directory);
+  const app = openAppDatabase(path.join(directory, "app.sqlite"));
+  apps.push(app);
+  return app;
+}
+
+afterEach(() => {
+  for (const app of apps.splice(0)) app.close();
+  for (const directory of directories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("FolderStore", () => {
+  it("creates, orders, renames, and publishes folder changes", () => {
+    const app = openApp();
+    let changes = 0;
+    const unsubscribe = app.folders.subscribe(() => changes++);
+
+    app.folders.create({ folderId: "later", name: "Later", sortOrder: 2 });
+    app.folders.create({ folderId: "first", name: "First", sortOrder: 1 });
+    expect(app.folders.list().map((folder) => folder.folderId)).toEqual([
+      "first",
+      "later",
+    ]);
+    expect(app.folders.update("later", { name: "Projects" })?.name).toBe("Projects");
+    expect(app.folders.update("missing", { name: "Missing" })).toBeUndefined();
+    expect(changes).toBe(3);
+
+    unsubscribe();
+  });
+
+  it("keeps folder names unique without regard to case", () => {
+    const app = openApp();
+    app.folders.create({ folderId: "one", name: "Projects" });
+    expect(() =>
+      app.folders.create({ folderId: "two", name: "projects" }),
+    ).toThrow();
+  });
+
+  it("moves threads to unfiled when their folder is deleted", () => {
+    const app = openApp();
+    app.folders.create({ folderId: "projects", name: "Projects" });
+    app.threadStore.create({ threadId: "thread-1", folderId: "projects" });
+
+    expect(app.folders.delete("projects")).toBe(true);
+    expect(app.threadStore.get("thread-1")?.folderId).toBeUndefined();
+    expect(app.folders.delete("projects")).toBe(false);
+  });
+});

--- a/packages/storage/src/folders.ts
+++ b/packages/storage/src/folders.ts
@@ -1,0 +1,135 @@
+/** Durable user-defined folders for organizing thread metadata. */
+import Database from "better-sqlite3";
+
+export interface FolderRecord {
+  folderId: string;
+  name: string;
+  sortOrder: number;
+  createdAt: string;
+}
+
+interface FolderRow {
+  folder_id: string;
+  name: string;
+  sort_order: number;
+  created_at: string;
+}
+
+export interface NewFolderInput {
+  folderId: string;
+  name: string;
+  sortOrder?: number;
+  createdAt?: string;
+}
+
+export type FolderPatch = Partial<Pick<FolderRecord, "name" | "sortOrder">>;
+
+export class FolderStore {
+  private readonly listeners = new Set<() => void>();
+
+  constructor(private readonly db: Database.Database) {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS folders (
+        folder_id  TEXT PRIMARY KEY,
+        name       TEXT NOT NULL COLLATE NOCASE UNIQUE,
+        sort_order INTEGER NOT NULL,
+        created_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_folders_sort
+        ON folders (sort_order, name);
+    `);
+  }
+
+  list(): FolderRecord[] {
+    return this.db
+      .prepare<[], FolderRow>("SELECT * FROM folders ORDER BY sort_order, name COLLATE NOCASE")
+      .all()
+      .map(toFolder);
+  }
+
+  get(folderId: string): FolderRecord | undefined {
+    const row = this.db
+      .prepare<[string], FolderRow>("SELECT * FROM folders WHERE folder_id = ?")
+      .get(folderId);
+    return row ? toFolder(row) : undefined;
+  }
+
+  create(input: NewFolderInput): FolderRecord {
+    const sortOrder =
+      input.sortOrder ??
+      (
+        this.db
+          .prepare<[], { next: number }>(
+            "SELECT COALESCE(MAX(sort_order), -1) + 1 AS next FROM folders",
+          )
+          .get()?.next ?? 0
+      );
+    const record: FolderRecord = {
+      folderId: input.folderId,
+      name: input.name,
+      sortOrder,
+      createdAt: input.createdAt ?? new Date().toISOString(),
+    };
+    this.db
+      .prepare(
+        `INSERT INTO folders (folder_id, name, sort_order, created_at)
+         VALUES (@folder_id, @name, @sort_order, @created_at)`,
+      )
+      .run(toRow(record));
+    this.emit();
+    return record;
+  }
+
+  update(folderId: string, patch: FolderPatch): FolderRecord | undefined {
+    const current = this.get(folderId);
+    if (!current) return undefined;
+    const updated = { ...current, ...patch, folderId, createdAt: current.createdAt };
+    this.db
+      .prepare(
+        `UPDATE folders
+         SET name = @name, sort_order = @sort_order
+         WHERE folder_id = @folder_id`,
+      )
+      .run(toRow(updated));
+    this.emit();
+    return updated;
+  }
+
+  /** Deleting a folder preserves its threads as unfiled. */
+  delete(folderId: string): boolean {
+    const remove = this.db.transaction(() => {
+      this.db.prepare("UPDATE threads SET folder_id = NULL WHERE folder_id = ?").run(folderId);
+      return this.db.prepare("DELETE FROM folders WHERE folder_id = ?").run(folderId).changes > 0;
+    });
+    const deleted = remove();
+    if (deleted) this.emit();
+    return deleted;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) listener();
+  }
+}
+
+function toFolder(row: FolderRow): FolderRecord {
+  return {
+    folderId: row.folder_id,
+    name: row.name,
+    sortOrder: row.sort_order,
+    createdAt: row.created_at,
+  };
+}
+
+function toRow(record: FolderRecord): FolderRow {
+  return {
+    folder_id: record.folderId,
+    name: record.name,
+    sort_order: record.sortOrder,
+    created_at: record.createdAt,
+  };
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -3,6 +3,7 @@ export * from "./persistence.js";
 export * from "./sqlite-store.js";
 export * from "./triggers.js";
 export * from "./threads.js";
+export * from "./folders.js";
 export * from "./attachments.js";
 export * from "./search.js";
 export * from "./settings.js";

--- a/packages/storage/src/threads.test.ts
+++ b/packages/storage/src/threads.test.ts
@@ -54,6 +54,14 @@ describe("ThreadStore: CRUD", () => {
     s.close();
   });
 
+  it("round-trips and clears folder membership", () => {
+    const s = openThreadStore(tmpDb());
+    s.create({ threadId: "th1", folderId: "projects" });
+    expect(s.get("th1")?.folderId).toBe("projects");
+    expect(s.update("th1", { folderId: "research" })?.folderId).toBe("research");
+    expect(s.update("th1", { folderId: null })?.folderId).toBeUndefined();
+  });
+
   it("ensure() is idempotent — creates once, returns existing after", () => {
     const s = openThreadStore(tmpDb());
     const a = s.ensure({ threadId: "th1", title: "first" });
@@ -169,5 +177,37 @@ describe("ThreadStore: CRUD", () => {
     const t = s2.get("th1");
     expect(t?.title).toBe("persisted");
     expect(t?.parentThreadId).toBe("p");
+  });
+
+  it("adds folder membership to databases created before folders existed", () => {
+    const file = tmpDb();
+    const db = new Database(file);
+    db.exec(`
+      CREATE TABLE threads (
+        thread_id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        parent_thread_id TEXT,
+        parent_checkpoint_id TEXT,
+        source TEXT NOT NULL DEFAULT 'user',
+        pinned INTEGER NOT NULL DEFAULT 0,
+        unread INTEGER NOT NULL DEFAULT 0,
+        awaiting_action INTEGER NOT NULL DEFAULT 0,
+        model_id TEXT,
+        created_at TEXT NOT NULL,
+        last_activity_at TEXT NOT NULL,
+        last_message TEXT,
+        last_message_role TEXT
+      );
+      INSERT INTO threads (
+        thread_id, title, source, created_at, last_activity_at
+      ) VALUES (
+        'legacy', 'Existing conversation', 'user', '2026-01-01', '2026-01-01'
+      );
+    `);
+    db.close();
+
+    const store = openThreadStore(file);
+    expect(store.get("legacy")?.title).toBe("Existing conversation");
+    expect(store.update("legacy", { folderId: "projects" })?.folderId).toBe("projects");
   });
 });

--- a/packages/storage/src/threads.ts
+++ b/packages/storage/src/threads.ts
@@ -7,6 +7,7 @@ export interface ThreadRecord {
   threadId: string;
   title: string;
   source: ThreadSource;
+  folderId?: string;
   pinned: boolean;
   /** Indicates completed activity that the user has not viewed. */
   unread: boolean;
@@ -26,6 +27,7 @@ export interface ThreadRecord {
 interface ThreadRow {
   thread_id: string;
   title: string;
+  folder_id: string | null;
   parent_thread_id: string | null;
   parent_checkpoint_id: string | null;
   source: string;
@@ -43,6 +45,7 @@ export interface NewThreadInput {
   threadId: string;
   title?: string;
   source?: ThreadSource;
+  folderId?: string;
   pinned?: boolean;
   parentThreadId?: string;
   parentCheckpointId?: string;
@@ -64,7 +67,9 @@ export type ThreadPatch = Partial<
     | "lastMessage"
     | "lastMessageRole"
   >
->;
+> & {
+  folderId?: string | null;
+};
 
 export class ThreadStore {
   private readonly db: Database.Database;
@@ -76,6 +81,7 @@ export class ThreadStore {
       CREATE TABLE IF NOT EXISTS threads (
         thread_id            TEXT PRIMARY KEY,
         title                TEXT NOT NULL,
+        folder_id            TEXT,
         parent_thread_id     TEXT,
         parent_checkpoint_id TEXT,
         source               TEXT NOT NULL DEFAULT 'user',
@@ -92,6 +98,13 @@ export class ThreadStore {
         ON threads (pinned DESC, last_activity_at DESC);
       CREATE INDEX IF NOT EXISTS idx_threads_source  ON threads (source);
     `);
+    const columns = this.db
+      .prepare<[], { name: string }>("PRAGMA table_info(threads)")
+      .all();
+    if (!columns.some((column) => column.name === "folder_id")) {
+      this.db.exec("ALTER TABLE threads ADD COLUMN folder_id TEXT");
+    }
+    this.db.exec("CREATE INDEX IF NOT EXISTS idx_threads_folder ON threads (folder_id)");
   }
 
   /** The shared database handle is owned by `openAppDatabase`. */
@@ -103,6 +116,7 @@ export class ThreadStore {
       threadId: input.threadId,
       title: input.title ?? "New conversation",
       source: input.source ?? "user",
+      ...(input.folderId !== undefined ? { folderId: input.folderId } : {}),
       pinned: input.pinned ?? false,
       unread: false,
       awaitingAction: false,
@@ -117,11 +131,11 @@ export class ThreadStore {
     this.db
       .prepare(
         `INSERT INTO threads
-           (thread_id, title, parent_thread_id, parent_checkpoint_id, source, pinned, unread,
+           (thread_id, title, folder_id, parent_thread_id, parent_checkpoint_id, source, pinned, unread,
             awaiting_action, model_id, created_at, last_activity_at, last_message,
             last_message_role)
          VALUES
-           (@thread_id, @title, @parent_thread_id, @parent_checkpoint_id, @source, @pinned, @unread,
+           (@thread_id, @title, @folder_id, @parent_thread_id, @parent_checkpoint_id, @source, @pinned, @unread,
             @awaiting_action, @model_id, @created_at, @last_activity_at, @last_message,
             @last_message_role)`,
       )
@@ -154,17 +168,20 @@ export class ThreadStore {
   update(threadId: string, patch: ThreadPatch): ThreadRecord | undefined {
     const current = this.get(threadId);
     if (!current) return undefined;
+    const { folderId, ...rest } = patch;
     const merged: ThreadRecord = {
       ...current,
-      ...patch,
+      ...rest,
       threadId,
       createdAt: current.createdAt,
       lastActivityAt: current.lastActivityAt,
+      ...(folderId ? { folderId } : {}),
     };
+    if ("folderId" in patch && folderId === null) delete merged.folderId;
     this.db
       .prepare(
         `UPDATE threads SET
-           title = @title, parent_thread_id = @parent_thread_id,
+           title = @title, folder_id = @folder_id, parent_thread_id = @parent_thread_id,
            parent_checkpoint_id = @parent_checkpoint_id, source = @source,
            pinned = @pinned, unread = @unread, awaiting_action = @awaiting_action,
            model_id = @model_id,
@@ -216,6 +233,7 @@ function toThread(row: ThreadRow): ThreadRecord {
     createdAt: row.created_at,
     lastActivityAt: row.last_activity_at,
   };
+  if (row.folder_id !== null) rec.folderId = row.folder_id;
   if (row.parent_thread_id !== null) rec.parentThreadId = row.parent_thread_id;
   if (row.parent_checkpoint_id !== null) rec.parentCheckpointId = row.parent_checkpoint_id;
   if (row.model_id !== null) rec.modelId = row.model_id;
@@ -228,6 +246,7 @@ function toRow(rec: ThreadRecord): ThreadRow {
   return {
     thread_id: rec.threadId,
     title: rec.title,
+    folder_id: rec.folderId ?? null,
     parent_thread_id: rec.parentThreadId ?? null,
     parent_checkpoint_id: rec.parentCheckpointId ?? null,
     source: rec.source,


### PR DESCRIPTION
## Summary
- add persistent conversation folders with create, rename, delete, and move operations
- add an Inbox folder view plus a filter toggle beside Action that resets to All when hidden
- preserve folder placement for new conversations and forks, with global Unread and Action queues
- add storage, API, and web client coverage and document the behavior

## Verification
- npm run build
- npm run typecheck
- npm run lint
- npm test
- manual desktop verification

Closes #35