### PR TITLE
Improve HITL tool argument editing

### DIFF
--- a/apps/web/src/components/ApprovalArguments.test.tsx
+++ b/apps/web/src/components/ApprovalArguments.test.tsx
@@ -1,0 +1,171 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  ApprovalArgumentEditor,
+  ApprovalArguments,
+  formatArgumentLabel,
+  parseArgumentDraft,
+  updateArgumentAtPath,
+} from "./ApprovalArguments.js";
+
+describe("ApprovalArguments", () => {
+  it("presents argument names and values without serialized JSON", () => {
+    const html = renderToStaticMarkup(
+      <ApprovalArguments
+        value={{
+          recipient_email: "avery@example.com",
+          sendCopy: true,
+          details: { message: "A long value that should wrap naturally." },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Recipient email");
+    expect(html).toContain("Send copy");
+    expect(html).toContain("avery@example.com");
+    expect(html).toContain(">Yes<");
+    expect(html).not.toContain(">Boolean<");
+    expect(html).not.toContain("&quot;recipient_email&quot;");
+  });
+
+  it("keeps empty and scalar values distinguishable in the approval summary", () => {
+    const html = renderToStaticMarkup(
+      <ApprovalArguments
+        value={{
+          empty: "",
+          numericText: "2",
+          numericValue: 2,
+          missing: null,
+          tags: [],
+        }}
+      />,
+    );
+
+    expect(html).toContain("Empty text");
+    expect(html).toContain(">Text<");
+    expect(html).toContain(">Null<");
+    expect(html).toContain(">None<");
+    expect(html).not.toContain(">Number<");
+  });
+
+  it("renders top-level primitive and array values", () => {
+    const primitive = renderToStaticMarkup(<ApprovalArguments value="ready" />);
+    const array = renderToStaticMarkup(<ApprovalArguments value={["one", 2]} />);
+
+    expect(primitive).toContain(">ready<");
+    expect(primitive).not.toContain(">Text<");
+    expect(array).toContain(">one<");
+    expect(array).not.toContain(">Number<");
+  });
+
+  it("renders a field-first editor with JSON available as a secondary view", () => {
+    const html = renderToStaticMarkup(
+      <ApprovalArgumentEditor
+        value={{ subject: "Hello", retries: 2 }}
+        rawDraft={'{\n  "subject": "Hello",\n  "retries": 2\n}'}
+        rawError={null}
+        onChange={() => undefined}
+        onRawChange={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('role="group"');
+    expect(html).toContain('aria-pressed="true"');
+    expect(html).toContain(">Fields<");
+    expect(html).toContain(">JSON<");
+    expect(html).toContain(">Hello</textarea>");
+    expect(html).not.toContain("approval-json-editor");
+  });
+
+  it("falls back to JSON for an empty argument object", () => {
+    const html = renderToStaticMarkup(
+      <ApprovalArgumentEditor
+        value={{}}
+        rawDraft="{}"
+        rawError={null}
+        onChange={() => undefined}
+        onRawChange={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("approval-json-editor");
+    expect(html).not.toContain(">Fields<");
+    expect(html).not.toContain('role="group"');
+  });
+
+  it("keeps an invalid Fields control focusable and associates its error", () => {
+    const html = renderToStaticMarkup(
+      <ApprovalArgumentEditor
+        value={{ retries: 2 }}
+        rawDraft='{ "retries":'
+        rawError="Unexpected end of JSON input"
+        onChange={() => undefined}
+        onRawChange={() => undefined}
+      />,
+    );
+
+    const fieldsButton = html.match(/<button[^>]*>Fields<\/button>/)?.[0];
+    expect(fieldsButton).toBeDefined();
+    expect(html).toContain('aria-disabled="true"');
+    expect(html).toContain("aria-describedby=");
+    expect(fieldsButton).not.toMatch(/\sdisabled=/);
+    expect(html).toContain("Unexpected end of JSON input");
+  });
+
+  it("offers typed values for a null argument", () => {
+    const html = renderToStaticMarkup(
+      <ApprovalArgumentEditor
+        value={{ note: null }}
+        rawDraft='{ "note": null }'
+        rawError={null}
+        onChange={() => undefined}
+        onRawChange={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('<option value="null" selected="">Not set</option>');
+    expect(html).toContain('<option value="string">Text</option>');
+    expect(html).toContain('<option value="number">Number</option>');
+    expect(html).toContain('<option value="boolean">Yes / no</option>');
+  });
+});
+
+describe("argument editing helpers", () => {
+  it("formats machine-oriented keys as readable field labels", () => {
+    expect(formatArgumentLabel("delivery_address")).toBe("Delivery address");
+    expect(formatArgumentLabel("sendCopy")).toBe("Send copy");
+    expect(formatArgumentLabel("aws_outlook_mcp_email_send")).toBe(
+      "AWS outlook MCP email send",
+    );
+  });
+
+  it("updates a nested value without mutating the original arguments", () => {
+    const original = {
+      message: { recipients: [{ email: "old@example.com" }] },
+      urgent: false,
+    };
+
+    const updated = updateArgumentAtPath(
+      original,
+      ["message", "recipients", 0, "email"],
+      "new@example.com",
+    );
+
+    expect(updated).toEqual({
+      message: { recipients: [{ email: "new@example.com" }] },
+      urgent: false,
+    });
+    expect(original.message.recipients[0]!.email).toBe("old@example.com");
+  });
+
+  it("parses valid drafts and reports invalid drafts", () => {
+    expect(parseArgumentDraft('{ "retries": 2 }')).toEqual({
+      ok: true,
+      value: { retries: 2 },
+      error: null,
+    });
+    expect(parseArgumentDraft('{ "retries":')).toMatchObject({
+      ok: false,
+    });
+  });
+});

--- a/apps/web/src/components/ApprovalArguments.tsx
+++ b/apps/web/src/components/ApprovalArguments.tsx
@@ -1,0 +1,527 @@
+import { useEffect, useId, useRef, useState } from "react";
+
+type JsonPath = Array<string | number>;
+
+interface ApprovalArgumentsProps {
+  value: unknown;
+}
+
+interface ApprovalArgumentEditorProps {
+  value: unknown;
+  rawDraft: string;
+  rawError: string | null;
+  onChange: (value: unknown) => void;
+  onRawChange: (value: string) => void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isStructured(value: unknown): value is Record<string, unknown> | unknown[] {
+  return isRecord(value) || Array.isArray(value);
+}
+
+const LABEL_ACRONYMS = new Set([
+  "api",
+  "arn",
+  "aws",
+  "html",
+  "http",
+  "https",
+  "id",
+  "json",
+  "mcp",
+  "sql",
+  "uri",
+  "url",
+]);
+
+export function formatArgumentLabel(key: string): string {
+  const tokens = key
+    .replace(/[_-]+/g, " ")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((token) => {
+      const lower = token.toLowerCase();
+      return LABEL_ACRONYMS.has(lower) ? lower.toUpperCase() : lower;
+    });
+  if (tokens.length === 0) return key;
+  if (!LABEL_ACRONYMS.has(tokens[0]!.toLowerCase())) {
+    tokens[0] = tokens[0]!.charAt(0).toUpperCase() + tokens[0]!.slice(1);
+  }
+  return tokens.join(" ");
+}
+
+export function updateArgumentAtPath(value: unknown, path: JsonPath, next: unknown): unknown {
+  if (path.length === 0) return next;
+
+  const [head, ...tail] = path;
+  if (Array.isArray(value) && typeof head === "number") {
+    const copy = [...value];
+    copy[head] = updateArgumentAtPath(copy[head], tail, next);
+    return copy;
+  }
+  if (isRecord(value) && typeof head === "string") {
+    return {
+      ...value,
+      [head]: updateArgumentAtPath(value[head], tail, next),
+    };
+  }
+  return value;
+}
+
+export type ParsedArgumentDraft =
+  | { ok: true; value: unknown; error: null }
+  | { ok: false; error: string };
+
+export function parseArgumentDraft(draft: string): ParsedArgumentDraft {
+  try {
+    return { ok: true, value: JSON.parse(draft), error: null };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Invalid JSON",
+    };
+  }
+}
+
+function ScalarValue({
+  children,
+  type,
+  empty = false,
+  showType = false,
+}: {
+  children: string;
+  type: "Boolean" | "Null" | "Number" | "Text";
+  empty?: boolean;
+  showType?: boolean;
+}) {
+  return (
+    <span className="approval-argument-scalar">
+      <span className={empty ? "approval-argument-empty" : "approval-argument-value"}>
+        {children}
+      </span>
+      {showType && <span className="approval-argument-type">{type}</span>}
+    </span>
+  );
+}
+
+function isAmbiguousText(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized !== "" &&
+    (Number.isFinite(Number(normalized)) ||
+      normalized === "true" ||
+      normalized === "false" ||
+      normalized === "null")
+  );
+}
+
+function PrimitiveValue({ value }: { value: unknown }) {
+  if (value === null) {
+    return <ScalarValue type="Null" empty showType>Not set</ScalarValue>;
+  }
+  if (typeof value === "boolean") {
+    return <ScalarValue type="Boolean">{value ? "Yes" : "No"}</ScalarValue>;
+  }
+  if (typeof value === "number") {
+    return <ScalarValue type="Number">{String(value)}</ScalarValue>;
+  }
+  if (typeof value === "string") {
+    return value === "" ? (
+      <ScalarValue type="Text" empty showType>
+        Empty text
+      </ScalarValue>
+    ) : (
+      <ScalarValue type="Text" showType={isAmbiguousText(value)}>{value}</ScalarValue>
+    );
+  }
+  return <span className="approval-argument-value">{String(value)}</span>;
+}
+
+function ArgumentValue({ value }: { value: unknown }) {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <span className="approval-argument-empty">None</span>;
+    return (
+      <ol className="approval-argument-list">
+        {value.map((item, index) => (
+          <li key={index}>
+            <span className="approval-argument-index">{index + 1}</span>
+            <ArgumentValue value={item} />
+          </li>
+        ))}
+      </ol>
+    );
+  }
+
+  if (isRecord(value)) {
+    if (Object.keys(value).length === 0) {
+      return <span className="approval-argument-empty">None</span>;
+    }
+    return (
+      <dl className="approval-argument-nested">
+        {Object.entries(value).map(([key, item]) => (
+          <div key={key}>
+            <dt title={key}>{formatArgumentLabel(key)}</dt>
+            <dd>
+              <ArgumentValue value={item} />
+            </dd>
+          </div>
+        ))}
+      </dl>
+    );
+  }
+
+  return <PrimitiveValue value={value} />;
+}
+
+export function ApprovalArguments({ value }: ApprovalArgumentsProps) {
+  if (isRecord(value)) {
+    const entries = Object.entries(value);
+    if (entries.length === 0) {
+      return <div className="approval-arguments-empty">No arguments</div>;
+    }
+    return (
+      <dl className="approval-arguments">
+        {entries.map(([key, item]) => (
+          <div className="approval-argument" key={key}>
+            <dt title={key}>{formatArgumentLabel(key)}</dt>
+            <dd>
+              <ArgumentValue value={item} />
+            </dd>
+          </div>
+        ))}
+      </dl>
+    );
+  }
+
+  return (
+    <div className="approval-arguments approval-arguments-single">
+      <ArgumentValue value={value} />
+    </div>
+  );
+}
+
+function resizeArgumentTextarea(textarea: HTMLTextAreaElement) {
+  textarea.style.height = "auto";
+  const borderHeight = textarea.offsetHeight - textarea.clientHeight;
+  textarea.style.height = `${Math.min(textarea.scrollHeight + borderHeight, 180)}px`;
+}
+
+function TextArgumentField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const inputId = useId();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (textareaRef.current) resizeArgumentTextarea(textareaRef.current);
+  }, [value]);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea || typeof ResizeObserver === "undefined") return;
+
+    let width = textarea.getBoundingClientRect().width;
+    const observer = new ResizeObserver(() => {
+      const nextWidth = textarea.getBoundingClientRect().width;
+      if (nextWidth === width) return;
+      width = nextWidth;
+      resizeArgumentTextarea(textarea);
+    });
+    observer.observe(textarea);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <label className="approval-field" htmlFor={inputId}>
+      <span className="approval-field-label">{label}</span>
+      <textarea
+        ref={textareaRef}
+        id={inputId}
+        className="approval-field-text"
+        value={value}
+        rows={1}
+        onChange={(event) => {
+          resizeArgumentTextarea(event.currentTarget);
+          onChange(event.target.value);
+        }}
+        spellCheck
+        wrap="soft"
+      />
+    </label>
+  );
+}
+
+function NumberArgumentField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  const inputId = useId();
+  const [draft, setDraft] = useState(String(value));
+
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  const commit = (next: string) => {
+    setDraft(next);
+    if (next.trim() === "") return;
+    const parsed = Number(next);
+    if (Number.isFinite(parsed)) onChange(parsed);
+  };
+
+  return (
+    <label className="approval-field" htmlFor={inputId}>
+      <span className="approval-field-label">{label}</span>
+      <input
+        id={inputId}
+        className="approval-field-input"
+        type="text"
+        inputMode="decimal"
+        value={draft}
+        onChange={(event) => commit(event.target.value)}
+        onBlur={() => {
+          const parsed = Number(draft);
+          setDraft(
+            draft.trim() !== "" && Number.isFinite(parsed) ? String(parsed) : String(value),
+          );
+        }}
+      />
+    </label>
+  );
+}
+
+function NullArgumentField({
+  label,
+  onChange,
+}: {
+  label: string;
+  onChange: (value: unknown) => void;
+}) {
+  const inputId = useId();
+  return (
+    <label className="approval-field" htmlFor={inputId}>
+      <span className="approval-field-label">{label}</span>
+      <select
+        id={inputId}
+        className="approval-field-input approval-null-type"
+        value="null"
+        onChange={(event) => {
+          if (event.target.value === "string") onChange("");
+          if (event.target.value === "number") onChange(0);
+          if (event.target.value === "boolean") onChange(false);
+        }}
+      >
+        <option value="null">Not set</option>
+        <option value="string">Text</option>
+        <option value="number">Number</option>
+        <option value="boolean">Yes / no</option>
+      </select>
+    </label>
+  );
+}
+
+function ArgumentField({
+  label,
+  value,
+  path,
+  onChange,
+}: {
+  label: string;
+  value: unknown;
+  path: JsonPath;
+  onChange: (path: JsonPath, value: unknown) => void;
+}) {
+  if (Array.isArray(value)) {
+    return (
+      <div className="approval-field approval-field-group">
+        <div className="approval-field-label">{label}</div>
+        <div className="approval-field-children">
+          {value.length === 0 ? (
+            <span className="approval-argument-empty">None</span>
+          ) : (
+            value.map((item, index) => (
+              <ArgumentField
+                key={index}
+                label={`Item ${index + 1}`}
+                value={item}
+                path={[...path, index]}
+                onChange={onChange}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (isRecord(value)) {
+    return (
+      <div className="approval-field approval-field-group">
+        <div className="approval-field-label">{label}</div>
+        <div className="approval-field-children">
+          {Object.keys(value).length === 0 ? (
+            <span className="approval-argument-empty">None</span>
+          ) : (
+            Object.entries(value).map(([key, item]) => (
+              <ArgumentField
+                key={key}
+                label={formatArgumentLabel(key)}
+                value={item}
+                path={[...path, key]}
+                onChange={onChange}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (typeof value === "boolean") {
+    return (
+      <div className="approval-field approval-field-boolean">
+        <span className="approval-field-label">{label}</span>
+        <label className="approval-boolean-control">
+          <input
+            type="checkbox"
+            checked={value}
+            onChange={(event) => onChange(path, event.target.checked)}
+          />
+          <span>{value ? "Yes" : "No"}</span>
+        </label>
+      </div>
+    );
+  }
+
+  if (typeof value === "number") {
+    return (
+      <NumberArgumentField
+        label={label}
+        value={value}
+        onChange={(next) => onChange(path, next)}
+      />
+    );
+  }
+
+  if (typeof value === "string") {
+    return (
+      <TextArgumentField
+        label={label}
+        value={value}
+        onChange={(next) => onChange(path, next)}
+      />
+    );
+  }
+
+  if (value === null) {
+    return <NullArgumentField label={label} onChange={(next) => onChange(path, next)} />;
+  }
+
+  return <PrimitiveValue value={value} />;
+}
+
+export function ApprovalArgumentEditor({
+  value,
+  rawDraft,
+  rawError,
+  onChange,
+  onRawChange,
+}: ApprovalArgumentEditorProps) {
+  const supportsFields =
+    isStructured(value) && (Array.isArray(value) ? value.length > 0 : Object.keys(value).length > 0);
+  const [mode, setMode] = useState<"fields" | "json">(supportsFields ? "fields" : "json");
+  const errorId = useId();
+
+  const updateField = (path: JsonPath, next: unknown) => {
+    onChange(updateArgumentAtPath(value, path, next));
+  };
+
+  return (
+    <div className="approval-editor">
+      {supportsFields && (
+        <div className="approval-editor-modes" role="group" aria-label="Argument editor view">
+          <button
+            type="button"
+            aria-pressed={mode === "fields"}
+            aria-disabled={Boolean(rawError)}
+            aria-describedby={rawError ? errorId : undefined}
+            className={mode === "fields" ? "active" : undefined}
+            onClick={() => {
+              if (!rawError) setMode("fields");
+            }}
+          >
+            Fields
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === "json"}
+            className={mode === "json" ? "active" : undefined}
+            onClick={() => setMode("json")}
+          >
+            JSON
+          </button>
+        </div>
+      )}
+
+      {mode === "fields" && supportsFields ? (
+        <div className="approval-fields">
+          {Array.isArray(value) ? (
+            value.map((item, index) => (
+              <ArgumentField
+                key={index}
+                label={`Item ${index + 1}`}
+                value={item}
+                path={[index]}
+                onChange={updateField}
+              />
+            ))
+          ) : (
+            Object.entries(value).map(([key, item]) => (
+              <ArgumentField
+                key={key}
+                label={formatArgumentLabel(key)}
+                value={item}
+                path={[key]}
+                onChange={updateField}
+              />
+            ))
+          )}
+        </div>
+      ) : (
+        <textarea
+          className="approval-json-editor"
+          rows={Math.min(14, Math.max(5, rawDraft.split("\n").length + 1))}
+          value={rawDraft}
+          onChange={(event) => onRawChange(event.target.value)}
+          aria-invalid={Boolean(rawError)}
+          aria-label="Tool arguments as JSON"
+          spellCheck={false}
+          wrap="soft"
+        />
+      )}
+
+      {rawError && (
+        <span className="approval-editor-error" id={errorId} role="alert">
+          {rawError}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ChatFeed.test.tsx
+++ b/apps/web/src/components/ChatFeed.test.tsx
@@ -1,0 +1,46 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { UIPartLike } from "@/projection";
+import { InterruptConfirmation } from "./ChatFeed.js";
+
+type ApprovalPart = Extract<UIPartLike, { type: `tool-${string}` }>;
+
+function approvalPart(overrides: Partial<ApprovalPart> = {}): ApprovalPart {
+  return {
+    type: "tool-mcp__outlook__send_email",
+    toolCallId: "interrupt-1",
+    state: "approval-requested",
+    input: { recipient_email: "avery@example.com" },
+    allowedDecisions: ["approve", "edit", "reject"],
+    ...overrides,
+  } as ApprovalPart;
+}
+
+describe("InterruptConfirmation", () => {
+  it("shows a readable tool label without hiding its exact identifier", () => {
+    const html = renderToStaticMarkup(<InterruptConfirmation part={approvalPart()} />);
+
+    expect(html).toContain("MCP outlook send email");
+    expect(html).toContain("mcp__outlook__send_email");
+    expect(html).toContain("avery@example.com");
+  });
+
+  it("shows every call and exact tool identifier in a batch", () => {
+    const html = renderToStaticMarkup(
+      <InterruptConfirmation
+        part={approvalPart({
+          batch: [
+            { toolName: "send_email", args: { subject: "First" } },
+            { toolName: "calendar__create_event", args: { title: "Review" } },
+          ],
+        })}
+      />,
+    );
+
+    expect(html).toContain("approval-batch");
+    expect(html).toContain("send_email");
+    expect(html).toContain("calendar__create_event");
+    expect(html).toContain("First");
+    expect(html).toContain("Review");
+  });
+});

--- a/apps/web/src/components/ChatFeed.tsx
+++ b/apps/web/src/components/ChatFeed.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, useState, type PointerEventHandler } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEventHandler,
+} from "react";
 import { ExternalLink, Forward, MessageCircle } from "lucide-react";
 import {
   isForkableTurn,
@@ -37,6 +44,12 @@ import {
 } from "@/components/ai-elements/confirmation";
 import { PartErrorBoundary } from "@/components/PartErrorBoundary";
 import { Avatar } from "./Avatar.js";
+import {
+  ApprovalArgumentEditor,
+  ApprovalArguments,
+  formatArgumentLabel,
+  parseArgumentDraft,
+} from "./ApprovalArguments.js";
 import { approvalEditState } from "./approval-edit.js";
 import { useAttachmentSrc } from "../attachment-src.js";
 
@@ -225,7 +238,13 @@ function PartView({
 
   if (part.type.startsWith("tool-")) {
     if (part.state === "approval-requested") {
-      return <InterruptConfirmation part={part} onDecision={onDecision} />;
+      return (
+        <InterruptConfirmation
+          key={part.toolCallId}
+          part={part}
+          onDecision={onDecision}
+        />
+      );
     }
 
     return (
@@ -314,7 +333,7 @@ function AttachmentPart({
   );
 }
 
-function InterruptConfirmation({
+export function InterruptConfirmation({
   part,
   onDecision,
 }: {
@@ -328,12 +347,14 @@ function InterruptConfirmation({
   ) => void;
 }) {
   const toolName = part.type.slice("tool-".length);
+  const toolLabel = formatArgumentLabel(toolName);
   const [editing, setEditing] = useState(false);
   const [responding, setResponding] = useState(false);
-  const [originalDraft] = useState(() => JSON.stringify(part.input, null, 2));
+  const originalDraft = JSON.stringify(part.input, null, 2) ?? "null";
   const [draft, setDraft] = useState(originalDraft);
   const [responseDraft, setResponseDraft] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  const parsedDraft = useMemo(() => parseArgumentDraft(draft), [draft]);
+  const error = parsedDraft.ok ? null : parsedDraft.error;
 
   const batch = part.batch;
   const isBatch = Array.isArray(batch) && batch.length > 1;
@@ -342,21 +363,21 @@ function InterruptConfirmation({
   const canEdit = !isBatch && allowed.includes("edit");
   const editState = approvalEditState(originalDraft, draft);
 
+  useEffect(() => {
+    if (!editing) setDraft(originalDraft);
+  }, [editing, originalDraft]);
+
   const submitEdit = () => {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(draft);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Invalid JSON");
-      return;
-    }
-    setError(null);
-    onDecision?.(part.toolCallId, "edit", parsed, toolName);
+    if (!parsedDraft.ok) return;
+    onDecision?.(part.toolCallId, "edit", parsedDraft.value, toolName);
   };
 
   const revertEdit = () => {
     setDraft(originalDraft);
-    setError(null);
+  };
+
+  const updateDraftValue = (value: unknown) => {
+    setDraft(JSON.stringify(value, null, 2) ?? "null");
   };
 
   const submitRespond = () => {
@@ -365,44 +386,60 @@ function InterruptConfirmation({
   };
 
   return (
-    <Confirmation approval={{ id: part.toolCallId }} state="approval-requested">
-      <ConfirmationTitle>
-        {isBatch ? (
-          <>
-            Approve <b>{batch!.length}</b> <b>{toolName}</b> calls?
-          </>
-        ) : (
-          <>
-            Approve <b>{toolName}</b>? <code className="text-xs">{JSON.stringify(part.input)}</code>
-          </>
-        )}
+    <Confirmation
+      approval={{ id: part.toolCallId }}
+      state="approval-requested"
+      className="hitl-confirmation"
+    >
+      <ConfirmationTitle className="hitl-confirmation-title">
+        <span>
+          {isBatch ? (
+            <>
+              Approve <b>{batch!.length}</b> <b>{toolLabel}</b> calls?
+            </>
+          ) : (
+            <>
+              Approve <b>{toolLabel}</b>?
+            </>
+          )}
+        </span>
+        {toolLabel !== toolName && <code className="hitl-tool-id">{toolName}</code>}
       </ConfirmationTitle>
       <ConfirmationRequest>
         {isBatch && (
-          <ul className="mb-2 flex flex-col gap-1">
-            {batch!.map((call, i) => (
-              <li key={i} className="text-xs">
-                <b>{call.toolName}</b> <code>{JSON.stringify(call.args)}</code>
-              </li>
-            ))}
+          <ul className="approval-batch">
+            {batch!.map((call, i) => {
+              const callLabel = formatArgumentLabel(call.toolName);
+              return (
+                <li key={i}>
+                  <div className="approval-batch-tool">
+                    <b>{callLabel}</b>
+                    {callLabel !== call.toolName && (
+                      <code className="hitl-tool-id">{call.toolName}</code>
+                    )}
+                  </div>
+                  <ApprovalArguments value={call.args} />
+                </li>
+              );
+            })}
           </ul>
         )}
+        {!isBatch && !editing && <ApprovalArguments value={part.input} />}
         {editing && (
-          <div className="mb-2 flex flex-col gap-1">
-            <textarea
-              className="w-full rounded-md border border-border bg-background p-2 font-mono text-xs text-foreground"
-              rows={Math.min(12, draft.split("\n").length + 1)}
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              spellCheck={false}
+          <div className="hitl-editor-wrap">
+            <ApprovalArgumentEditor
+              value={parsedDraft.ok ? parsedDraft.value : part.input}
+              rawDraft={draft}
+              rawError={error}
+              onChange={updateDraftValue}
+              onRawChange={setDraft}
             />
-            {error && <span className="text-destructive text-xs">⚠ {error}</span>}
           </div>
         )}
         {responding && (
-          <div className="mb-2 flex flex-col gap-1">
+          <div className="hitl-response-wrap">
             <textarea
-              className="w-full rounded-md border border-border bg-background p-2 text-sm text-foreground"
+              className="hitl-response-editor"
               rows={3}
               value={responseDraft}
               onChange={(e) => setResponseDraft(e.target.value)}
@@ -411,7 +448,7 @@ function InterruptConfirmation({
             />
           </div>
         )}
-        <ConfirmationActions>
+        <ConfirmationActions className="hitl-actions">
           {editing && editState.changed && (
             <ConfirmationAction variant="outline" onClick={revertEdit}>
               Revert changes
@@ -425,7 +462,12 @@ function InterruptConfirmation({
           </ConfirmationAction>
           {canRespond && !editing && (
             responding ? (
-              <ConfirmationAction onClick={submitRespond}>Send response</ConfirmationAction>
+              <>
+                <ConfirmationAction variant="outline" onClick={() => setResponding(false)}>
+                  Back
+                </ConfirmationAction>
+                <ConfirmationAction onClick={submitRespond}>Send response</ConfirmationAction>
+              </>
             ) : (
               <ConfirmationAction variant="outline" onClick={() => { setResponding(true); setEditing(false); }}>
                 Respond
@@ -435,7 +477,7 @@ function InterruptConfirmation({
           {canEdit && !responding && (
             editing ? (
               editState.changed && (
-                <ConfirmationAction onClick={submitEdit}>
+                <ConfirmationAction disabled={!parsedDraft.ok} onClick={submitEdit}>
                   {editState.approveLabel}
                 </ConfirmationAction>
               )

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -543,6 +543,148 @@ body {
 .tool-io { margin: 0; padding: 8px 10px; font-size: 12px; background: var(--code-bg); overflow-x: auto; }
 .tool-io.out { border-top: 1px solid var(--border); }
 
+.hitl-confirmation {
+  width: min(48rem, calc(100vw - 3rem));
+  max-width: 100%;
+  gap: 12px;
+}
+.hitl-confirmation-title {
+  min-width: 0; display: flex; flex-direction: column; align-items: flex-start; gap: 3px;
+  color: var(--text);
+}
+.hitl-confirmation-title b { overflow-wrap: anywhere; }
+.hitl-tool-id {
+  max-width: 100%; color: var(--dim); font-family: var(--mono); font-size: 10px;
+  font-weight: 500; line-height: 1.35; white-space: pre-wrap; overflow-wrap: anywhere;
+}
+.approval-arguments {
+  width: 100%; min-width: 0;
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px;
+}
+.approval-arguments-single { display: block; }
+.approval-argument {
+  min-width: 0; padding: 8px 10px;
+  background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px;
+}
+.approval-argument > dt,
+.approval-argument-nested dt,
+.approval-field-label {
+  min-width: 0; color: var(--dim); font-size: 11px; font-weight: 700;
+  line-height: 1.3; overflow-wrap: anywhere;
+}
+.approval-argument > dd { margin-top: 4px; }
+.approval-argument-value {
+  display: block; color: var(--text); line-height: 1.45;
+  white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word;
+}
+.approval-argument-empty { color: var(--dim); font-style: italic; }
+.approval-argument-scalar {
+  min-width: 0; display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
+}
+.approval-argument-type {
+  flex: 0 0 auto; color: var(--dim); font-size: 9px; font-weight: 700;
+  line-height: 1.4; text-transform: uppercase; letter-spacing: .04em;
+}
+.approval-argument-list {
+  display: flex; flex-direction: column; gap: 5px;
+  margin: 0; padding: 0; list-style: none;
+}
+.approval-argument-list > li {
+  display: grid; grid-template-columns: 20px minmax(0, 1fr); gap: 6px; align-items: start;
+}
+.approval-argument-index {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 20px; height: 20px; border-radius: 50%;
+  background: var(--panel); color: var(--dim); font-size: 10px; font-variant-numeric: tabular-nums;
+}
+.approval-argument-nested { display: flex; flex-direction: column; gap: 6px; }
+.approval-argument-nested > div {
+  min-width: 0; padding-left: 8px; border-left: 2px solid var(--border);
+}
+.approval-argument-nested dd { margin-top: 2px; }
+.approval-arguments-empty {
+  width: 100%; padding: 8px 10px; color: var(--dim); font-style: italic;
+  background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px;
+}
+.approval-batch {
+  width: 100%; display: flex; flex-direction: column; gap: 8px; margin: 0; padding: 0;
+  list-style: none;
+}
+.approval-batch > li {
+  min-width: 0; display: flex; flex-direction: column; gap: 6px;
+  padding: 10px; border: 1px solid var(--border); border-radius: 6px;
+}
+.approval-batch-tool {
+  min-width: 0; display: flex; flex-direction: column; align-items: flex-start; gap: 2px;
+}
+.approval-batch-tool > b { overflow-wrap: anywhere; }
+.hitl-editor-wrap, .hitl-response-wrap { width: 100%; min-width: 0; }
+.approval-editor { width: 100%; min-width: 0; display: flex; flex-direction: column; gap: 8px; }
+.approval-editor-modes {
+  align-self: flex-start; display: inline-flex; padding: 2px; gap: 2px;
+  background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px;
+}
+.approval-editor-modes button {
+  min-height: 28px; padding: 0 10px; border: 0; border-radius: 4px;
+  background: transparent; color: var(--dim); cursor: pointer; font: inherit; font-size: 12px;
+}
+.approval-editor-modes button.active {
+  background: var(--panel); color: var(--text); box-shadow: 0 1px 2px rgba(0, 0, 0, .16);
+}
+.approval-editor-modes button[aria-disabled="true"] { opacity: .45; cursor: not-allowed; }
+.approval-fields {
+  width: 100%; min-width: 0;
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px;
+  padding: 1px;
+}
+.approval-field {
+  min-width: 0; display: flex; flex-direction: column; align-items: stretch; gap: 5px;
+}
+.approval-field-input,
+.approval-field-text,
+.approval-json-editor,
+.hitl-response-editor {
+  width: 100%; min-width: 0; border: 1px solid var(--border); border-radius: 6px;
+  background: var(--bg); color: var(--text);
+}
+.approval-field-input { height: 38px; padding: 7px 9px; font: inherit; }
+.approval-field-text {
+  min-height: 42px; max-height: 180px; height: auto; padding: 9px 10px;
+  resize: vertical; overflow-y: auto; font: inherit; line-height: 1.45;
+  white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word;
+}
+.approval-null-type { cursor: pointer; }
+.approval-field-group {
+  grid-column: 1 / -1; padding: 10px;
+  border: 1px solid var(--border); border-radius: 6px;
+}
+.approval-field-children {
+  min-width: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px;
+}
+.approval-field-group > .approval-field-label { margin-bottom: 3px; color: var(--text); }
+.approval-field-boolean {
+  min-height: 64px; padding: 8px 10px;
+  background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px;
+}
+.approval-boolean-control {
+  align-self: flex-start; display: inline-flex; align-items: center; gap: 7px;
+  color: var(--text); cursor: pointer; font-weight: 600;
+}
+.approval-boolean-control input { width: 16px; height: 16px; accent-color: var(--brand); }
+.approval-json-editor {
+  min-height: 140px; max-height: min(52vh, 30rem); padding: 10px 12px;
+  resize: vertical; overflow-x: hidden; font-family: var(--mono); font-size: 12px; line-height: 1.55;
+  white-space: pre-wrap; overflow-wrap: break-word; word-break: normal;
+}
+.approval-editor-error { color: var(--danger); font-size: 12px; overflow-wrap: anywhere; }
+.hitl-response-editor {
+  min-height: 88px; max-height: 220px; padding: 10px 12px;
+  resize: vertical; font: inherit; line-height: 1.45;
+}
+.hitl-actions {
+  width: 100%; align-self: stretch; flex-wrap: wrap; padding-top: 2px;
+}
+
 /* Anchors the mention and model popovers above the composer. */
 .composer-wrap { position: relative; flex: 0 0 auto; padding: 12px 16px 16px; background: var(--bg); }
 .composer {
@@ -1608,6 +1750,16 @@ textarea.field-input { resize: vertical; line-height: 1.5; }
   .composer textarea { min-height: 44px; max-height: 140px; }
   .feed { padding: 12px; }
   .msg { max-width: 100%; }
+  .hitl-confirmation { width: calc(100vw - 24px); padding: 12px; }
+  .approval-arguments,
+  .approval-fields,
+  .approval-field-children { grid-template-columns: minmax(0, 1fr); }
+  .approval-field-group { padding: 9px; }
+  .hitl-actions {
+    display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: stretch;
+  }
+  .hitl-actions > button { width: 100%; min-width: 0; padding-inline: 8px; }
+  .hitl-actions > button:last-child:nth-child(odd) { grid-column: 1 / -1; }
 
   .logs-toolbar { grid-template-columns: minmax(0, 1fr); padding: 10px 12px; }
   .logs-search, .logs-levels { grid-column: 1; }


### PR DESCRIPTION
## Summary
- present tool arguments as readable fields while preserving exact tool identifiers
- add a responsive field-first editor with JSON fallback and mobile layout
- keep long text accessible across pane resizing and improve edit/respond state handling

## Testing
- `npm test`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- ESLint on changed web files
- `npm run build`
- Chromium checks at desktop/mobile widths and with the Activity rail open