### PR TITLE
Add model context window overrides

### DIFF
--- a/apps/api-server/src/agent-host.ts
+++ b/apps/api-server/src/agent-host.ts
@@ -336,6 +336,7 @@ export class AgentHost {
 
   private graphs?: GraphManager;
   private readonly warmup: Promise<void>;
+  private readonly providerPreferenceUpdates = new Map<string, Promise<void>>();
   private readinessState: "warming" | "ready" | "failed" = "warming";
 
   private skillsDir?: string | false;
@@ -854,20 +855,72 @@ export class AgentHost {
     preferences: ProviderModelPreferences,
   ): Promise<void> {
     await this.warmup;
-    this.graphs!.setEnabledModels(
-      providerId,
-      preferences.mode === "selected" ? preferences.selected : undefined,
-    );
-    this.providerConfigs.setModelPreferences(providerId, preferences);
-    if (!this.explicitModelId && !this.providerConfigs.getDefaultModel()) {
-      await this.setDefaultModel(null);
-    }
+    await this.queueProviderPreferenceUpdate(providerId, async () => {
+      const previous = this.providerConfigs.getModelPreferences(providerId);
+      this.providerConfigs.setModelPreferences(providerId, preferences);
+      this.graphs!.setEnabledModels(
+        providerId,
+        preferences.mode === "selected" ? preferences.selected : undefined,
+      );
+      try {
+        await this.graphs!.setModelOverrides(providerId, preferences.overrides);
+      } catch (error) {
+        if (previous) this.providerConfigs.setModelPreferences(providerId, previous);
+        else this.providerConfigs.removeModelPreferences(providerId);
+        this.restoreEnabledModels(providerId, previous);
+        throw error;
+      }
+      if (!this.explicitModelId && !this.providerConfigs.getDefaultModel()) {
+        await this.setDefaultModel(null);
+      }
+    });
   }
 
   async clearProviderModelPreferences(providerId: string): Promise<void> {
     await this.warmup;
-    this.graphs!.setEnabledModels(providerId, undefined);
-    this.providerConfigs.removeModelPreferences(providerId);
+    await this.queueProviderPreferenceUpdate(providerId, async () => {
+      const previous = this.providerConfigs.getModelPreferences(providerId);
+      this.providerConfigs.removeModelPreferences(providerId);
+      this.graphs!.setEnabledModels(providerId, undefined);
+      try {
+        await this.graphs!.setModelOverrides(providerId, undefined);
+      } catch (error) {
+        if (previous) this.providerConfigs.setModelPreferences(providerId, previous);
+        this.restoreEnabledModels(providerId, previous);
+        throw error;
+      }
+    });
+  }
+
+  private queueProviderPreferenceUpdate(
+    providerId: string,
+    update: () => Promise<void>,
+  ): Promise<void> {
+    const prior = this.providerPreferenceUpdates.get(providerId) ?? Promise.resolve();
+    const result = prior.then(update);
+    const tail = result.catch(() => {});
+    this.providerPreferenceUpdates.set(providerId, tail);
+    return result.finally(() => {
+      if (this.providerPreferenceUpdates.get(providerId) === tail) {
+        this.providerPreferenceUpdates.delete(providerId);
+      }
+    });
+  }
+
+  private async drainProviderPreferenceUpdates(): Promise<void> {
+    while (this.providerPreferenceUpdates.size > 0) {
+      await Promise.all(this.providerPreferenceUpdates.values());
+    }
+  }
+
+  private restoreEnabledModels(
+    providerId: string,
+    previous: ProviderModelPreferences | undefined,
+  ): void {
+    this.graphs!.setEnabledModels(
+      providerId,
+      previous?.mode === "selected" ? previous.selected : undefined,
+    );
   }
 
   async contextWindow(): Promise<number | undefined> {
@@ -1821,6 +1874,7 @@ export class AgentHost {
     // Run-end and pending-delete maintenance write through the app stores, so let
     // them settle before any store closes.
     await this.drainMaintenance();
+    await this.drainProviderPreferenceUpdates();
     await this.mcpReloads.catch(() => {});
     await Promise.allSettled(this.mcpRetirements);
     // Disarm before closing transports because their onclose hooks also fire here.

--- a/apps/api-server/src/graph-manager.test.ts
+++ b/apps/api-server/src/graph-manager.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { ModelRegistry, type SkillCatalog, type SkillCatalogEntry } from "@pizza-bot/core";
-import { registerBuiltinProviders } from "@pizza-bot/inference-providers";
+import {
+  ModelRegistry,
+  type ModelProvider,
+  type SkillCatalog,
+  type SkillCatalogEntry,
+} from "@pizza-bot/core";
+import { registerBuiltinProviders, UnavailableChatModel } from "@pizza-bot/inference-providers";
 import { GraphManager } from "./graph-manager.js";
 
 const MODEL_ID = "bedrock:global.anthropic.claude-sonnet-5";
@@ -50,6 +55,69 @@ describe("GraphManager", () => {
 
     await registry.replaceCapabilities({ skills: new Map() });
     expect(await registry.agentFor(OTHER_MODEL_ID)).not.toBe(first);
+  });
+
+  it("rebuilds the warm graph when its provider context override changes", async () => {
+    const registry = await createRegistry();
+    const first = registry.agent;
+
+    await registry.setModelOverrides("bedrock", {
+      "global.anthropic.claude-sonnet-5": { contextWindow: 32_768 },
+    });
+
+    expect(registry.agent).not.toBe(first);
+  });
+
+  it("invalidates model variants without rebuilding an unrelated warm graph", async () => {
+    const registry = await createRegistry();
+    const warm = registry.agent;
+    const firstVariant = await registry.agentFor(OTHER_MODEL_ID);
+
+    await registry.setModelOverrides("openai", {
+      "private-deployment": { contextWindow: 32_768 },
+    });
+
+    expect(registry.agent).toBe(warm);
+    expect(await registry.agentFor(OTHER_MODEL_ID)).not.toBe(firstVariant);
+  });
+
+  it("restores registry overrides when the warm graph cannot rebuild", async () => {
+    let failBuild = false;
+    const models = new ModelRegistry();
+    const provider: ModelProvider = {
+      id: "stub",
+      async listModels() {
+        return [{
+          id: "model",
+          provider: "stub",
+          displayName: "Model",
+          contextWindow: 128_000,
+        }];
+      },
+      async buildModel() {
+        if (failBuild) throw new Error("provider unavailable");
+        return new UnavailableChatModel();
+      },
+    };
+    models.register(provider);
+    const registry = new GraphManager({
+      modelId: "stub:model",
+      models,
+      dependencies: {},
+    });
+    await registry.initialize(await models.buildModel("stub:model"));
+    const warm = registry.agent;
+    failBuild = true;
+
+    await expect(registry.setModelOverrides("stub", {
+      model: { contextWindow: 32_768 },
+    })).rejects.toThrow("provider unavailable");
+
+    expect(models.getModelOverrides("stub")).toBeUndefined();
+    expect(registry.agent).toBe(warm);
+    await expect(models.listAll()).resolves.toEqual([
+      expect.objectContaining({ contextWindow: 128_000 }),
+    ]);
   });
 
   it("allows a requested model absent from provider discovery", async () => {

--- a/apps/api-server/src/graph-manager.ts
+++ b/apps/api-server/src/graph-manager.ts
@@ -98,6 +98,8 @@ export class GraphManager {
     displayName: string;
     provider: string;
     contextWindow?: number;
+    detectedContextWindow?: number;
+    contextWindowSource?: "override";
   }>> {
     const descriptors = await this.models.listAll({ includeDisabled });
     return descriptors.map((descriptor) => ({
@@ -105,6 +107,12 @@ export class GraphManager {
       displayName: descriptor.displayName,
       provider: descriptor.provider,
       ...(descriptor.contextWindow ? { contextWindow: descriptor.contextWindow } : {}),
+      ...(descriptor.detectedContextWindow
+        ? { detectedContextWindow: descriptor.detectedContextWindow }
+        : {}),
+      ...(descriptor.contextWindowSource
+        ? { contextWindowSource: descriptor.contextWindowSource }
+        : {}),
     }));
   }
 
@@ -117,6 +125,8 @@ export class GraphManager {
       displayName: string;
       provider: string;
       contextWindow?: number;
+      detectedContextWindow?: number;
+      contextWindowSource?: "override";
     }>;
     providers: ModelCatalogStatus[];
   }> {
@@ -128,6 +138,12 @@ export class GraphManager {
         provider: descriptor.provider,
         ...(descriptor.contextWindow
           ? { contextWindow: descriptor.contextWindow }
+          : {}),
+        ...(descriptor.detectedContextWindow
+          ? { detectedContextWindow: descriptor.detectedContextWindow }
+          : {}),
+        ...(descriptor.contextWindowSource
+          ? { contextWindowSource: descriptor.contextWindowSource }
           : {}),
       })),
       providers: snapshot.providers,
@@ -153,6 +169,28 @@ export class GraphManager {
 
   setEnabledModels(providerId: string, modelIds: readonly string[] | undefined): void {
     this.models.setEnabledModels(providerId, modelIds);
+  }
+
+  async setModelOverrides(
+    providerId: string,
+    overrides: Parameters<ModelRegistry["setModelOverrides"]>[1],
+  ): Promise<void> {
+    await this.enqueueUpdate(async () => {
+      const previous = this.models.getModelOverrides(providerId);
+      const changed = this.models.setModelOverrides(providerId, overrides);
+      if (!changed) return;
+      try {
+        if (this.modelId.startsWith(`${providerId}:`)) {
+          await this.rebuild();
+          return;
+        }
+        this.cache.clear();
+        this.cache.set(this.modelId, Promise.resolve(this.agent));
+      } catch (error) {
+        this.models.setModelOverrides(providerId, previous);
+        throw error;
+      }
+    });
   }
 
   providerProcessEnv(): Record<string, string> {

--- a/apps/api-server/src/routes-providers.test.ts
+++ b/apps/api-server/src/routes-providers.test.ts
@@ -21,6 +21,14 @@ interface ProviderView {
   modelPreferences: ProviderModelPreferences;
 }
 
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 describe("provider routes", () => {
   let dataRoot: string;
   let pluginsDir: string;
@@ -334,9 +342,133 @@ describe("provider routes", () => {
     expect(models.models).toEqual([expect.objectContaining({ id: "anthropic:claude-b" })]);
   });
 
+  it("persists model-specific context-window overrides", async () => {
+    const res = await putModels("anthropic", {
+      mode: "all",
+      selected: [],
+      overrides: {
+        "private-large": { contextWindow: 131_072 },
+        "private-small": { contextWindow: 32_768 },
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      mode: "all",
+      selected: [],
+      overrides: {
+        "private-large": { contextWindow: 131_072 },
+        "private-small": { contextWindow: 32_768 },
+      },
+    });
+    expect((await list()).find((p) => p.id === "anthropic")!.modelPreferences)
+      .toEqual({
+        mode: "all",
+        selected: [],
+        overrides: {
+          "private-large": { contextWindow: 131_072 },
+          "private-small": { contextWindow: 32_768 },
+        },
+      });
+  });
+
+  it("restores persisted preferences when applying an override fails", async () => {
+    const previous: ProviderModelPreferences = {
+      mode: "selected",
+      selected: ["private-small"],
+      overrides: { "private-small": { contextWindow: 32_768 } },
+    };
+    await host.setProviderModelPreferences("openai", previous);
+    const graphs = (host as unknown as {
+      graphs: {
+        setEnabledModels(providerId: string, modelIds: string[] | undefined): void;
+        setModelOverrides(
+          providerId: string,
+          overrides: ProviderModelPreferences["overrides"],
+        ): Promise<void>;
+      };
+    }).graphs;
+    const setEnabledModels = vi.spyOn(graphs, "setEnabledModels");
+    vi.spyOn(graphs, "setModelOverrides").mockRejectedValueOnce(
+      new Error("provider unavailable"),
+    );
+
+    await expect(host.setProviderModelPreferences("openai", {
+      mode: "all",
+      selected: [],
+      overrides: { "private-large": { contextWindow: 131_072 } },
+    })).rejects.toThrow("provider unavailable");
+
+    expect(host.providerConfigs.getModelPreferences("openai")).toEqual(previous);
+    expect(setEnabledModels).toHaveBeenLastCalledWith("openai", ["private-small"]);
+  });
+
+  it("serializes same-provider preference updates across rollback", async () => {
+    const previous: ProviderModelPreferences = {
+      mode: "selected",
+      selected: ["private-small"],
+    };
+    const first: ProviderModelPreferences = {
+      mode: "all",
+      selected: [],
+      overrides: { "private-large": { contextWindow: 131_072 } },
+    };
+    const second: ProviderModelPreferences = {
+      mode: "selected",
+      selected: ["private-large"],
+      overrides: { "private-large": { contextWindow: 65_536 } },
+    };
+    await host.setProviderModelPreferences("openai", previous);
+    const graphs = (host as unknown as {
+      graphs: {
+        setModelOverrides(
+          providerId: string,
+          overrides: ProviderModelPreferences["overrides"],
+        ): Promise<void>;
+      };
+    }).graphs;
+    const firstStarted = deferred();
+    const rejectFirst = deferred();
+    const setModelOverrides = vi.spyOn(graphs, "setModelOverrides")
+      .mockImplementationOnce(async () => {
+        firstStarted.resolve();
+        await rejectFirst.promise;
+        throw new Error("provider unavailable");
+      })
+      .mockResolvedValueOnce();
+
+    const firstUpdate = host.setProviderModelPreferences("openai", first);
+    const firstResult = expect(firstUpdate).rejects.toThrow("provider unavailable");
+    await firstStarted.promise;
+    const secondUpdate = host.setProviderModelPreferences("openai", second);
+
+    expect(setModelOverrides).toHaveBeenCalledTimes(1);
+    rejectFirst.resolve();
+    await firstResult;
+    await secondUpdate;
+
+    expect(setModelOverrides).toHaveBeenCalledTimes(2);
+    expect(host.providerConfigs.getModelPreferences("openai")).toEqual(second);
+  });
+
   it("rejects malformed model preferences and unknown providers", async () => {
     expect((await putModels("anthropic", { mode: "selected", selected: "claude" })).status)
       .toBe(400);
+    expect((await putModels("anthropic", {
+      mode: "all",
+      selected: [],
+      overrides: { "private-deployment": { contextWindow: 0 } },
+    })).status).toBe(400);
+    expect((await putModels("anthropic", {
+      mode: "all",
+      selected: [],
+      overrides: { "private-deployment": { contextWindow: 32_768.5 } },
+    })).status).toBe(400);
+    expect((await putModels("anthropic", {
+      mode: "all",
+      selected: [],
+      overrides: { "private-deployment": { contextWindow: 10_000_001 } },
+    })).status).toBe(400);
     expect((await putModels("nope", { mode: "all", selected: [] })).status).toBe(404);
   });
 

--- a/apps/api-server/src/routes-providers.ts
+++ b/apps/api-server/src/routes-providers.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import {
   envReferenceName,
   isEnvReference,
+  MAX_CONTEXT_WINDOW,
+  parseModelOverrides,
   type ProviderAuthMethod,
   type ProviderModelPreferences,
   type SavedProviderConfig,
@@ -87,7 +89,9 @@ export function providerRoutes(host: AgentHost): Hono {
     const raw = (await c.req.json().catch(() => ({}))) as {
       mode?: unknown;
       selected?: unknown;
+      overrides?: unknown;
     };
+    const overrides = parseModelOverrides(raw.overrides);
     if (
       (raw.mode !== "all" && raw.mode !== "selected") ||
       !Array.isArray(raw.selected) ||
@@ -96,13 +100,18 @@ export function providerRoutes(host: AgentHost): Hono {
         modelId.length > 0 &&
         modelId.length <= 512
       ) ||
-      raw.selected.length > 5_000
+      raw.selected.length > 5_000 ||
+      overrides === null
     ) {
-      return c.json({ error: "Body must be { mode: \"all\" | \"selected\", selected: string[] }." }, 400);
+      return c.json({
+        error:
+          `Body must include a valid model mode, selected model IDs, and integer context-window overrides between 1 and ${MAX_CONTEXT_WINDOW}.`,
+      }, 400);
     }
     const preferences: ProviderModelPreferences = {
       mode: raw.mode,
       selected: [...new Set(raw.selected)],
+      ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
     };
     await host.setProviderModelPreferences(id, preferences);
     return c.json(preferences);

--- a/apps/web/src/api-client.ts
+++ b/apps/web/src/api-client.ts
@@ -903,6 +903,8 @@ export interface ModelsInfo {
     displayName: string;
     provider: string;
     contextWindow?: number;
+    detectedContextWindow?: number;
+    contextWindowSource?: "override";
   }>;
   providers?: ModelCatalogStatus[];
   default: string;
@@ -931,6 +933,7 @@ export interface ProviderView {
 export interface ProviderModelPreferences {
   mode: "all" | "selected";
   selected: string[];
+  overrides?: Record<string, { contextWindow: number }>;
 }
 
 export interface AgentInfo {

--- a/apps/web/src/components/settings/ProvidersSettings.test.ts
+++ b/apps/web/src/components/settings/ProvidersSettings.test.ts
@@ -3,9 +3,26 @@ import type { ProviderConfigView, ProviderView } from "@/api-client";
 import type { ProviderAuthMethod } from "@pizza-bot/core";
 import {
   getProviderStatus,
+  parseContextWindow,
   secretKeysWithStoredValue,
   unavailableLocalSecretValidationError,
 } from "./ProvidersSettings.js";
+
+describe("parseContextWindow", () => {
+  it("accepts positive whole token counts with common separators", () => {
+    expect(parseContextWindow("32768")).toBe(32_768);
+    expect(parseContextWindow("131,072")).toBe(131_072);
+    expect(parseContextWindow("1_000_000")).toBe(1_000_000);
+  });
+
+  it("rejects empty, fractional, negative, and unsafe values", () => {
+    expect(parseContextWindow("")).toBeUndefined();
+    expect(parseContextWindow("32768.5")).toBeUndefined();
+    expect(parseContextWindow("-1")).toBeUndefined();
+    expect(parseContextWindow("10,000,001")).toBeUndefined();
+    expect(parseContextWindow(String(Number.MAX_SAFE_INTEGER + 1))).toBeUndefined();
+  });
+});
 
 function provider(overrides: Partial<ProviderView>): ProviderView {
   return {

--- a/apps/web/src/components/settings/ProvidersSettings.tsx
+++ b/apps/web/src/components/settings/ProvidersSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { ArrowLeft, ChevronRight, RefreshCw, Search, X } from "lucide-react";
+import { ArrowLeft, ChevronRight, RefreshCw, Search, Settings2, X } from "lucide-react";
 import { SECRET_UNCHANGED } from "@/api-client";
 import type {
   ProviderView,
@@ -8,14 +8,31 @@ import type {
   ModelsInfo,
   StatusInfo,
 } from "@/api-client";
-import type {
-  ModelCatalogStatus,
-  ProviderAuthField,
-  ProviderAuthMethod,
+import {
+  isValidContextWindow,
+  MAX_CONTEXT_WINDOW,
+  type ModelCatalogStatus,
+  type ProviderAuthField,
+  type ProviderAuthMethod,
 } from "@pizza-bot/core";
 import { L } from "../../lexicon.js";
 import { groupModelsByProvider, providerLabel } from "../../model-options.js";
 import { useAppToast } from "../AppToast.js";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../ui/tooltip.js";
 
 // Secret inputs never receive stored values. Desktop stores raw keys in the OS
 // keychain; browser mode accepts only an environment-variable reference.
@@ -135,10 +152,14 @@ function ProviderSummary({
   onSelect: () => void;
 }) {
   const status = getProviderStatus(provider, catalog, health);
+  const overrideCount = Object.keys(provider.modelPreferences.overrides ?? {}).length;
   const modelSummary =
     provider.modelPreferences.mode === "selected"
       ? `${provider.modelPreferences.selected.length} selected`
       : `${modelCount} model${modelCount === 1 ? "" : "s"}`;
+  const summary = overrideCount > 0
+    ? `${modelSummary} · ${overrideCount} override${overrideCount === 1 ? "" : "s"}`
+    : modelSummary;
 
   return (
     <button type="button" className="settings-provider-summary" onClick={onSelect}>
@@ -147,7 +168,7 @@ function ProviderSummary({
           <span className="settings-provider-name">{providerLabel(provider.id)}</span>
           <span className={`provenance-badge ${status.tone}`}>{status.label}</span>
         </span>
-        <span className="settings-row-hint">{modelSummary}</span>
+        <span className="settings-row-hint">{summary}</span>
       </span>
       <ChevronRight size={17} aria-hidden="true" />
     </button>
@@ -451,6 +472,11 @@ function ProviderModelsField({
 }) {
   const selected = new Set(preferences.selected);
   const normalized = query.trim().toLowerCase();
+  const overrides = preferences.overrides ?? {};
+  const [editingModelId, setEditingModelId] = useState<string | null>(null);
+  const [editorMode, setEditorMode] = useState<"automatic" | "override">("automatic");
+  const [contextDraft, setContextDraft] = useState("");
+  const [contextError, setContextError] = useState<string | null>(null);
   const rawId = (qualified: string) =>
     qualified.startsWith(`${providerId}:`)
       ? qualified.slice(providerId.length + 1)
@@ -458,14 +484,28 @@ function ProviderModelsField({
   const discovered = models.map((model) => ({
     id: rawId(model.id),
     displayName: model.displayName,
+    contextWindow: model.contextWindow,
+    detectedContextWindow: model.detectedContextWindow,
+    contextWindowSource: model.contextWindowSource,
     savedOnly: false,
   }));
   const discoveredIds = new Set(discovered.map((model) => model.id));
+  const retainedIds = [...new Set([
+    ...(preferences.mode === "selected" ? preferences.selected : []),
+    ...Object.keys(overrides),
+  ])];
   const choices = [
     ...discovered,
-    ...preferences.selected
+    ...retainedIds
       .filter((id) => !discoveredIds.has(id))
-      .map((id) => ({ id, displayName: id, savedOnly: true })),
+      .map((id) => ({
+        id,
+        displayName: id,
+        contextWindow: overrides[id]?.contextWindow,
+        detectedContextWindow: undefined,
+        contextWindowSource: overrides[id] ? "override" as const : undefined,
+        savedOnly: true,
+      })),
   ];
   const visible = choices
     .filter((model) =>
@@ -477,7 +517,40 @@ function ProviderModelsField({
     const next = new Set(selected);
     if (next.has(modelId)) next.delete(modelId);
     else next.add(modelId);
-    onChange({ mode: "selected", selected: [...next] });
+    onChange({ ...preferences, mode: "selected", selected: [...next] });
+  };
+  const editingModel = choices.find((model) => model.id === editingModelId);
+  const detectedContextWindow = automaticContextWindow(editingModel);
+  const openEditor = (modelId: string) => {
+    const existing = overrides[modelId];
+    const model = choices.find((choice) => choice.id === modelId);
+    const detected = automaticContextWindow(model);
+    setEditingModelId(modelId);
+    setEditorMode(existing ? "override" : "automatic");
+    setContextDraft(existing ? String(existing.contextWindow) : detected ? String(detected) : "");
+    setContextError(null);
+  };
+  const applyEditor = () => {
+    if (!editingModelId) return;
+    const nextOverrides = { ...overrides };
+    if (editorMode === "automatic") {
+      delete nextOverrides[editingModelId];
+    } else {
+      const contextWindow = parseContextWindow(contextDraft);
+      if (contextWindow === undefined) {
+        setContextError(
+          `Enter a whole number between 1 and ${MAX_CONTEXT_WINDOW.toLocaleString("en-US")}.`,
+        );
+        return;
+      }
+      nextOverrides[editingModelId] = { contextWindow };
+    }
+    const { overrides: _currentOverrides, ...base } = preferences;
+    onChange({
+      ...base,
+      ...(Object.keys(nextOverrides).length > 0 ? { overrides: nextOverrides } : {}),
+    });
+    setEditingModelId(null);
   };
 
   return (
@@ -523,52 +596,190 @@ function ProviderModelsField({
           <span className="segmented-count">{preferences.selected.length}</span>
         </button>
       </div>
-      {preferences.mode === "selected" && (
-        <>
-          <div className="sidebar-search-wrap provider-model-search">
-            <Search size={15} className="sidebar-search-icon" />
-            <input
-              className="sidebar-search"
-              aria-label={`Search ${providerId} models`}
-              placeholder="Search models..."
-              value={query}
-              onChange={(event) => onQueryChange(event.target.value)}
-            />
-            {query && (
+      <div className="sidebar-search-wrap provider-model-search">
+        <Search size={15} className="sidebar-search-icon" />
+        <input
+          className="sidebar-search"
+          aria-label={`Search ${providerId} models`}
+          placeholder="Search models..."
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+        />
+        {query && (
+          <button
+            type="button"
+            className="sidebar-search-clear"
+            aria-label="Clear model search"
+            onClick={() => onQueryChange("")}
+          >
+            <X size={14} />
+          </button>
+        )}
+      </div>
+      <div className="provider-model-list">
+        {visible.length === 0 && (
+          <div className="provider-model-empty">{L.modelCatalogEmpty}</div>
+        )}
+        <TooltipProvider>
+          {visible.map((model) => {
+            const contextOverride = overrides[model.id];
+            const providerContextWindow = automaticContextWindow(model);
+            const modelCopy = (
+              <span className="provider-model-option-copy">
+                <span className="provider-model-option-name">
+                  {model.displayName}
+                  {model.savedOnly ? ` ${L.modelCatalogSavedOnly}` : ""}
+                </span>
+                <span className="provider-model-option-context">
+                  Context {formatContextWindow(
+                    contextOverride?.contextWindow ?? providerContextWindow,
+                  )}
+                  {contextOverride && <span className="provenance-badge user">Override</span>}
+                </span>
+              </span>
+            );
+            return (
+              <div className="provider-model-option" key={model.id}>
+                {preferences.mode === "selected" ? (
+                  <label className="provider-model-option-select selectable">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(model.id)}
+                      onChange={() => toggle(model.id)}
+                    />
+                    {modelCopy}
+                  </label>
+                ) : (
+                  <div className="provider-model-option-select">{modelCopy}</div>
+                )}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="provider-model-settings"
+                      aria-label={`Settings for ${model.displayName}`}
+                      onClick={() => openEditor(model.id)}
+                    >
+                      <Settings2 size={15} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent sideOffset={6}>Model settings</TooltipContent>
+                </Tooltip>
+              </div>
+            );
+          })}
+        </TooltipProvider>
+      </div>
+
+      <Dialog
+        open={editingModelId !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditingModelId(null);
+        }}
+      >
+        <DialogContent className="provider-model-settings-dialog">
+          <DialogHeader>
+            <DialogTitle className="provider-model-settings-title">
+              {editingModel?.displayName ?? editingModelId}
+            </DialogTitle>
+            <DialogDescription className="sr-only">
+              Configure model context window.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="provider-model-settings-body">
+            <div className="field-label">Context window</div>
+            <div
+              className="segmented provider-context-mode"
+              role="group"
+              aria-label="Context window source"
+            >
               <button
                 type="button"
-                className="sidebar-search-clear"
-                aria-label="Clear model search"
-                onClick={() => onQueryChange("")}
+                className={`segmented-btn${editorMode === "automatic" ? " active" : ""}`}
+                aria-pressed={editorMode === "automatic"}
+                onClick={() => {
+                  setEditorMode("automatic");
+                  setContextError(null);
+                }}
               >
-                <X size={14} />
+                Automatic
               </button>
+              <button
+                type="button"
+                className={`segmented-btn${editorMode === "override" ? " active" : ""}`}
+                aria-pressed={editorMode === "override"}
+                onClick={() => {
+                  setEditorMode("override");
+                  if (!contextDraft && detectedContextWindow) {
+                    setContextDraft(String(detectedContextWindow));
+                  }
+                  setContextError(null);
+                }}
+              >
+                Override
+              </button>
+            </div>
+            {editorMode === "automatic" ? (
+              <div className="provider-context-automatic">
+                <span>Provider value</span>
+                <strong>{formatContextWindow(detectedContextWindow, true)}</strong>
+              </div>
+            ) : (
+              <label className="field provider-context-input-field">
+                <span className="field-label">Tokens</span>
+                <input
+                  className="field-input"
+                  inputMode="numeric"
+                  autoFocus
+                  value={contextDraft}
+                  aria-invalid={contextError !== null}
+                  onChange={(event) => {
+                    setContextDraft(event.target.value);
+                    setContextError(null);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") applyEditor();
+                  }}
+                />
+              </label>
             )}
+            {contextError && <div className="provider-context-error">{contextError}</div>}
           </div>
-          <div className="provider-model-list">
-            {visible.length === 0 && (
-              <div className="provider-model-empty">{L.modelCatalogEmpty}</div>
-            )}
-            {visible.map((model) => {
-              return (
-                <label className="provider-model-option" key={model.id}>
-                  <input
-                    type="checkbox"
-                    checked={selected.has(model.id)}
-                    onChange={() => toggle(model.id)}
-                  />
-                  <span>
-                    {model.displayName}
-                    {model.savedOnly ? ` ${L.modelCatalogSavedOnly}` : ""}
-                  </span>
-                </label>
-              );
-            })}
-          </div>
-        </>
-      )}
+          <DialogFooter>
+            <DialogClose asChild>
+              <button type="button" className="btn-secondary">Cancel</button>
+            </DialogClose>
+            <button type="button" className="btn-primary" onClick={applyEditor}>
+              Done
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
+}
+
+export function parseContextWindow(value: string): number | undefined {
+  const normalized = value.trim().replace(/[,_\s]/g, "");
+  if (!/^\d+$/.test(normalized)) return undefined;
+  const parsed = Number(normalized);
+  return isValidContextWindow(parsed) ? parsed : undefined;
+}
+
+function automaticContextWindow(model: {
+  contextWindow?: number;
+  detectedContextWindow?: number;
+  contextWindowSource?: "override";
+} | undefined): number | undefined {
+  return model?.detectedContextWindow ??
+    (model?.contextWindowSource === "override" ? undefined : model?.contextWindow);
+}
+
+function formatContextWindow(value: number | undefined, full = false): string {
+  if (value === undefined) return "Not reported";
+  return new Intl.NumberFormat("en-US", full
+    ? { maximumFractionDigits: 0 }
+    : { notation: "compact", maximumFractionDigits: 1 }).format(value);
 }
 
 function FieldInput({

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -904,13 +904,62 @@ button.sidebar-folder-row:hover,
 }
 .provider-model-empty { padding: 12px; color: var(--dim); font-size: 12px; }
 .provider-model-option {
-  min-height: 38px; padding: 8px 10px; display: flex; align-items: center; gap: 9px;
-  color: var(--text); font-size: 13px; cursor: pointer;
+  min-height: 48px; padding: 6px 8px 6px 10px; display: flex; align-items: center; gap: 9px;
+  color: var(--text); font-size: 13px;
 }
 .provider-model-option + .provider-model-option { border-top: 1px solid var(--border); }
 .provider-model-option:hover { background: var(--panel-2); }
 .provider-model-option input { accent-color: var(--brand); }
-.provider-model-option span { min-width: 0; overflow-wrap: anywhere; }
+.provider-model-option-select {
+  display: flex; align-items: center; gap: 9px; min-width: 0; flex: 1;
+}
+.provider-model-option-select.selectable { cursor: pointer; }
+.provider-model-option-copy {
+  display: flex; flex-direction: column; min-width: 0; flex: 1; gap: 2px;
+}
+.provider-model-option-name {
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.provider-model-option-context {
+  display: flex; align-items: center; gap: 6px; min-height: 15px;
+  color: var(--dim); font-size: 11px;
+}
+.provider-model-option-context .provenance-badge {
+  min-width: 0; padding: 1px 5px; font-size: 9px;
+}
+.provider-model-settings {
+  display: grid; place-items: center; width: 30px; height: 30px; flex: 0 0 auto;
+  border: 1px solid transparent; border-radius: 6px;
+  background: transparent; color: var(--dim); cursor: pointer;
+}
+.provider-model-settings:hover {
+  border-color: var(--border); background: var(--panel); color: var(--text);
+}
+.provider-model-settings:focus-visible {
+  outline: 2px solid var(--brand); outline-offset: 1px;
+}
+.provider-model-settings-dialog {
+  width: min(430px, calc(100vw - 28px)); gap: 18px; border-radius: 8px;
+  background: var(--panel); color: var(--text);
+}
+.provider-model-settings-title {
+  max-width: calc(100% - 28px); overflow-wrap: anywhere;
+  font-size: 15px; line-height: 1.35;
+}
+.provider-model-settings-body { display: grid; gap: 10px; }
+.provider-context-mode { width: 100%; }
+.provider-context-mode .segmented-btn { flex: 1 1 0; }
+.provider-context-automatic {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  min-height: 40px; padding: 0 11px; border: 1px solid var(--border);
+  border-radius: 7px; background: var(--panel-2); color: var(--dim); font-size: 12px;
+}
+.provider-context-automatic strong {
+  color: var(--text); font-size: 13px; font-variant-numeric: tabular-nums;
+}
+.provider-context-input-field { margin: 0; }
+.provider-context-input-field .field-input { font-variant-numeric: tabular-nums; }
+.provider-context-error { color: var(--danger, #e5484d); font-size: 12px; }
 
 .composer-send {
   display: inline-flex; align-items: center; justify-content: center;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -182,7 +182,9 @@ in `core/src/protocol-types.ts`:
   cross-thread.
 - **Model context limits** are resolved by each inference-provider adapter from
   effective local configuration or provider metadata, with models.dev filling
-  missing catalog fields. The adapter publishes the same available limit as
+  missing catalog fields. An optional model-specific user override is persisted
+  with provider model preferences and takes precedence over discovered metadata.
+  The registry publishes the effective limit as
   `ModelDescriptor.contextWindow` for clients and
   `model.profile.maxInputTokens` for DeepAgents summarization. Native LangChain
   profiles remain the fallback when catalog metadata is unavailable.

--- a/packages/core/src/model-provider.test.ts
+++ b/packages/core/src/model-provider.test.ts
@@ -5,6 +5,7 @@ import {
   ModelRegistry,
   ModelUnavailableError,
   recommendedModelCandidates,
+  type ModelBuildOptions,
   type ModelDescriptor,
   type ModelProvider,
 } from "./model-provider.js";
@@ -12,7 +13,7 @@ import {
 function stubProvider(opts: {
   id?: string;
   models?: ModelDescriptor[];
-  build?: (modelId: string) => Promise<BaseChatModel>;
+  build?: (modelId: string, options?: ModelBuildOptions) => Promise<BaseChatModel>;
   onBuild?: (modelId: string) => void;
 }): ModelProvider {
   const id = opts.id ?? "stub";
@@ -24,9 +25,9 @@ function stubProvider(opts: {
     async listModels() {
       return models;
     },
-    async buildModel(modelId: string) {
+    async buildModel(modelId: string, options?: ModelBuildOptions) {
       opts.onBuild?.(modelId);
-      if (opts.build) return opts.build(modelId);
+      if (opts.build) return opts.build(modelId, options);
       return { modelId } as unknown as BaseChatModel;
     },
   };
@@ -114,6 +115,25 @@ describe("ModelRegistry.resolveModel (requested selection)", () => {
     expect(err.code).toBe("AUTH_EXPIRED");
     expect(err.message).toContain("unavailable");
   });
+
+  it("projects a model-specific context override into the built model profile", async () => {
+    const registry = new ModelRegistry();
+    registry.register(stubProvider({
+      build: async (_modelId, options) => ({
+        profile: { toolCalling: true, maxInputTokens: options?.contextWindow ?? 128_000 },
+      }) as unknown as BaseChatModel,
+    }));
+    registry.setModelOverrides("stub", {
+      "private-deployment": { contextWindow: 32_768 },
+    });
+
+    const model = await registry.resolveModel("stub:private-deployment");
+
+    expect(model.profile).toMatchObject({
+      toolCalling: true,
+      maxInputTokens: 32_768,
+    });
+  });
 });
 
 describe("ModelRegistry.listAll", () => {
@@ -154,6 +174,54 @@ describe("ModelRegistry.listAll", () => {
 
     registry.setEnabledModels("stub", undefined);
     await expect(registry.listAll()).resolves.toHaveLength(2);
+  });
+
+  it("overrides catalog context per model and restores discovered metadata", async () => {
+    const registry = new ModelRegistry();
+    registry.register(stubProvider({
+      models: [{
+        id: "model-a",
+        provider: "stub",
+        displayName: "Model A",
+        contextWindow: 128_000,
+      }],
+    }));
+    registry.setModelOverrides("stub", {
+      "model-a": { contextWindow: 32_768 },
+    });
+
+    await expect(registry.listAll()).resolves.toEqual([
+      expect.objectContaining({
+        id: "model-a",
+        contextWindow: 32_768,
+        detectedContextWindow: 128_000,
+        contextWindowSource: "override",
+      }),
+    ]);
+
+    registry.setModelOverrides("stub", undefined);
+    await expect(registry.listAll()).resolves.toEqual([
+      expect.objectContaining({
+        id: "model-a",
+        contextWindow: 128_000,
+      }),
+    ]);
+  });
+
+  it("detects override changes without depending on object key order", () => {
+    const registry = new ModelRegistry();
+    expect(registry.setModelOverrides("stub", {
+      "model-a": { contextWindow: 32_768 },
+      "model-b": { contextWindow: 65_536 },
+    })).toBe(true);
+    expect(registry.setModelOverrides("stub", {
+      "model-b": { contextWindow: 65_536 },
+      "model-a": { contextWindow: 32_768 },
+    })).toBe(false);
+    expect(registry.setModelOverrides("stub", {
+      "model-a": { contextWindow: 32_768 },
+      "model-b": { contextWindow: 131_072 },
+    })).toBe(true);
   });
 
   it("reports provider failures without hiding successful catalogs", async () => {

--- a/packages/core/src/model-provider.ts
+++ b/packages/core/src/model-provider.ts
@@ -1,12 +1,15 @@
 /** Provider-agnostic registry keyed by `provider:model`. */
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type { ErrorCode } from "./protocol-types.js";
+import type { ModelOverrides } from "./provider-config.js";
 
 export interface ModelDescriptor {
   id: string;
   provider: string;
   displayName: string;
   contextWindow?: number;
+  detectedContextWindow?: number;
+  contextWindowSource?: "override";
   maxOutputTokens?: number;
   supportsTools?: boolean;
   supportsVision?: boolean;
@@ -145,10 +148,14 @@ export interface ResolvedProviderConfig {
   values: Record<string, string>;
 }
 
+export interface ModelBuildOptions {
+  contextWindow?: number;
+}
+
 export interface ModelProvider {
   readonly id: string;
   listModels(): Promise<ModelDescriptor[]>;
-  buildModel(modelId: string): Promise<BaseChatModel>;
+  buildModel(modelId: string, options?: ModelBuildOptions): Promise<BaseChatModel>;
   readonly authSchema?: readonly ProviderAuthMethod[];
   /** The provider can use ambient credentials or defaults without saved config. */
   readonly availableWithoutConfig?: boolean;
@@ -212,6 +219,7 @@ export class ModelRegistry {
   private catalogGeneration = 0;
   private lastGoodModels = new Map<string, ModelDescriptor[]>();
   private enabledModels = new Map<string, Set<string>>();
+  private modelOverrides = new Map<string, Map<string, ModelOverrides>>();
 
   register(provider: ModelProvider): void {
     this.providers.set(provider.id, provider);
@@ -233,6 +241,39 @@ export class ModelRegistry {
     else this.enabledModels.set(providerId, new Set(modelIds));
   }
 
+  setModelOverrides(
+    providerId: string,
+    overrides: Readonly<Record<string, ModelOverrides>> | undefined,
+  ): boolean {
+    const entries = Object.entries(overrides ?? {});
+    const previous = this.modelOverrides.get(providerId);
+    if (
+      (previous?.size ?? 0) === entries.length &&
+      entries.every(([modelId, value]) =>
+        previous?.get(modelId)?.contextWindow === value.contextWindow
+      )
+    ) {
+      return false;
+    }
+    if (entries.length === 0) {
+      this.modelOverrides.delete(providerId);
+      return true;
+    }
+    this.modelOverrides.set(
+      providerId,
+      new Map(entries.map(([modelId, value]) => [modelId, { ...value }])),
+    );
+    return true;
+  }
+
+  getModelOverrides(providerId: string): Record<string, ModelOverrides> | undefined {
+    const overrides = this.modelOverrides.get(providerId);
+    if (!overrides) return undefined;
+    return Object.fromEntries(
+      [...overrides].map(([modelId, value]) => [modelId, { ...value }]),
+    );
+  }
+
   private parse(qualified: string): { provider: string; modelId: string } | undefined {
     const idx = qualified.indexOf(":");
     if (idx <= 0 || idx === qualified.length - 1) return undefined;
@@ -244,7 +285,14 @@ export class ModelRegistry {
     if (!parsed) throw new Error(`Model id "${qualified}" must be "provider:model".`);
     const p = this.providers.get(parsed.provider);
     if (!p) throw new Error(`No model provider registered for "${parsed.provider}".`);
-    return p.buildModel(parsed.modelId);
+    const contextWindow = this.modelOverrides
+      .get(parsed.provider)
+      ?.get(parsed.modelId)
+      ?.contextWindow;
+    return p.buildModel(
+      parsed.modelId,
+      contextWindow === undefined ? undefined : { contextWindow },
+    );
   }
 
   async validate(qualified: string): Promise<ModelAvailability> {
@@ -261,7 +309,13 @@ export class ModelRegistry {
       };
     }
     // Discovery is advisory and may itself be unavailable for remote providers.
-    const descriptor = (await p.listModels().catch(() => [])).find((d) => d.id === parsed.modelId);
+    const discovered = (await p.listModels().catch(() => [])).find((d) => d.id === parsed.modelId);
+    const descriptor = discovered
+      ? this.applyDescriptorOverrides(
+          discovered,
+          this.modelOverrides.get(parsed.provider)?.get(parsed.modelId),
+        )
+      : undefined;
     return {
       available: true,
       provider: parsed.provider,
@@ -281,7 +335,14 @@ export class ModelRegistry {
     }
     const p = this.providers.get(check.provider)!;
     try {
-      return await p.buildModel(check.modelId);
+      const contextWindow = this.modelOverrides
+        .get(check.provider)
+        ?.get(check.modelId)
+        ?.contextWindow;
+      return await p.buildModel(
+        check.modelId,
+        contextWindow === undefined ? undefined : { contextWindow },
+      );
     } catch (err) {
       const code = codeOf(err);
       throw new ModelUnavailableError(
@@ -301,13 +362,34 @@ export class ModelRegistry {
     options: { includeDisabled?: boolean; refresh?: boolean } = {},
   ): Promise<ModelCatalogSnapshot> {
     const snapshot = await this.loadCatalog(options.refresh === true);
-    const models = options.includeDisabled
+    const enabledModels = options.includeDisabled
       ? snapshot.models
       : snapshot.models.filter((model) => {
           const enabled = this.enabledModels.get(model.provider);
           return enabled === undefined || enabled.has(model.id);
         });
+    const models = enabledModels.map((model) =>
+      this.applyDescriptorOverrides(
+        model,
+        this.modelOverrides.get(model.provider)?.get(model.id),
+      )
+    );
     return { models, providers: snapshot.providers };
+  }
+
+  private applyDescriptorOverrides(
+    descriptor: ModelDescriptor,
+    overrides: ModelOverrides | undefined,
+  ): ModelDescriptor {
+    if (!overrides) return descriptor;
+    return {
+      ...descriptor,
+      ...(descriptor.contextWindow !== undefined
+        ? { detectedContextWindow: descriptor.contextWindow }
+        : {}),
+      contextWindow: overrides.contextWindow,
+      contextWindowSource: "override",
+    };
   }
 
   private async loadCatalog(refresh: boolean): Promise<ModelCatalogSnapshot> {

--- a/packages/core/src/provider-config.ts
+++ b/packages/core/src/provider-config.ts
@@ -7,6 +7,45 @@ export interface SavedProviderConfig {
 export interface ProviderModelPreferences {
   mode: "all" | "selected";
   selected: string[];
+  overrides?: Record<string, ModelOverrides>;
+}
+
+export interface ModelOverrides {
+  contextWindow: number;
+}
+
+export const MAX_CONTEXT_WINDOW = 10_000_000;
+export const MAX_MODEL_OVERRIDES = 5_000;
+
+export function isValidContextWindow(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0 &&
+    (value as number) <= MAX_CONTEXT_WINDOW;
+}
+
+export function parseModelOverrides(
+  value: unknown,
+): NonNullable<ProviderModelPreferences["overrides"]> | null {
+  if (value === undefined) return {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const entries = Object.entries(value);
+  if (entries.length > MAX_MODEL_OVERRIDES) return null;
+
+  const overrides: NonNullable<ProviderModelPreferences["overrides"]> = {};
+  for (const [modelId, candidate] of entries) {
+    if (
+      !modelId ||
+      modelId.length > 512 ||
+      !candidate ||
+      typeof candidate !== "object" ||
+      Array.isArray(candidate)
+    ) {
+      return null;
+    }
+    const contextWindow = (candidate as { contextWindow?: unknown }).contextWindow;
+    if (!isValidContextWindow(contextWindow)) return null;
+    overrides[modelId] = { contextWindow };
+  }
+  return overrides;
 }
 
 const ENV_REFERENCE = /^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/;

--- a/packages/inference-providers/src/loader.ts
+++ b/packages/inference-providers/src/loader.ts
@@ -36,5 +36,6 @@ export async function registerBuiltinProviders(registry: ModelRegistry, configs?
     if (preferences?.mode === "selected") {
       registry.setEnabledModels(provider.id, preferences.selected);
     }
+    registry.setModelOverrides(provider.id, preferences?.overrides);
   }
 }

--- a/packages/inference-providers/src/providers/anthropic.ts
+++ b/packages/inference-providers/src/providers/anthropic.ts
@@ -1,6 +1,12 @@
 /** Anthropic-direct provider backed by lazy-loaded `ChatAnthropic`. */
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import type { ModelProvider, ModelDescriptor, ResolvedProviderConfig, ProviderAuthMethod } from "@pizza-bot/core";
+import type {
+  ModelBuildOptions,
+  ModelProvider,
+  ModelDescriptor,
+  ResolvedProviderConfig,
+  ProviderAuthMethod,
+} from "@pizza-bot/core";
 import {
   enrichModelDescriptors,
   resolveModelsDevCatalog,
@@ -192,9 +198,12 @@ export class AnthropicLangChainModelProvider implements ModelProvider {
     }
   }
 
-  async buildModel(modelId: string): Promise<BaseChatModel> {
+  async buildModel(
+    modelId: string,
+    options: ModelBuildOptions = {},
+  ): Promise<BaseChatModel> {
     try {
-      return await this.construct(modelId);
+      return await this.construct(modelId, options);
     } catch (err) {
       const code = translateAnthropicError(err);
       if (code)
@@ -203,7 +212,10 @@ export class AnthropicLangChainModelProvider implements ModelProvider {
     }
   }
 
-  private async construct(modelId: string): Promise<BaseChatModel> {
+  private async construct(
+    modelId: string,
+    options: ModelBuildOptions,
+  ): Promise<BaseChatModel> {
     const apiKey = this.apiKey ?? process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
       throw new AnthropicBuildError("No Anthropic API key configured (set ANTHROPIC_API_KEY).", "AUTH_EXPIRED");
@@ -219,6 +231,9 @@ export class AnthropicLangChainModelProvider implements ModelProvider {
       baseUrl: this.resolvedBaseUrl(),
       authMode: this.authMode,
       fetch: this.fetchFn,
+      ...(options.contextWindow !== undefined
+        ? { contextWindow: options.contextWindow }
+        : {}),
       ...(descriptor ? { descriptor } : {}),
     });
   }
@@ -246,6 +261,7 @@ export interface AnthropicChatModelOptions {
   baseUrl: string;
   authMode: AnthropicAuthMode;
   descriptor?: ModelDescriptor;
+  contextWindow?: number;
   fetch?: typeof fetch;
 }
 
@@ -260,6 +276,7 @@ export async function createAnthropicChatModel(
     baseUrl,
     authMode,
     descriptor,
+    contextWindow,
     fetch: fetchFn,
   } = options;
   const defaultHeaders = authMode === "bearer"
@@ -271,7 +288,10 @@ export async function createAnthropicChatModel(
 
   class ContextAwareChatAnthropic extends ChatAnthropic {
     override get profile() {
-      return withContextWindow(super.profile, descriptor?.contextWindow);
+      return withContextWindow(
+        super.profile,
+        contextWindow ?? descriptor?.contextWindow,
+      );
     }
   }
 

--- a/packages/inference-providers/src/providers/bedrock/langchain.ts
+++ b/packages/inference-providers/src/providers/bedrock/langchain.ts
@@ -2,6 +2,7 @@
 import type { BaseMessage } from "@langchain/core/messages";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type {
+  ModelBuildOptions,
   ModelProvider,
   ModelDescriptor,
   ProviderAuthMethod,
@@ -258,9 +259,12 @@ export class BedrockLangChainModelProvider implements ModelProvider {
     };
   }
 
-  async buildModel(modelId: string): Promise<BaseChatModel> {
+  async buildModel(
+    modelId: string,
+    options: ModelBuildOptions = {},
+  ): Promise<BaseChatModel> {
     try {
-      return await this.construct(modelId);
+      return await this.construct(modelId, options);
     } catch (err) {
       const code = translateBedrockError(err);
       if (code) throw new BedrockBuildError(err instanceof Error ? err.message : String(err), code, { cause: err });
@@ -268,7 +272,10 @@ export class BedrockLangChainModelProvider implements ModelProvider {
     }
   }
 
-  private async construct(modelId: string): Promise<BaseChatModel> {
+  private async construct(
+    modelId: string,
+    options: ModelBuildOptions,
+  ): Promise<BaseChatModel> {
     if (!this.descriptors.has(modelId)) {
       await this.listModels().catch(() => []);
     }
@@ -292,6 +299,9 @@ export class BedrockLangChainModelProvider implements ModelProvider {
           : `${mantleEndpoint(this.region)}/v1`,
         fetch: await this.mantleFetch(),
         learnedMaxTokens: this.learnedMaxTokens,
+        ...(options.contextWindow !== undefined
+          ? { contextWindow: options.contextWindow }
+          : {}),
         ...(descriptor ? { descriptor } : {}),
       });
     }
@@ -306,16 +316,22 @@ export class BedrockLangChainModelProvider implements ModelProvider {
         baseUrl: `${mantleEndpoint(this.region)}/anthropic`,
         authMode: "api-key",
         fetch: await this.mantleFetch(),
+        ...(options.contextWindow !== undefined
+          ? { contextWindow: options.contextWindow }
+          : {}),
         ...(descriptor ? { descriptor } : {}),
       });
     }
 
-    return this.constructConverse(modelId, descriptor);
+    return this.constructConverse(
+      modelId,
+      options.contextWindow ?? descriptor?.contextWindow,
+    );
   }
 
   private async constructConverse(
     modelId: string,
-    descriptor: ModelDescriptor | undefined,
+    contextWindow: number | undefined,
   ): Promise<BaseChatModel> {
     const { ChatBedrockConverse } = await import("@langchain/aws");
     const reasoning = supportsReasoning(modelId);
@@ -324,7 +340,7 @@ export class BedrockLangChainModelProvider implements ModelProvider {
     // from this dynamically imported class, so only `messages` remains typed.
     class ReasoningSafeChatBedrockConverse extends ChatBedrockConverse {
       override get profile() {
-        return withContextWindow(super.profile, descriptor?.contextWindow);
+        return withContextWindow(super.profile, contextWindow);
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/inference-providers/src/providers/google.ts
+++ b/packages/inference-providers/src/providers/google.ts
@@ -5,6 +5,7 @@ import type { BaseMessage } from "@langchain/core/messages";
 import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import type { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
 import type {
+  ModelBuildOptions,
   ModelDescriptor,
   ModelProvider,
   ProviderAuthMethod,
@@ -166,9 +167,12 @@ export class GoogleLangChainModelProvider implements ModelProvider {
     }
   }
 
-  async buildModel(modelId: string): Promise<BaseChatModel> {
+  async buildModel(
+    modelId: string,
+    options: ModelBuildOptions = {},
+  ): Promise<BaseChatModel> {
     try {
-      return await this.construct(modelId);
+      return await this.construct(modelId, options);
     } catch (error) {
       const code = translateGoogleError(error);
       if (code) {
@@ -182,7 +186,10 @@ export class GoogleLangChainModelProvider implements ModelProvider {
     }
   }
 
-  private async construct(modelId: string): Promise<BaseChatModel> {
+  private async construct(
+    modelId: string,
+    options: ModelBuildOptions,
+  ): Promise<BaseChatModel> {
     const { ChatGoogle } = await import("@langchain/google/node");
     const apiKey = this.resolveApiKey();
     if (!apiKey) {
@@ -203,7 +210,10 @@ export class GoogleLangChainModelProvider implements ModelProvider {
     );
     class ThoughtSignatureSafeChatGoogle extends ChatGoogle {
       override get profile() {
-        return withContextWindow(super.profile, descriptor?.contextWindow);
+        return withContextWindow(
+          super.profile,
+          options.contextWindow ?? descriptor?.contextWindow,
+        );
       }
 
       override async _generate(

--- a/packages/inference-providers/src/providers/ollama.test.ts
+++ b/packages/inference-providers/src/providers/ollama.test.ts
@@ -57,6 +57,12 @@ describe("Ollama model discovery", () => {
 
     const model = await provider.buildModel("small:latest");
     expect(model.profile.maxInputTokens).toBe(8_192);
+
+    const overridden = await provider.buildModel("small:latest", {
+      contextWindow: 16_384,
+    }) as typeof model & { numCtx?: number };
+    expect(overridden.numCtx).toBe(16_384);
+    expect(overridden.profile.maxInputTokens).toBe(16_384);
   });
 
   it("replaces a cleared custom host with the environment fallback", async () => {

--- a/packages/inference-providers/src/providers/ollama.ts
+++ b/packages/inference-providers/src/providers/ollama.ts
@@ -5,7 +5,13 @@ import { AIMessage, AIMessageChunk, type BaseMessage } from "@langchain/core/mes
 import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import type { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
 import type { ChatModelStreamEvent } from "@langchain/core/language_models/event";
-import type { ModelProvider, ModelDescriptor, ResolvedProviderConfig, ProviderAuthMethod } from "@pizza-bot/core";
+import type {
+  ModelBuildOptions,
+  ModelProvider,
+  ModelDescriptor,
+  ResolvedProviderConfig,
+  ProviderAuthMethod,
+} from "@pizza-bot/core";
 import {
   buildToolArgNames,
   coerceOllamaMessageContent,
@@ -122,7 +128,10 @@ export class OllamaLangChainModelProvider implements ModelProvider {
     }));
   }
 
-  async buildModel(modelId: string): Promise<BaseChatModel> {
+  async buildModel(
+    modelId: string,
+    options: ModelBuildOptions = {},
+  ): Promise<BaseChatModel> {
     const { ChatOllama } = await import("@langchain/ollama");
     const runSignal = new AsyncLocalStorage<AbortSignal>();
     const fetchWithRunSignal: typeof fetch = (input, init) => {
@@ -130,7 +139,8 @@ export class OllamaLangChainModelProvider implements ModelProvider {
       return this.fetchFn(input, signal ? { ...init, signal } : init);
     };
     const details = await this.inspectModel(modelId);
-    const numCtx = this.effectiveContextWindow(details);
+    // Explicit overrides are authoritative request-level KV cache sizes.
+    const numCtx = options.contextWindow ?? this.effectiveContextWindow(details);
     const think = this.thinking === "enabled" ||
       (this.thinking === "auto" && details?.capabilities?.includes("thinking") === true);
     const modelProfile = {

--- a/packages/inference-providers/src/providers/openai.ts
+++ b/packages/inference-providers/src/providers/openai.ts
@@ -8,6 +8,7 @@ import type { ChatModelStreamEvent } from "@langchain/core/language_models/event
 import type { ChatOpenAIFields } from "@langchain/openai";
 import {
   classifyError,
+  type ModelBuildOptions,
   type ModelProvider,
   type ModelDescriptor,
   type ResolvedProviderConfig,
@@ -200,9 +201,12 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
     }
   }
 
-  async buildModel(modelId: string): Promise<BaseChatModel> {
+  async buildModel(
+    modelId: string,
+    options: ModelBuildOptions = {},
+  ): Promise<BaseChatModel> {
     try {
-      return await this.construct(modelId);
+      return await this.construct(modelId, options);
     } catch (err) {
       const code = translateOpenAIError(err);
       if (code)
@@ -211,7 +215,10 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
     }
   }
 
-  private async construct(modelId: string): Promise<BaseChatModel> {
+  private async construct(
+    modelId: string,
+    options: ModelBuildOptions,
+  ): Promise<BaseChatModel> {
     const apiKey = this.apiKey ?? process.env.OPENAI_API_KEY;
     if (!apiKey) {
       throw new OpenAiBuildError("No OpenAI API key configured (set OPENAI_API_KEY).", "AUTH_EXPIRED");
@@ -237,6 +244,9 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
       apiMode: this.apiMode,
       learnedMaxTokens,
       fetch: this.fetchFn,
+      ...(options.contextWindow !== undefined
+        ? { contextWindow: options.contextWindow }
+        : {}),
       ...(descriptor ? { descriptor } : {}),
       ...(configuredBaseUrl ? { baseUrl: configuredBaseUrl } : {}),
     });
@@ -249,6 +259,7 @@ export interface OpenAiChatModelOptions {
   maxTokens: number;
   apiMode: OpenAiApiMode;
   descriptor?: ModelDescriptor;
+  contextWindow?: number;
   learnedMaxTokens?: Map<string, number>;
   baseUrl?: string;
   fetch?: typeof fetch;
@@ -319,6 +330,7 @@ export async function createOpenAiChatModel(
     maxTokens,
     apiMode,
     descriptor,
+    contextWindow,
     learnedMaxTokens,
     baseUrl,
     fetch: fetchFn,
@@ -340,7 +352,10 @@ export async function createOpenAiChatModel(
 
   class DialectChatOpenAI extends ChatOpenAI {
     override get profile() {
-      return withContextWindow(super.profile, descriptor?.contextWindow);
+      return withContextWindow(
+        super.profile,
+        contextWindow ?? descriptor?.contextWindow,
+      );
     }
 
     private outbound(messages: BaseMessage[]): BaseMessage[] {

--- a/packages/inference-providers/src/providers/openrouter.ts
+++ b/packages/inference-providers/src/providers/openrouter.ts
@@ -1,6 +1,7 @@
 /** OpenRouter provider backed by the native LangChain `ChatOpenRouter` integration. */
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type {
+  ModelBuildOptions,
   ModelDescriptor,
   ModelProvider,
   ProviderAuthMethod,
@@ -170,7 +171,10 @@ export class OpenRouterLangChainModelProvider implements ModelProvider {
     }
   }
 
-  async buildModel(modelId: string): Promise<BaseChatModel> {
+  async buildModel(
+    modelId: string,
+    options: ModelBuildOptions = {},
+  ): Promise<BaseChatModel> {
     const { ChatOpenRouter } = await import("@langchain/openrouter");
     const apiKey = this.resolveApiKey();
     if (!apiKey) {
@@ -191,7 +195,10 @@ export class OpenRouterLangChainModelProvider implements ModelProvider {
 
     class ContextAwareChatOpenRouter extends ChatOpenRouter {
       override get profile() {
-        return withContextWindow(super.profile, descriptor?.contextWindow);
+        return withContextWindow(
+          super.profile,
+          options.contextWindow ?? descriptor?.contextWindow,
+        );
       }
     }
 

--- a/packages/storage/src/provider-configs.test.ts
+++ b/packages/storage/src/provider-configs.test.ts
@@ -21,12 +21,74 @@ describe("ProviderConfigStore model preferences", () => {
     db.close();
   });
 
+  it("persists model-specific context-window overrides", () => {
+    const db = new Database(":memory:");
+    const store = new ProviderConfigStore(db);
+
+    store.setModelPreferences("openai", {
+      mode: "all",
+      selected: [],
+      overrides: {
+        "private-large": { contextWindow: 131_072 },
+        "private-small": { contextWindow: 32_768 },
+      },
+    });
+
+    expect(store.getModelPreferences("openai")).toEqual({
+      mode: "all",
+      selected: [],
+      overrides: {
+        "private-large": { contextWindow: 131_072 },
+        "private-small": { contextWindow: 32_768 },
+      },
+    });
+    db.close();
+  });
+
   it("ignores corrupt persisted preferences", () => {
     const db = new Database(":memory:");
     const store = new ProviderConfigStore(db);
     db.prepare(
       "INSERT INTO provider_model_preferences (provider_id, preferences, updated_at) VALUES (?, ?, ?)",
     ).run("openai", "{\"mode\":\"selected\",\"selected\":\"nope\"}", new Date().toISOString());
+
+    expect(store.getModelPreferences("openai")).toBeUndefined();
+    db.close();
+  });
+
+  it("ignores invalid persisted context-window overrides", () => {
+    const db = new Database(":memory:");
+    const store = new ProviderConfigStore(db);
+    db.prepare(
+      "INSERT INTO provider_model_preferences (provider_id, preferences, updated_at) VALUES (?, ?, ?)",
+    ).run(
+      "openai",
+      JSON.stringify({
+        mode: "all",
+        selected: [],
+        overrides: { "private-deployment": { contextWindow: -1 } },
+      }),
+      new Date().toISOString(),
+    );
+
+    expect(store.getModelPreferences("openai")).toBeUndefined();
+    db.close();
+  });
+
+  it("ignores persisted context windows above the supported bound", () => {
+    const db = new Database(":memory:");
+    const store = new ProviderConfigStore(db);
+    db.prepare(
+      "INSERT INTO provider_model_preferences (provider_id, preferences, updated_at) VALUES (?, ?, ?)",
+    ).run(
+      "openai",
+      JSON.stringify({
+        mode: "all",
+        selected: [],
+        overrides: { "private-deployment": { contextWindow: 10_000_001 } },
+      }),
+      new Date().toISOString(),
+    );
 
     expect(store.getModelPreferences("openai")).toBeUndefined();
     db.close();

--- a/packages/storage/src/provider-configs.ts
+++ b/packages/storage/src/provider-configs.ts
@@ -1,9 +1,10 @@
 /** Persists provider settings as environment-variable references, never secrets. */
 import Database from "better-sqlite3";
-import type {
-  ProviderConfigPort,
-  ProviderModelPreferences,
-  SavedProviderConfig,
+import {
+  parseModelOverrides,
+  type ProviderConfigPort,
+  type ProviderModelPreferences,
+  type SavedProviderConfig,
 } from "@pizza-bot/core";
 
 interface ConfigRow {
@@ -158,12 +159,18 @@ function parseConfig(json: string): SavedProviderConfig | undefined {
 function parseModelPreferences(json: string): ProviderModelPreferences | undefined {
   try {
     const parsed = JSON.parse(json) as Partial<ProviderModelPreferences>;
+    const overrides = parseModelOverrides(parsed.overrides);
     if (
       (parsed.mode === "all" || parsed.mode === "selected") &&
       Array.isArray(parsed.selected) &&
-      parsed.selected.every((id) => typeof id === "string")
+      parsed.selected.every((id) => typeof id === "string") &&
+      overrides !== null
     ) {
-      return { mode: parsed.mode, selected: [...new Set(parsed.selected)] };
+      return {
+        mode: parsed.mode,
+        selected: [...new Set(parsed.selected)],
+        ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
+      };
     }
   } catch {
     // Ignore corrupt records.


### PR DESCRIPTION
Closes #27.

## Summary
- add per-model context-window overrides to provider settings
- apply effective limits through each inference-provider adapter, including Ollama request-level `num_ctx`
- validate and persist overrides with transactional runtime rollback
- serialize concurrent preference updates and preserve provider-detected values in the UI

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- desktop and mobile browser checks