### PR TITLE
feat: prepare versioned plugin contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@ frontend consumes them through the `@langchain/langgraph-sdk`
   message/thread-slice projection helpers live in `apps/web/src/projection` — the
   only consumer is the web app, so they sit beside it rather than in a shared
   package. The eslint layering rule enforces core's purity.
+- `packages/plugin-api` is the public, browser-safe plugin contract — no
+  `node:*`, LangChain, runtime, or UI imports. `packages/plugin-sdk` owns the
+  Node-bound filesystem loader, materializers, MCP clients, and contribution
+  registries. The eslint layering rule enforces plugin-api's purity.
 - **`packages/runtime-langgraph` is the ONLY production package that imports
   `deepagents` — the graph engine.** The `tests/langgraph-compat` workspace is a
   test-only exception because it pins DeepAgents' public exports. If the

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ references, skill authoring, approval gates, and plugin installation.
 
 ```text
 apps/        api-server (Hono) | cli | desktop-shell (Electron) | web (React)
-packages/    core | runtime-langgraph | inference-providers | plugin-sdk | storage | logging
+packages/    core | runtime-langgraph | inference-providers | plugin-api | plugin-sdk | storage | logging
 plugins/     bundled Plugin packages and their packaging workspace
 skills/      optional Built-in Agent Skills
 tests/       LangGraph compatibility and protocol conformance

--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -32,6 +32,7 @@
     "@langchain/langgraph-sdk": "~1.9.28",
     "@pizza-bot/core": "*",
     "@pizza-bot/logging": "*",
+    "@pizza-bot/plugin-api": "*",
     "@pizza-bot/plugin-sdk": "*",
     "@pizza-bot/inference-providers": "*",
     "@pizza-bot/runtime-langgraph": "*",

--- a/apps/api-server/src/agent-host-mcp.test.ts
+++ b/apps/api-server/src/agent-host-mcp.test.ts
@@ -11,7 +11,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { McpServerEntry } from "@pizza-bot/plugin-sdk";
+import type { McpServerEntry } from "@pizza-bot/plugin-api";
 import { AgentHost } from "./agent-host.js";
 import { buildApp } from "./index.js";
 

--- a/apps/api-server/src/agent-host.test.ts
+++ b/apps/api-server/src/agent-host.test.ts
@@ -7,7 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import type { ProtocolEvent } from "@langchain/langgraph";
 import {
   PIZZA_BOT_AGENT,
@@ -15,7 +15,7 @@ import {
   type RunOptions,
   type ThreadState,
 } from "@pizza-bot/core";
-import { pluginManifestSchema } from "@pizza-bot/plugin-sdk";
+import { pluginManifestSchema } from "@pizza-bot/plugin-api";
 import { AgentHost } from "./agent-host.js";
 import type { ImportedPlugin } from "./plugin-import.js";
 
@@ -97,6 +97,21 @@ describe("AgentHost lifecycle and identity", () => {
 
   it("keeps user skills under the data root", async () => {
     expect(await host.skillsDirectory()).toBe(join(dataRoot, "skills"));
+  });
+
+  it("rejects unsafe plugin management names", async () => {
+    const outsideName = `${basename(dataRoot)}-outside`;
+    const outside = join(dataRoot, "..", outsideName);
+    mkdirSync(join(outside, ".claude-plugin"), { recursive: true });
+    try {
+      expect(await host.pluginIsInstalled(`../../${outsideName}`)).toBe(false);
+      await expect(
+        host.deletePlugin(`../../${outsideName}`),
+      ).resolves.toBe(false);
+      expect(existsSync(join(outside, ".claude-plugin"))).toBe(true);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 
   it("loads and removes a user skill", async () => {

--- a/apps/api-server/src/agent-host.ts
+++ b/apps/api-server/src/agent-host.ts
@@ -49,6 +49,7 @@ import {
 } from "@pizza-bot/storage";
 import {
   loadPlugins,
+  createPluginHostContract,
   loadBuiltinSkills,
   loadUserSkills,
   loadUserMcpServers,
@@ -60,11 +61,15 @@ import {
   type McpConnectResult,
   type McpConnectionEvent,
   type LoadedPlugins,
-  type PluginMaterializerReason,
   type ToolCatalog,
 } from "@pizza-bot/plugin-sdk";
 import { McpHealthMonitor, type McpClientLike } from "./mcp-health-monitor.js";
-import type { McpServerEntry } from "@pizza-bot/plugin-sdk";
+import {
+  pluginNameSchema,
+  type McpServerEntry,
+  type PluginMaterializerReason,
+} from "@pizza-bot/plugin-api";
+import apiPackage from "../package.json" with { type: "json" };
 import {
   resolvePluginsDir,
   resolveExternalPluginsDirs,
@@ -93,6 +98,7 @@ import { getLogger, redactDiagnosticText } from "@pizza-bot/logging";
 
 const mcpLog = getLogger("mcp");
 const LAST_RESORT_MODEL = "bedrock:global.anthropic.claude-sonnet-5";
+const PLUGIN_HOST_CONTRACT = createPluginHostContract(apiPackage.version);
 
 function stateAwaitsAction(state: ThreadState): boolean {
   if (state.awaitingInput === true || (state.interrupts?.length ?? 0) > 0) {
@@ -1462,6 +1468,7 @@ export class AgentHost {
     const userEntries = await this.loadUserMcpEntries();
     const next = await loadPlugins({
       pluginsDir: this.pluginDirs,
+      hostContract: PLUGIN_HOST_CONTRACT,
       extraMcpServers: userEntries,
       ...(this.providerMcpEnv ? { extraEnv: this.providerMcpEnv } : {}),
       log: (m) => console.log(`[plugins] ${m}`),
@@ -1499,7 +1506,7 @@ export class AgentHost {
         throw error;
       }
       console.log(
-        `[plugins] runtime reload complete: ${next.manifests.length} plugin(s), ${Object.keys(catalog).length} MCP server(s) connected`,
+        `[plugins] runtime reload complete: ${next.pluginReports.filter((plugin) => plugin.status === "loaded").length} plugin(s), ${Object.keys(catalog).length} MCP server(s) connected`,
       );
     });
   }
@@ -1513,7 +1520,7 @@ export class AgentHost {
   /** A plugin is user-managed only if it was installed into the writable install dir. */
   async pluginIsInstalled(name: string): Promise<boolean> {
     const dir = await this.pluginsInstallDirectory();
-    if (!dir) return false;
+    if (!dir || !pluginNameSchema.safeParse(name).success) return false;
     const entries = await readdir(join(dir, name)).catch(() => null);
     return entries !== null && entries.includes(".claude-plugin");
   }
@@ -1691,6 +1698,7 @@ export class AgentHost {
       const plugins = pluginsDir
         ? await loadPlugins({
             pluginsDir,
+            hostContract: PLUGIN_HOST_CONTRACT,
             extraMcpServers: userMcpServers,
             extraEnv: host.providerMcpEnv,
             log: (m) => console.log(`[plugins] ${m}`),

--- a/apps/api-server/src/plugin-import.ts
+++ b/apps/api-server/src/plugin-import.ts
@@ -1,5 +1,8 @@
 /** Parses a plugin ZIP into a manifest-validated bundle ready to write under the install directory. */
-import { pluginManifestSchema, type PluginManifest } from "@pizza-bot/plugin-sdk";
+import {
+  pluginManifestSchema,
+  type PluginManifest,
+} from "@pizza-bot/plugin-api";
 import { ArchiveError, readZipArchive, safeArchivePath } from "./archive.js";
 
 export const MAX_PLUGIN_ARCHIVE_BYTES = 50 * 1024 * 1024;

--- a/apps/api-server/src/routes-mcp.ts
+++ b/apps/api-server/src/routes-mcp.ts
@@ -2,9 +2,11 @@ import { Hono } from "hono";
 import {
   loadUserMcpServers,
   writeUserMcpServers,
+} from "@pizza-bot/plugin-sdk";
+import {
   mcpServerEntrySchema,
   type McpServerEntry,
-} from "@pizza-bot/plugin-sdk";
+} from "@pizza-bot/plugin-api";
 import { CapabilityDependencyError, type AgentHost } from "./agent-host.js";
 import { fileResourceRoutes, type ParseResult } from "./resource-crud.js";
 

--- a/apps/api-server/src/routes-plugins.test.ts
+++ b/apps/api-server/src/routes-plugins.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   ContributionRegistry,
-  pluginManifestSchema,
   type LoadedPlugins,
 } from "@pizza-bot/plugin-sdk";
+import { pluginManifestSchema } from "@pizza-bot/plugin-api";
 import type { AgentHost } from "./agent-host.js";
 import { pluginRoutes } from "./routes-plugins.js";
 import { storedZip } from "./test-utils/stored-zip.js";
@@ -49,14 +49,22 @@ describe("plugin routes", () => {
     );
     const plugins = {
       registry,
-      manifests: [
-        pluginManifestSchema.parse({
+      pluginReports: [
+        {
           name: "external-bundle",
-          displayName: "External Bundle",
-          version: "1.2.3",
-          description: "External integrations.",
-          author: { name: "External Publisher" },
-        }),
+          root: "/addons/external-bundle",
+          apiVersion: "pizza-bot/v1",
+          status: "loaded",
+          manifest: pluginManifestSchema.parse({
+            name: "external-bundle",
+            displayName: "External Bundle",
+            version: "1.2.3",
+            description: "External integrations.",
+            author: { name: "External Publisher" },
+            engines: { pizzaBot: ">=1 <2" },
+            capabilities: { required: ["skills/v1"] },
+          }),
+        },
       ],
       tools: {},
       catalog: {},
@@ -81,11 +89,19 @@ describe("plugin routes", () => {
     expect(await response.json()).toMatchObject({
       plugins: [
         {
+          id: expect.stringMatching(/^plugin_[A-Za-z0-9_-]{16}$/),
           name: "external-bundle",
+          apiVersion: "pizza-bot/v1",
+          status: "loaded",
           displayName: "External Bundle",
           version: "1.2.3",
           description: "External integrations.",
           author: "External Publisher",
+          engine: ">=1 <2",
+          capabilities: {
+            required: ["skills/v1"],
+            optional: [],
+          },
           removable: false,
           contributions: {
             skills: 1,
@@ -96,6 +112,81 @@ describe("plugin routes", () => {
             sourceRoots: ["/addons"],
             lastSyncedAt: "2026-08-10T00:00:00.000Z",
           },
+        },
+      ],
+    });
+  });
+
+  it("reports incompatible, disabled, and failed plugins without contributions", async () => {
+    const registry = new ContributionRegistry();
+    registry.registerPlugin("future-plugin");
+    registry.registerSkill(
+      "future-plugin",
+      "/plugins/loaded-copy/skills/example",
+      "example",
+      "/plugins/loaded-copy/skills/example/SKILL.md",
+    );
+    const plugins = {
+      registry,
+      pluginReports: [
+        {
+          name: "future-plugin",
+          root: "/plugins/future-plugin",
+          apiVersion: "pizza-bot/v2",
+          status: "incompatible",
+          detail: "Unsupported plugin API version",
+        },
+        {
+          name: "paused-plugin",
+          root: "/plugins/paused-plugin",
+          apiVersion: "pizza-bot/v1",
+          status: "disabled",
+          detail: "Disabled by plugin manifest",
+          manifest: pluginManifestSchema.parse({
+            name: "paused-plugin",
+            enabled: false,
+          }),
+        },
+        {
+          name: "broken-plugin",
+          root: "/plugins/broken-plugin",
+          apiVersion: "unknown",
+          status: "failed",
+          detail: "Invalid plugin manifest",
+        },
+      ],
+      tools: {},
+      catalog: {},
+      skills: new Map(),
+      materializations: {},
+    } satisfies LoadedPlugins;
+    const host = {
+      whenReady: async () => {},
+      plugins,
+      pluginIsInstalled: async () => true,
+    } as unknown as AgentHost;
+
+    const response = await pluginRoutes(host).request("/plugins");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      plugins: [
+        {
+          id: expect.stringMatching(/^plugin_[A-Za-z0-9_-]{16}$/),
+          name: "future-plugin",
+          apiVersion: "pizza-bot/v2",
+          status: "incompatible",
+          detail: "Unsupported plugin API version",
+          removable: true,
+          contributions: { skills: 0, mcpServers: 0 },
+        },
+        {
+          name: "paused-plugin",
+          status: "disabled",
+        },
+        {
+          name: "broken-plugin",
+          status: "failed",
         },
       ],
     });

--- a/apps/api-server/src/routes-plugins.ts
+++ b/apps/api-server/src/routes-plugins.ts
@@ -1,4 +1,6 @@
 import { Hono } from "hono";
+import type { PluginLoadStatus } from "@pizza-bot/plugin-api";
+import { createHash } from "node:crypto";
 import type { AgentHost } from "./agent-host.js";
 import {
   MAX_PLUGIN_ARCHIVE_BYTES,
@@ -9,12 +11,21 @@ import { limitMultipartBody } from "./request-limits.js";
 
 export interface PluginsResponse {
   plugins: Array<{
+    id: string;
     name: string;
+    apiVersion: string;
     version?: string;
     displayName?: string;
     description?: string;
     author?: string;
     homepage?: string;
+    status: PluginLoadStatus;
+    detail?: string;
+    engine?: string;
+    capabilities?: {
+      required: string[];
+      optional: string[];
+    };
     // True only for plugins installed into the writable install dir (deletable through this API).
     removable: boolean;
     contributions: {
@@ -28,6 +39,14 @@ export interface PluginsResponse {
       detail?: string;
     };
   }>;
+}
+
+function pluginReportId(root: string): string {
+  const digest = createHash("sha256")
+    .update(root)
+    .digest("base64url")
+    .slice(0, 16);
+  return `plugin_${digest}`;
 }
 
 export function pluginRoutes(host: AgentHost): Hono {
@@ -102,23 +121,32 @@ export function pluginRoutes(host: AgentHost): Hono {
     if (!loaded) return c.json(resp);
 
     resp.plugins = await Promise.all(
-      loaded.manifests.map(async (m) => {
+      loaded.pluginReports.map(async (report) => {
+        const m = report.manifest;
         const count = (entries: Iterable<{ pluginName: string }>) =>
-          [...entries].filter((entry) => entry.pluginName === m.name).length;
+          report.status === "loaded"
+            ? [...entries].filter((entry) => entry.pluginName === report.name).length
+            : 0;
         return {
-          name: m.name,
-          ...(m.version ? { version: m.version } : {}),
-          ...(m.displayName ? { displayName: m.displayName } : {}),
-          ...(m.description ? { description: m.description } : {}),
-          ...(m.author?.name ? { author: m.author.name } : {}),
-          ...(m.homepage ? { homepage: m.homepage } : {}),
-          removable: await host.pluginIsInstalled(m.name),
+          id: pluginReportId(report.root),
+          name: report.name,
+          apiVersion: report.apiVersion,
+          status: report.status,
+          ...(report.detail ? { detail: report.detail } : {}),
+          ...(m?.version ? { version: m.version } : {}),
+          ...(m?.displayName ? { displayName: m.displayName } : {}),
+          ...(m?.description ? { description: m.description } : {}),
+          ...(m?.author?.name ? { author: m.author.name } : {}),
+          ...(m?.homepage ? { homepage: m.homepage } : {}),
+          ...(m?.engines?.pizzaBot ? { engine: m.engines.pizzaBot } : {}),
+          ...(m?.capabilities ? { capabilities: m.capabilities } : {}),
+          removable: await host.pluginIsInstalled(report.name),
           contributions: {
             skills: count(loaded.registry.skills.values()),
             mcpServers: count(loaded.registry.mcpServers.values()),
           },
-          ...(loaded.materializations[m.name]
-            ? { materialization: loaded.materializations[m.name] }
+          ...(loaded.materializations[report.name]
+            ? { materialization: loaded.materializations[report.name] }
             : {}),
         };
       }),

--- a/apps/api-server/tsconfig.json
+++ b/apps/api-server/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../../packages/runtime-langgraph" },
     { "path": "../../packages/inference-providers" },
     { "path": "../../packages/storage" },
+    { "path": "../../packages/plugin-api" },
     { "path": "../../packages/plugin-sdk" }
   ],
   "include": ["src"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@langchain/langgraph-sdk": "~1.9.28",
     "@pizza-bot/core": "*",
+    "@pizza-bot/plugin-api": "*",
     "@radix-ui/react-use-controllable-state": "^1.2.6",
     "@streamdown/cjk": "^1.0.3",
     "@streamdown/code": "^1.1.1",

--- a/apps/web/src/api-client.ts
+++ b/apps/web/src/api-client.ts
@@ -17,6 +17,7 @@ import {
   updateStateWireSchema,
   type ThreadStateWire,
 } from "@pizza-bot/core";
+import type { PluginLoadStatus } from "@pizza-bot/plugin-api";
 
 export interface ApiClientOptions {
   baseUrl: string;
@@ -858,12 +859,21 @@ export interface McpServerRow {
 }
 
 export interface PluginInfo {
+  id: string;
   name: string;
+  apiVersion?: string;
   version?: string;
   displayName?: string;
   description?: string;
   author?: string;
   homepage?: string;
+  status?: PluginLoadStatus;
+  detail?: string;
+  engine?: string;
+  capabilities?: {
+    required: string[];
+    optional: string[];
+  };
   removable: boolean;
   contributions: { skills: number; mcpServers: number };
   materialization?: {

--- a/apps/web/src/components/plugins/PluginsModule.tsx
+++ b/apps/web/src/components/plugins/PluginsModule.tsx
@@ -92,7 +92,7 @@ export function PluginsModule({
               ].filter((entry) => entry.count > 0);
 
               return (
-                <li className="plugin-card" key={plugin.name}>
+                <li className="plugin-card" key={plugin.id}>
                   <div className="plugin-card-icon" aria-hidden="true">
                     <Puzzle size={20} />
                   </div>
@@ -100,8 +100,20 @@ export function PluginsModule({
                     <div className="plugin-card-heading">
                       <h2>{plugin.displayName ?? plugin.name}</h2>
                       {plugin.version && <span className="plugin-version">v{plugin.version}</span>}
+                      {plugin.status && plugin.status !== "loaded" && (
+                        <span
+                          className={`plugin-load-status ${plugin.status}`}
+                        >
+                          {plugin.status}
+                        </span>
+                      )}
                     </div>
                     {plugin.description && <p>{plugin.description}</p>}
+                    {plugin.status && plugin.status !== "loaded" && plugin.detail && (
+                      <p className={`plugin-load-detail ${plugin.status}`}>
+                        {plugin.detail}
+                      </p>
+                    )}
                     <div className="plugin-card-meta">
                       {plugin.author && <span>{plugin.author}</span>}
                       {plugin.homepage && (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1230,10 +1230,20 @@ button.sidebar-folder-row:hover,
   flex: 0 0 auto; font-family: var(--mono, ui-monospace, monospace);
   font-size: 10px; color: var(--dim);
 }
+.plugin-load-status {
+  flex: 0 0 auto; font-size: 10px; font-weight: 700; text-transform: capitalize;
+  color: var(--dim);
+}
+.plugin-load-status.incompatible,
+.plugin-load-status.failed { color: var(--danger, #e5484d); }
+.plugin-load-status.disabled { color: var(--warning); }
 .plugin-card-main > p {
   margin: 5px 0 0; max-width: 680px; color: var(--dim);
   font-size: 12.5px; line-height: 1.45;
 }
+.plugin-card-main > .plugin-load-detail.incompatible,
+.plugin-card-main > .plugin-load-detail.failed { color: var(--danger, #e5484d); }
+.plugin-card-main > .plugin-load-detail.disabled { color: var(--warning); }
 .plugin-card-meta { display: flex; gap: 12px; margin-top: 8px; font-size: 11.5px; color: var(--dim); }
 .plugin-card-meta a { color: var(--brand); text-decoration: none; }
 .plugin-card-meta a:hover { text-decoration: underline; }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ The spine is a nearly-pure core package plus a set of composition-root apps:
 ```
 apps/        api-server (Hono) · cli · desktop-shell (Electron) · web (React)
 packages/    core · runtime-langgraph · inference-providers
-             · plugin-sdk · storage · logging
+             · plugin-api · plugin-sdk · storage · logging
 plugins/     shipped plugin bundles and their packaging workspace
 skills/      SKILL.md capabilities the orchestrator equips + delegates to
 tests/       langgraph-compat
@@ -335,7 +335,9 @@ recovering occurrences, so recovered runs receive the settled skill projection.
 
 ## 8. Plugins
 
-A plugin contributes declarative resource types (`packages/plugin-sdk`),
+A plugin declares its browser-safe contract through `packages/plugin-api`;
+the Node-bound loader and host live in `packages/plugin-sdk`. Plugins contribute
+declarative resource types,
 using a supported subset of the Claude Code plugin format:
 
 - **MCP servers** — connected via `@langchain/mcp-adapters`
@@ -392,11 +394,12 @@ atomically activating a versioned snapshot under
 `<data-root>/plugin-materializations`; a failed later run retains the last good
 snapshot and reports stale status. There is no source watcher.
 
-`GET /plugins` (`routes-plugins.ts`) reports each manifest's name/metadata,
-skill + MCP-server counts, and materialization status. Unsupported manifest
-fields (`commands`, the `pizzaBot.ui` slot/tool-view block) are parsed and
-dropped rather than rejected, so a Claude Code plugin that carries them still
-loads.
+`GET /plugins` (`routes-plugins.ts`) reports every discovered plugin, including
+its loaded, disabled, incompatible, or failed status and diagnostic detail.
+Loaded entries also report manifest metadata, skill + MCP-server counts, and
+materialization status. Unsupported manifest fields (`commands`, the
+`pizzaBot.ui` slot/tool-view block) are parsed and dropped rather than rejected,
+so a Claude Code plugin that carries them still loads.
 
 **Security boundary:** plugin-shipped skills may not declare `hooks`,
 `mcpServers`, or `permissionMode` (mirrors the Claude Code rule). Configured

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -100,5 +100,11 @@ id; removing the customization restores the plugin skill. Plugin MCP server
 definitions remain part of the installed bundle. Install only sources you
 trust.
 
+The screen retains every discovered bundle and reports whether it loaded, was
+disabled by its manifest, is incompatible with this Pizza Bot release, or
+failed validation or activation. Disabled plugins are re-enabled by editing
+their manifest and setting top-level `enabled` to `true`, then reloading plugins
+or restarting Pizza Bot.
+
 See the [plugins guide](../plugins/README.md) for the supported manifest subset,
 resource paths, materializers, and packaging shipped plugin dependencies.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -98,6 +98,31 @@ export default tseslint.config(
     },
   },
   {
+    // Public plugin contracts must be usable by plugin authors and browser clients.
+    files: ["packages/plugin-api/src/**/*.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "node:*",
+                "@langchain/*",
+                "@pizza-bot/*",
+                "deepagents",
+                "ai",
+                "react",
+              ],
+              message:
+                "plugin-api is a public, browser-safe contract package; host, runtime, and UI dependencies stay in plugin-sdk or their owning app.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ["**/*.test.ts", "**/*.test.tsx"],
     languageOptions: { globals: { ...globals.node } },
     rules: {

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -6,3 +6,5 @@
 
 Only plugins under the repository's top-level `plugins/` directory ship with
 Pizza Bot. These examples are starting points for custom plugin bundles.
+Their manifests declare `apiVersion` explicitly: this versions the manifest
+contract, while `version` identifies the plugin release.

--- a/examples/plugins/mcp-status/.claude-plugin/plugin.json
+++ b/examples/plugins/mcp-status/.claude-plugin/plugin.json
@@ -1,6 +1,11 @@
 {
+  "apiVersion": "pizza-bot/v1",
   "name": "mcp-status",
   "version": "1.0.0",
+  "engines": { "pizzaBot": ">=1.0.0 <2.0.0" },
+  "capabilities": {
+    "required": ["mcp-servers/v1", "skills/v1"]
+  },
   "displayName": "MCP Status",
   "description": "Reference plugin bundling a skill and an MCP server.",
   "author": { "name": "Pizza Bot OSS" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@pizza-bot/core": "*",
         "@pizza-bot/inference-providers": "*",
         "@pizza-bot/logging": "*",
+        "@pizza-bot/plugin-api": "*",
         "@pizza-bot/plugin-sdk": "*",
         "@pizza-bot/runtime-langgraph": "*",
         "@pizza-bot/storage": "*",
@@ -102,6 +103,7 @@
       "dependencies": {
         "@langchain/langgraph-sdk": "~1.9.28",
         "@pizza-bot/core": "*",
+        "@pizza-bot/plugin-api": "*",
         "@radix-ui/react-use-controllable-state": "^1.2.6",
         "@streamdown/cjk": "^1.0.3",
         "@streamdown/code": "^1.1.1",
@@ -2856,6 +2858,10 @@
     },
     "node_modules/@pizza-bot/logging": {
       "resolved": "packages/logging",
+      "link": true
+    },
+    "node_modules/@pizza-bot/plugin-api": {
+      "resolved": "packages/plugin-api",
       "link": true
     },
     "node_modules/@pizza-bot/plugin-playwright-mcp": {
@@ -6325,6 +6331,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -14546,7 +14559,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -16113,6 +16125,14 @@
         "@types/node": "^24.13.3"
       }
     },
+    "packages/plugin-api": {
+      "name": "@pizza-bot/plugin-api",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.0.0"
+      }
+    },
     "packages/plugin-sdk": {
       "name": "@pizza-bot/plugin-sdk",
       "version": "1.0.0",
@@ -16121,11 +16141,14 @@
         "@langchain/mcp-adapters": "^1.1.3",
         "@pizza-bot/core": "*",
         "@pizza-bot/logging": "*",
+        "@pizza-bot/plugin-api": "*",
+        "semver": "^7.7.3",
         "yaml": "^2.9.0",
         "zod": "^4.0.0"
       },
       "devDependencies": {
-        "@types/node": "^24.13.3"
+        "@types/node": "^24.13.3",
+        "@types/semver": "^7.7.1"
       }
     },
     "packages/runtime-langgraph": {

--- a/packages/plugin-api/README.md
+++ b/packages/plugin-api/README.md
@@ -1,0 +1,16 @@
+# `@pizza-bot/plugin-api`
+
+Public, browser-safe schemas and types for Pizza Bot plugin manifests. This
+package has no Node, LangChain, runtime, or UI dependency.
+
+The workspace package remains private until its npm publication surface and
+release process are defined; "public" describes the supported plugin-facing API
+boundary.
+
+`apiVersion` selects the manifest contract. `version` identifies a release of
+the plugin itself. `engines.pizzaBot` constrains compatible host releases, while
+`capabilities.required` names host features that must exist before activation.
+Unknown optional capabilities do not prevent a plugin from loading.
+
+Filesystem discovery, materialization, MCP process management, and contribution
+loading remain in `@pizza-bot/plugin-sdk`.

--- a/packages/plugin-api/package.json
+++ b/packages/plugin-api/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@pizza-bot/plugin-api",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Public, browser-safe Pizza Bot plugin manifest schemas and contract types.",
+  "license": "Apache-2.0",
+  "main": "./dist/index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "source": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rimraf dist tsconfig.tsbuildinfo && tsc -b",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rimraf dist .turbo tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "zod": "^4.0.0"
+  }
+}

--- a/packages/plugin-api/src/index.ts
+++ b/packages/plugin-api/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./manifest.js";
+export * from "./qualified-id.js";

--- a/packages/plugin-api/src/manifest.test.ts
+++ b/packages/plugin-api/src/manifest.test.ts
@@ -1,17 +1,51 @@
-import { describe, it, expect } from "vitest";
-import { PLUGIN_API_VERSION, pluginManifestSchema } from "./manifest.js";
+import { describe, expect, it } from "vitest";
+import {
+  PLUGIN_API_VERSION,
+  pluginManifestSchema,
+} from "./manifest.js";
 
-describe("plugin manifest (Claude-plugin superset)", () => {
-  it("accepts the supported fields from a Claude Code plugin manifest", () => {
-    const stock = {
+describe("plugin manifest contract", () => {
+  it("accepts the supported fields from a stock Claude Code manifest", () => {
+    const parsed = pluginManifestSchema.parse({
       name: "mcp-status",
       version: "1.2.0",
       skills: "./skills/",
       mcpServers: "./.mcp.json",
-    };
-    const parsed = pluginManifestSchema.parse(stock);
-    expect(parsed.name).toBe("mcp-status");
-    expect(parsed.apiVersion).toBe(PLUGIN_API_VERSION);
+    });
+
+    expect(parsed).toMatchObject({
+      name: "mcp-status",
+      apiVersion: PLUGIN_API_VERSION,
+    });
+  });
+
+  it("treats pre-versioned manifests as enabled v1 plugins", () => {
+    const parsed = pluginManifestSchema.parse({ name: "mcp-status" });
+
+    expect(parsed).toMatchObject({
+      apiVersion: PLUGIN_API_VERSION,
+      enabled: true,
+    });
+  });
+
+  it("separates plugin release, manifest API, engine, and capabilities", () => {
+    const parsed = pluginManifestSchema.parse({
+      apiVersion: PLUGIN_API_VERSION,
+      name: "interactive-tools",
+      version: "2.3.0",
+      engines: { pizzaBot: ">=1.0.0 <2.0.0" },
+      capabilities: {
+        required: ["mcp-servers/v1"],
+        optional: ["mcp-apps/v1"],
+      },
+    });
+
+    expect(parsed.version).toBe("2.3.0");
+    expect(parsed.engines?.pizzaBot).toBe(">=1.0.0 <2.0.0");
+    expect(parsed.capabilities).toEqual({
+      required: ["mcp-servers/v1"],
+      optional: ["mcp-apps/v1"],
+    });
   });
 
   it("accepts the current API version and rejects unsupported versions", () => {
@@ -29,20 +63,30 @@ describe("plugin manifest (Claude-plugin superset)", () => {
     ).toThrow();
   });
 
-  it("ignores unsupported manifest fields instead of failing", () => {
-    const withExtras = {
-      name: "mcp-status",
-      commands: ["./commands/status.md"],
-      pizzaBot: { ui: { slots: { "sidebar-panels": ["./ui/Panel.tsx"] } } },
-    };
-    const parsed = pluginManifestSchema.parse(withExtras);
-    expect(parsed.name).toBe("mcp-status");
-    expect(parsed).not.toHaveProperty("pizzaBot");
-    expect(parsed).not.toHaveProperty("commands");
+  it("rejects malformed capability identifiers", () => {
+    expect(() =>
+      pluginManifestSchema.parse({
+        name: "bad-capability",
+        capabilities: { required: ["mcp apps"] },
+      }),
+    ).toThrow();
   });
 
-  it("rejects a non-kebab-case name", () => {
-    expect(() => pluginManifestSchema.parse({ name: "MCP Status" })).toThrow();
+  it("rejects a non-kebab-case plugin name", () => {
+    expect(() =>
+      pluginManifestSchema.parse({ name: "MCP Status" }),
+    ).toThrow();
+  });
+
+  it("ignores unsupported top-level manifest fields", () => {
+    const parsed = pluginManifestSchema.parse({
+      name: "mcp-status",
+      commands: ["./commands/status.md"],
+      pizzaBot: { ui: { slots: ["./ui/Panel.tsx"] } },
+    });
+
+    expect(parsed).not.toHaveProperty("pizzaBot");
+    expect(parsed).not.toHaveProperty("commands");
   });
 
   it("accepts disabled stdio and remote MCP entries", () => {
@@ -53,6 +97,7 @@ describe("plugin manifest (Claude-plugin superset)", () => {
         remote: { url: "https://example.com/mcp", enabled: false },
       },
     });
+
     expect(parsed.mcpServers).toMatchObject({
       local: { enabled: false },
       remote: { enabled: false },
@@ -70,7 +115,7 @@ describe("plugin manifest (Claude-plugin superset)", () => {
     ).toThrow();
   });
 
-  it("accepts a namespaced materializer extension with lifecycle defaults", () => {
+  it("preserves namespaced extension metadata", () => {
     const parsed = pluginManifestSchema.parse({
       name: "generated-tools",
       extensions: {
@@ -82,16 +127,14 @@ describe("plugin manifest (Claude-plugin superset)", () => {
       },
     });
 
-    expect(
-      parsed.extensions?.["dev.pizzabot.materializer"],
-    ).toEqual({
-      entrypoint: "./dist/materialize.mjs",
-      sourceRoots: ["~/.pizza-bot/addons"],
-      sync: ["install", "startup", "manual"],
-      timeoutMs: 30_000,
-    });
     expect(parsed.extensions?.["example.com/metadata"]).toEqual({
       channel: "stable",
+    });
+    expect(
+      parsed.extensions?.["dev.pizzabot.materializer"],
+    ).toMatchObject({
+      sync: ["install", "startup", "manual"],
+      timeoutMs: 30_000,
     });
   });
 

--- a/packages/plugin-api/src/manifest.ts
+++ b/packages/plugin-api/src/manifest.ts
@@ -1,7 +1,38 @@
-/** Validates Pizza Bot's supported subset of declarative plugin manifests. */
+/** Browser-safe schemas for Pizza Bot's declarative plugin contract. */
 import { z } from "zod";
 
 export const PLUGIN_API_VERSION = "pizza-bot/v1" as const;
+
+export const pluginNameSchema = z
+  .string()
+  .regex(/^[a-z0-9][a-z0-9-]*$/, "kebab-case name");
+
+export const pluginCapabilityIdSchema = z
+  .string()
+  .regex(
+    /^[a-z0-9][a-z0-9._-]*\/v[1-9]\d*$/,
+    "capability id such as skills/v1",
+  );
+export type PluginCapabilityId = z.infer<typeof pluginCapabilityIdSchema>;
+
+export const pluginCapabilitiesSchema = z.object({
+  required: z.array(pluginCapabilityIdSchema).default([]),
+  optional: z.array(pluginCapabilityIdSchema).default([]),
+});
+export type PluginCapabilities = z.infer<typeof pluginCapabilitiesSchema>;
+
+export const pluginEnginesSchema = z.object({
+  pizzaBot: z.string().min(1),
+});
+export type PluginEngines = z.infer<typeof pluginEnginesSchema>;
+
+export const pluginLoadStatusSchema = z.enum([
+  "loaded",
+  "disabled",
+  "incompatible",
+  "failed",
+]);
+export type PluginLoadStatus = z.infer<typeof pluginLoadStatusSchema>;
 
 /** MCP server entry: stdio, streamable HTTP, or legacy SSE. */
 export const mcpServerEntrySchema = z.union([
@@ -53,11 +84,22 @@ const pluginExtensionsSchema = z
   })
   .passthrough();
 
+export const pluginManifestHeaderSchema = z
+  .object({
+    apiVersion: z.string().default(PLUGIN_API_VERSION),
+    name: z.string().optional(),
+  })
+  .passthrough();
+
 export const pluginManifestSchema = z.object({
   // Stock and pre-versioned manifests are interpreted as v1.
   apiVersion: z.literal(PLUGIN_API_VERSION).default(PLUGIN_API_VERSION),
-  name: z.string().regex(/^[a-z0-9][a-z0-9-]*$/, "kebab-case name"),
-  version: z.string().optional(),
+  name: pluginNameSchema,
+  // Plugin release version; this does not select the manifest API contract.
+  version: z.string().min(1).optional(),
+  enabled: z.boolean().default(true),
+  engines: pluginEnginesSchema.optional(),
+  capabilities: pluginCapabilitiesSchema.optional(),
   displayName: z.string().optional(),
   description: z.string().optional(),
   author: authorSchema.optional(),

--- a/packages/plugin-api/src/qualified-id.ts
+++ b/packages/plugin-api/src/qualified-id.ts
@@ -1,0 +1,8 @@
+export type PluginQualifiedId = `${string}/${string}`;
+
+export function qualifyPluginContributionId(
+  pluginName: string,
+  localId: string,
+): PluginQualifiedId {
+  return `${pluginName}/${localId}`;
+}

--- a/packages/plugin-api/tsconfig.json
+++ b/packages/plugin-api/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "Declarative plugin schema, loader, and contribution registries.",
+  "description": "Node plugin loader, MCP host, and contribution registries.",
   "exports": {
     ".": "./src/index.ts",
     "./runtime-resolver": "./src/runtime-resolver.ts"
@@ -19,10 +19,13 @@
     "@langchain/mcp-adapters": "^1.1.3",
     "@pizza-bot/core": "*",
     "@pizza-bot/logging": "*",
+    "@pizza-bot/plugin-api": "*",
+    "semver": "^7.7.3",
     "yaml": "^2.9.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {
-    "@types/node": "^24.13.3"
+    "@types/node": "^24.13.3",
+    "@types/semver": "^7.7.1"
   }
 }

--- a/packages/plugin-sdk/src/compatibility.test.ts
+++ b/packages/plugin-sdk/src/compatibility.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { pluginManifestSchema } from "@pizza-bot/plugin-api";
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createPluginHostContract,
+  evaluatePluginCompatibility,
+  type PluginHostContract,
+} from "./compatibility.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const productPackages = {
+  root: "package.json",
+  apiServer: "apps/api-server/package.json",
+  desktopShell: "apps/desktop-shell/package.json",
+  web: "apps/web/package.json",
+} as const;
+
+const host: PluginHostContract = {
+  version: "1.4.0",
+  capabilities: new Set(["skills/v1", "mcp-servers/v1"]),
+};
+
+async function packageVersion(relativePath: string): Promise<string> {
+  const parsed = JSON.parse(
+    await readFile(join(repoRoot, relativePath), "utf8"),
+  ) as { version: string };
+  return parsed.version;
+}
+
+describe("plugin compatibility", () => {
+  it("accepts matching engine and required capability declarations", () => {
+    const manifest = pluginManifestSchema.parse({
+      name: "compatible",
+      engines: { pizzaBot: ">=1.2.0 <2" },
+      capabilities: {
+        required: ["skills/v1"],
+        optional: ["mcp-apps/v1"],
+      },
+    });
+
+    expect(evaluatePluginCompatibility(manifest, host)).toEqual({
+      compatible: true,
+    });
+  });
+
+  it("rejects unsatisfied engine ranges", () => {
+    const manifest = pluginManifestSchema.parse({
+      name: "future-host",
+      engines: { pizzaBot: ">=2" },
+    });
+
+    expect(evaluatePluginCompatibility(manifest, host)).toMatchObject({
+      compatible: false,
+      detail: expect.stringContaining("this host is 1.4.0"),
+    });
+  });
+
+  it("rejects unknown required capabilities but ignores unknown optional ones", () => {
+    const required = pluginManifestSchema.parse({
+      name: "required-apps",
+      capabilities: { required: ["mcp-apps/v1"] },
+    });
+    const optional = pluginManifestSchema.parse({
+      name: "optional-apps",
+      capabilities: { optional: ["mcp-apps/v1"] },
+    });
+
+    expect(evaluatePluginCompatibility(required, host)).toMatchObject({
+      compatible: false,
+      detail: expect.stringContaining("mcp-apps/v1"),
+    });
+    expect(evaluatePluginCompatibility(optional, host)).toEqual({
+      compatible: true,
+    });
+  });
+
+  it("keeps product package versions aligned with the plugin host", async () => {
+    const apiVersion = await packageVersion(productPackages.apiServer);
+    const versions = Object.fromEntries(
+      await Promise.all(
+        Object.entries(productPackages).map(async ([name, relativePath]) => [
+          name,
+          await packageVersion(relativePath),
+        ]),
+      ),
+    );
+
+    expect(versions).toEqual({
+      root: apiVersion,
+      apiServer: apiVersion,
+      desktopShell: apiVersion,
+      web: apiVersion,
+    });
+  });
+
+  it("keeps shipped and example plugins compatible with the current host release", async () => {
+    const currentHost = createPluginHostContract(
+      await packageVersion(productPackages.apiServer),
+    );
+
+    for (const relativeRoot of ["plugins", "examples/plugins"]) {
+      const pluginsDir = join(repoRoot, relativeRoot);
+      const pluginDirs = (await readdir(pluginsDir, { withFileTypes: true }))
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+      let checked = 0;
+
+      for (const pluginDir of pluginDirs) {
+        const manifestPath = join(
+          pluginsDir,
+          pluginDir,
+          ".claude-plugin/plugin.json",
+        );
+        let raw: string;
+        try {
+          raw = await readFile(manifestPath, "utf8");
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+          throw error;
+        }
+
+        const manifest = pluginManifestSchema.parse(JSON.parse(raw));
+        expect(
+          evaluatePluginCompatibility(manifest, currentHost),
+          `${relativeRoot}/${pluginDir}`,
+        ).toEqual({ compatible: true });
+        checked++;
+      }
+
+      expect(checked, relativeRoot).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/plugin-sdk/src/compatibility.ts
+++ b/packages/plugin-sdk/src/compatibility.ts
@@ -1,0 +1,64 @@
+import type {
+  PluginCapabilityId,
+  PluginManifest,
+} from "@pizza-bot/plugin-api";
+import { satisfies, valid, validRange } from "semver";
+
+export const PLUGIN_HOST_CAPABILITIES = [
+  "mcp-servers/v1",
+  "skills/v1",
+  "materializer/v1",
+] as const satisfies readonly PluginCapabilityId[];
+
+export interface PluginHostContract {
+  version: string;
+  capabilities: ReadonlySet<string>;
+}
+
+export interface PluginCompatibility {
+  compatible: boolean;
+  detail?: string;
+}
+
+export function createPluginHostContract(version: string): PluginHostContract {
+  if (!valid(version)) {
+    throw new Error(`Invalid Pizza Bot host version "${version}"`);
+  }
+  return {
+    version,
+    capabilities: new Set(PLUGIN_HOST_CAPABILITIES),
+  };
+}
+
+export function evaluatePluginCompatibility(
+  manifest: PluginManifest,
+  host: PluginHostContract,
+): PluginCompatibility {
+  const range = manifest.engines?.pizzaBot;
+  if (range) {
+    if (!validRange(range)) {
+      return {
+        compatible: false,
+        detail: `Invalid engines.pizzaBot range "${range}"`,
+      };
+    }
+    if (!satisfies(host.version, range, { includePrerelease: true })) {
+      return {
+        compatible: false,
+        detail: `Requires Pizza Bot ${range}; this host is ${host.version}`,
+      };
+    }
+  }
+
+  const missing = (manifest.capabilities?.required ?? []).filter(
+    (capability) => !host.capabilities.has(capability),
+  );
+  if (missing.length > 0) {
+    return {
+      compatible: false,
+      detail: `Missing required plugin capabilities: ${missing.join(", ")}`,
+    };
+  }
+
+  return { compatible: true };
+}

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -1,4 +1,3 @@
-export * from "./manifest.js";
 export * from "./registry.js";
 export * from "./wildcard.js";
 export * from "./loader.js";
@@ -7,3 +6,4 @@ export * from "./skill-catalog.js";
 export * from "./runtime-resolver.js";
 export * from "./mcp-servers-config.js";
 export * from "./materializer.js";
+export * from "./compatibility.js";

--- a/packages/plugin-sdk/src/loader.test.ts
+++ b/packages/plugin-sdk/src/loader.test.ts
@@ -8,7 +8,7 @@ import {
   PluginContributionCollisionError,
 } from "./registry.js";
 import { FsPluginLoader, PluginPathError } from "./loader.js";
-import { pluginManifestSchema } from "./manifest.js";
+import { pluginManifestSchema } from "@pizza-bot/plugin-api";
 
 async function writeEnvExpansionPluginFixture(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "plugin-env-fixture-"));
@@ -59,11 +59,14 @@ describe("FsPluginLoader", () => {
     expect(serverArg.startsWith(EXAMPLE_ROOT)).toBe(true);
   });
 
-  it("discovers plugins under a directory and returns their manifests", async () => {
+  it("finds plugins under a directory for explicit host loading", async () => {
     const loader = new FsPluginLoader();
     const reg = new ContributionRegistry();
-    const manifests = await loader.discover(EXAMPLES_DIR, reg);
-    expect(manifests.map((m) => m.name)).toEqual(["mcp-status"]);
+    const sources = await loader.find(EXAMPLES_DIR);
+    for (const source of sources) {
+      await loader.load(source.manifest, source.root, reg);
+    }
+    expect(sources.map(({ manifest }) => manifest.name)).toEqual(["mcp-status"]);
     expect(reg.skills.has("health-report")).toBe(true);
     expect(reg.mcpServers.has("mcp-status")).toBe(true);
   });
@@ -99,14 +102,14 @@ describe("FsPluginLoader", () => {
   });
 
   it("rejects a manifest with a non-kebab-case name", async () => {
-    const loader = new FsPluginLoader();
+    const root = await mkdtemp(join(tmpdir(), "plugin-name-fixture-"));
+    const manifestPath = join(root, ".claude-plugin/plugin.json");
+    await mkdir(join(root, ".claude-plugin"), { recursive: true });
+    await writeFile(manifestPath, JSON.stringify({ name: "Bad Name" }));
+
     await expect(
-      (async () => {
-        const { pluginManifestSchema } = await import("./manifest.js");
-        return pluginManifestSchema.parse({ name: "Bad Name" });
-      })(),
-    ).rejects.toThrow();
-    void loader;
+      new FsPluginLoader().readManifest(manifestPath),
+    ).rejects.toThrow(/kebab-case name/);
   });
 
   it("reports malformed manifests while ignoring directories without one", async () => {
@@ -117,13 +120,12 @@ describe("FsPluginLoader", () => {
     await mkdir(join(pluginsDir, "ordinary-directory"));
 
     const errors: Array<{ root: string; error: unknown }> = [];
-    const manifests = await new FsPluginLoader().discover(
+    const sources = await new FsPluginLoader().find(
       pluginsDir,
-      new ContributionRegistry(),
       (root, error) => errors.push({ root, error }),
     );
 
-    expect(manifests).toEqual([]);
+    expect(sources).toEqual([]);
     expect(errors).toHaveLength(1);
     expect(errors[0]?.root).toBe(brokenRoot);
     expect(String(errors[0]?.error)).toContain("Invalid plugin manifest");

--- a/packages/plugin-sdk/src/loader.ts
+++ b/packages/plugin-sdk/src/loader.ts
@@ -11,11 +11,14 @@ import {
 } from "node:path";
 import { z } from "zod";
 import {
+  PLUGIN_API_VERSION,
+  pluginManifestHeaderSchema,
   pluginManifestSchema,
+  pluginNameSchema,
   mcpServerEntrySchema,
   type PluginManifest,
   type McpServerEntry,
-} from "./manifest.js";
+} from "@pizza-bot/plugin-api";
 import { expandMcpEnvVars } from "./mcp-servers-config.js";
 import { ContributionRegistry, type PluginLoader } from "./registry.js";
 
@@ -27,6 +30,18 @@ const mcpServersFileSchema = z.object({
 export interface PluginSource {
   root: string;
   manifest: PluginManifest;
+}
+
+export class UnsupportedPluginApiVersionError extends Error {
+  constructor(
+    readonly apiVersion: string,
+    readonly pluginName?: string,
+  ) {
+    super(
+      `Unsupported plugin API version "${apiVersion}"; this host supports "${PLUGIN_API_VERSION}"`,
+    );
+    this.name = "UnsupportedPluginApiVersionError";
+  }
 }
 
 export class PluginPathError extends Error {
@@ -41,29 +56,6 @@ export class PluginPathError extends Error {
 }
 
 export class FsPluginLoader implements PluginLoader {
-  /**
-   * Directories without a manifest are skipped. Malformed manifests and
-   * contribution load failures are reported through `onError`.
-   */
-  async discover(
-    pluginsDir: string,
-    into: ContributionRegistry,
-    onError: (pluginDir: string, err: unknown) => void = (_d, e) => {
-      throw e;
-    },
-  ): Promise<PluginManifest[]> {
-    const loaded: PluginManifest[] = [];
-    for (const { root, manifest } of await this.find(pluginsDir, onError)) {
-      try {
-        await this.load(manifest, root, into);
-        loaded.push(manifest);
-      } catch (err) {
-        onError(root, err);
-      }
-    }
-    return loaded;
-  }
-
   async find(
     pluginsDir: string,
     onError: (pluginDir: string, err: unknown) => void = (_d, e) => {
@@ -92,9 +84,22 @@ export class FsPluginLoader implements PluginLoader {
   async readManifest(manifestPath: string): Promise<PluginManifest> {
     try {
       const raw = await readFile(manifestPath, "utf8");
-      return pluginManifestSchema.parse(JSON.parse(raw));
+      const value: unknown = JSON.parse(raw);
+      const header = pluginManifestHeaderSchema.safeParse(value);
+      if (
+        header.success &&
+        header.data.apiVersion !== PLUGIN_API_VERSION
+      ) {
+        const pluginName = pluginNameSchema.safeParse(header.data.name);
+        throw new UnsupportedPluginApiVersionError(
+          header.data.apiVersion,
+          pluginName.success ? pluginName.data : undefined,
+        );
+      }
+      return pluginManifestSchema.parse(value);
     } catch (err) {
       if (isMissingFile(err)) throw err;
+      if (err instanceof UnsupportedPluginApiVersionError) throw err;
       throw new Error(
         `Invalid plugin manifest at ${manifestPath}: ${
           err instanceof Error ? err.message : String(err)

--- a/packages/plugin-sdk/src/materializer.test.ts
+++ b/packages/plugin-sdk/src/materializer.test.ts
@@ -10,7 +10,11 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadPlugins } from "./plugin-host.js";
 import { materializePlugin } from "./materializer.js";
-import { pluginManifestSchema, type PluginManifest } from "./manifest.js";
+import {
+  pluginManifestSchema,
+  type PluginManifest,
+} from "@pizza-bot/plugin-api";
+import { createPluginHostContract } from "./compatibility.js";
 
 const roots: string[] = [];
 
@@ -105,14 +109,18 @@ describe("plugin materializers", () => {
 
     const loaded = await loadPlugins({
       pluginsDir: fixture.pluginsDir,
+      hostContract: createPluginHostContract("1.0.0"),
       materializationCacheDir: fixture.cacheRoot,
       materializationReason: "install",
       connectMcp: false,
     });
 
-    expect(loaded.manifests.map((manifest) => manifest.name)).toEqual([
-      "generated-tools",
-    ]);
+    expect(loaded.pluginReports).toContainEqual(
+      expect.objectContaining({
+        name: "generated-tools",
+        status: "loaded",
+      }),
+    );
     expect(loaded.materializations["generated-tools"]).toMatchObject({
       state: "synced",
       sourceRoots: [fixture.sourceRoot],

--- a/packages/plugin-sdk/src/materializer.ts
+++ b/packages/plugin-sdk/src/materializer.ts
@@ -23,7 +23,7 @@ import type {
   PluginManifest,
   PluginMaterializer,
   PluginMaterializerReason,
-} from "./manifest.js";
+} from "@pizza-bot/plugin-api";
 import { FsPluginLoader } from "./loader.js";
 import { ContributionRegistry } from "./registry.js";
 import { loadSkillCatalog } from "./skill-catalog.js";

--- a/packages/plugin-sdk/src/mcp-servers-config.ts
+++ b/packages/plugin-sdk/src/mcp-servers-config.ts
@@ -2,7 +2,10 @@
 import { chmod, readFile, writeFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import { z } from "zod";
-import { mcpServerEntrySchema, type McpServerEntry } from "./manifest.js";
+import {
+  mcpServerEntrySchema,
+  type McpServerEntry,
+} from "@pizza-bot/plugin-api";
 
 /**
  * Entries remain unknown here so each can be validated independently without one

--- a/packages/plugin-sdk/src/plugin-host.ts
+++ b/packages/plugin-sdk/src/plugin-host.ts
@@ -2,15 +2,19 @@
 import type { StructuredToolInterface } from "@langchain/core/tools";
 import type { SkillCatalog } from "@pizza-bot/core";
 import { MultiServerMCPClient, type Connection } from "@langchain/mcp-adapters";
-import { join } from "node:path";
-import { FsPluginLoader } from "./loader.js";
+import type { PluginLoadStatus } from "@pizza-bot/plugin-api";
+import { basename, join } from "node:path";
+import {
+  FsPluginLoader,
+  UnsupportedPluginApiVersionError,
+} from "./loader.js";
 import { loadSkillCatalog } from "./skill-catalog.js";
 import { ContributionRegistry } from "./registry.js";
 import type {
   PluginManifest,
   McpServerEntry,
   PluginMaterializerReason,
-} from "./manifest.js";
+} from "@pizza-bot/plugin-api";
 import type { ToolCatalog } from "./wildcard.js";
 import {
   isNodeFamilyCommand,
@@ -24,18 +28,31 @@ import {
   type PluginMaterializationStatus,
 } from "./materializer.js";
 import { restoreNullableSchemaTypes } from "./mcp-schema.js";
+import {
+  evaluatePluginCompatibility,
+  type PluginHostContract,
+} from "./compatibility.js";
 
 export { parseFrontmatter };
 
 export interface LoadedPlugins {
   readonly registry: ContributionRegistry;
-  readonly manifests: PluginManifest[];
+  readonly pluginReports: readonly PluginLoadReport[];
   readonly tools: Record<string, StructuredToolInterface>;
   readonly catalog: ToolCatalog;
   readonly skills: SkillCatalog;
   readonly materializations: Readonly<Record<string, PluginMaterializationStatus>>;
   /** The host must close the client to reap MCP subprocesses. */
   readonly client?: McpClientPool;
+}
+
+export interface PluginLoadReport {
+  name: string;
+  root: string;
+  apiVersion: string;
+  status: PluginLoadStatus;
+  manifest?: PluginManifest;
+  detail?: string;
 }
 
 export type McpConnectionStatus = "loading" | "retrying" | "connected" | "error";
@@ -163,6 +180,8 @@ export interface LoadPluginsOptions {
   /** Host-owned cache for validated materializer output. */
   materializationCacheDir?: string;
   materializationReason?: PluginMaterializerReason;
+  /** Host contract used to evaluate engines and required capabilities. */
+  hostContract: PluginHostContract;
 }
 
 /** Invalid plugins and failed MCP connections are logged and skipped. */
@@ -173,13 +192,54 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadedPlugi
   const registry = new ContributionRegistry();
 
   const dirs = Array.isArray(opts.pluginsDir) ? opts.pluginsDir : [opts.pluginsDir];
-  const manifests: PluginManifest[] = [];
+  const pluginReports: PluginLoadReport[] = [];
   const materializations: Record<string, PluginMaterializationStatus> = {};
   for (const dir of dirs) {
     const found = await loader.find(dir, (d, err) => {
-      log(`skipping plugin at ${d}: ${err instanceof Error ? err.message : String(err)}`);
+      const detail = err instanceof Error ? err.message : String(err);
+      const unsupported = err instanceof UnsupportedPluginApiVersionError;
+      pluginReports.push({
+        name: unsupported && err.pluginName ? err.pluginName : basename(d),
+        root: d,
+        apiVersion: unsupported ? err.apiVersion : "unknown",
+        status: unsupported ? "incompatible" : "failed",
+        detail,
+      });
+      log(`skipping plugin at ${d}: ${detail}`);
     });
     for (const source of found) {
+      const report = (
+        status: PluginLoadStatus,
+        detail?: string,
+      ): void => {
+        pluginReports.push({
+          name: source.manifest.name,
+          root: source.root,
+          apiVersion: source.manifest.apiVersion,
+          status,
+          manifest: source.manifest,
+          ...(detail ? { detail } : {}),
+        });
+      };
+      if (!source.manifest.enabled) {
+        report("disabled", "Disabled by plugin manifest");
+        log(
+          `skipping plugin at ${source.root}: Disabled by plugin manifest`,
+        );
+        continue;
+      }
+      const compatibility = evaluatePluginCompatibility(
+        source.manifest,
+        opts.hostContract,
+      );
+      if (!compatibility.compatible) {
+        report("incompatible", compatibility.detail);
+        log(
+          `skipping plugin at ${source.root}: ${compatibility.detail ?? "Incompatible plugin"}`,
+        );
+        continue;
+      }
+
       const materializer =
         source.manifest.extensions?.["dev.pizzabot.materializer"];
       let loadRoot = source.root;
@@ -190,7 +250,7 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadedPlugi
             sourceRoots: materializer.sourceRoots,
             detail: "Plugin materialization cache is not configured",
           };
-          manifests.push(source.manifest);
+          report("failed", "Plugin materialization cache is not configured");
           continue;
         }
         const result = await materializePlugin({
@@ -204,7 +264,10 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadedPlugi
           log(
             `materializer for "${source.manifest.name}" failed: ${result.status.detail ?? "unknown error"}`,
           );
-          manifests.push(source.manifest);
+          report(
+            "failed",
+            result.status.detail ?? "Plugin materialization failed",
+          );
           continue;
         }
         loadRoot = result.root;
@@ -221,10 +284,12 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadedPlugi
             )
           : source.manifest;
         await loader.load(loadManifest, loadRoot, registry);
-        manifests.push(source.manifest);
+        report("loaded");
       } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        report("failed", detail);
         log(
-          `skipping plugin at ${source.root}: ${err instanceof Error ? err.message : String(err)}`,
+          `skipping plugin at ${source.root}: ${detail}`,
         );
       }
     }
@@ -241,7 +306,7 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadedPlugi
     }
     return {
       registry,
-      manifests,
+      pluginReports,
       tools: {},
       catalog: {},
       skills,
@@ -265,7 +330,7 @@ export async function loadPlugins(opts: LoadPluginsOptions): Promise<LoadedPlugi
 
   return {
     registry,
-    manifests,
+    pluginReports,
     tools,
     catalog,
     skills,

--- a/packages/plugin-sdk/src/plugin-reports.test.ts
+++ b/packages/plugin-sdk/src/plugin-reports.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadPlugins } from "./plugin-host.js";
+import { createPluginHostContract } from "./compatibility.js";
+
+const roots: string[] = [];
+const hostContract = createPluginHostContract("1.0.0");
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) =>
+      rm(root, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 100,
+      }),
+    ),
+  );
+});
+
+async function writePlugin(
+  directory: string,
+  manifest: unknown,
+): Promise<void> {
+  await mkdir(join(directory, ".claude-plugin"), { recursive: true });
+  await writeFile(
+    join(directory, ".claude-plugin", "plugin.json"),
+    typeof manifest === "string"
+      ? manifest
+      : `${JSON.stringify(manifest)}\n`,
+  );
+}
+
+async function pluginRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "plugin-reports-"));
+  roots.push(root);
+  return root;
+}
+
+describe("plugin load reports", () => {
+  it("retains loaded, disabled, incompatible, and failed discoveries", async () => {
+    const root = await pluginRoot();
+    await writePlugin(join(root, "loaded"), {
+      apiVersion: "pizza-bot/v1",
+      name: "loaded",
+      engines: { pizzaBot: ">=1 <2" },
+      capabilities: { required: ["skills/v1"] },
+    });
+    await writePlugin(join(root, "disabled"), {
+      apiVersion: "pizza-bot/v1",
+      name: "disabled",
+      enabled: false,
+    });
+    await writePlugin(join(root, "future-api"), {
+      apiVersion: "pizza-bot/v2",
+      name: "future-api",
+    });
+    await writePlugin(join(root, "unsafe-folder"), {
+      apiVersion: "pizza-bot/v3",
+      name: "../../../escape",
+    });
+    await writePlugin(join(root, "future-engine"), {
+      apiVersion: "pizza-bot/v1",
+      name: "future-engine",
+      engines: { pizzaBot: ">=2" },
+    });
+    await writePlugin(join(root, "missing-capability"), {
+      apiVersion: "pizza-bot/v1",
+      name: "missing-capability",
+      capabilities: { required: ["mcp-apps/v1"] },
+    });
+    await writePlugin(join(root, "malformed"), "{not-json");
+
+    const logs: string[] = [];
+    const result = await loadPlugins({
+      pluginsDir: root,
+      hostContract,
+      connectMcp: false,
+      log: (message) => logs.push(message),
+    });
+    const byName = new Map(
+      result.pluginReports.map((report) => [report.name, report]),
+    );
+
+    expect(byName.get("loaded")).toMatchObject({ status: "loaded" });
+    expect(byName.get("disabled")).toMatchObject({
+      status: "disabled",
+      detail: "Disabled by plugin manifest",
+    });
+    expect(byName.get("future-api")).toMatchObject({
+      apiVersion: "pizza-bot/v2",
+      status: "incompatible",
+    });
+    expect(byName.get("unsafe-folder")).toMatchObject({
+      apiVersion: "pizza-bot/v3",
+      status: "incompatible",
+    });
+    expect(byName.has("../../../escape")).toBe(false);
+    expect(byName.get("future-engine")).toMatchObject({
+      status: "incompatible",
+      detail: expect.stringContaining("Requires Pizza Bot"),
+    });
+    expect(byName.get("missing-capability")).toMatchObject({
+      status: "incompatible",
+      detail: expect.stringContaining("mcp-apps/v1"),
+    });
+    expect(byName.get("malformed")).toMatchObject({
+      apiVersion: "unknown",
+      status: "failed",
+    });
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Disabled by plugin manifest"),
+        expect.stringContaining("Requires Pizza Bot"),
+        expect.stringContaining("Missing required plugin capabilities"),
+      ]),
+    );
+  });
+
+  it("reports contribution load failures without partially registering them", async () => {
+    const root = await pluginRoot();
+    await mkdir(join(root, "outside"));
+    await writePlugin(join(root, "broken-path"), {
+      apiVersion: "pizza-bot/v1",
+      name: "broken-path",
+      skills: "../outside",
+    });
+
+    const result = await loadPlugins({
+      pluginsDir: root,
+      hostContract,
+      connectMcp: false,
+    });
+
+    expect(result.pluginReports).toContainEqual(
+      expect.objectContaining({
+        name: "broken-path",
+        status: "failed",
+        detail: expect.stringContaining("escapes the plugin root"),
+      }),
+    );
+    expect(result.registry.skills.size).toBe(0);
+  });
+});

--- a/packages/plugin-sdk/src/registry.ts
+++ b/packages/plugin-sdk/src/registry.ts
@@ -1,8 +1,13 @@
 /** Registries for validated plugin contributions. */
-import type { PluginManifest, McpServerEntry } from "./manifest.js";
+import {
+  qualifyPluginContributionId,
+  type McpServerEntry,
+  type PluginManifest,
+  type PluginQualifiedId,
+} from "@pizza-bot/plugin-api";
 
 export interface PluginContribution<T> {
-  qualifiedId: string;
+  qualifiedId: PluginQualifiedId;
   pluginName: string;
   root: string;
   value: T;
@@ -24,10 +29,6 @@ export class PluginContributionCollisionError extends Error {
     );
     this.name = "PluginContributionCollisionError";
   }
-}
-
-export function qualifyContributionId(pluginName: string, localId: string): string {
-  return `${pluginName}/${localId}`;
 }
 
 export class ContributionRegistry {
@@ -100,7 +101,7 @@ export class ContributionRegistry {
       );
     }
     registry.set(id, {
-      qualifiedId: qualifyContributionId(pluginName, id),
+      qualifiedId: qualifyPluginContributionId(pluginName, id),
       pluginName,
       root,
       value,

--- a/packages/plugin-sdk/tsconfig.json
+++ b/packages/plugin-sdk/tsconfig.json
@@ -5,6 +5,10 @@
     "outDir": "dist",
     "types": ["node"]
   },
-  "references": [{ "path": "../core" }, { "path": "../logging" }],
+  "references": [
+    { "path": "../core" },
+    { "path": "../logging" },
+    { "path": "../plugin-api" }
+  ],
   "include": ["src"]
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -33,6 +33,43 @@ A manifest lives at `<plugin>/.claude-plugin/plugin.json`. Unsupported fields
 rejected, so a Claude Code plugin that carries them still loads — but the host
 executes no plugin-supplied web components.
 
+### Manifest compatibility
+
+Pizza Bot distinguishes four independent compatibility facts:
+
+- `apiVersion` selects the manifest schema. The current value is
+  `pizza-bot/v1`; omitted values are accepted as v1 for Claude Code and older
+  Pizza Bot bundles.
+- `version` is the plugin's own release version. It does not select a manifest
+  schema or guarantee host compatibility.
+- `engines.pizzaBot` is a semver range for compatible Pizza Bot host releases.
+- `capabilities.required` lists versioned host features needed for activation.
+  Unknown required capabilities make the plugin incompatible; unknown entries
+  under `capabilities.optional` are ignored.
+
+Set top-level `enabled` to `false` to install a bundle without activating its
+contributions. The Plugins page and `GET /plugins` retain disabled,
+incompatible, and failed entries with diagnostic status instead of dropping
+them.
+
+```json
+{
+  "apiVersion": "pizza-bot/v1",
+  "name": "example-tools",
+  "version": "1.2.0",
+  "engines": { "pizzaBot": ">=1.0.0 <2.0.0" },
+  "capabilities": {
+    "required": ["mcp-servers/v1", "skills/v1"],
+    "optional": ["mcp-apps/v1"]
+  }
+}
+```
+
+Skill and MCP server references retain their existing local identifiers for
+configuration compatibility. Every registered contribution also has a
+`<plugin-name>/<local-id>` identity; new contribution kinds must use that
+plugin-qualified identity as their canonical key.
+
 The complete [MCP status example](../examples/plugins/mcp-status) is a small,
 self-contained reference plugin with a manifest, MCP server, and matching
 skill. It has no install step or external dependencies, so it can be copied or
@@ -86,7 +123,13 @@ by declaring the `dev.pizzabot.materializer` extension:
 
 ```json
 {
+  "apiVersion": "pizza-bot/v1",
   "name": "generated-tools",
+  "version": "1.0.0",
+  "engines": { "pizzaBot": ">=1.0.0 <2.0.0" },
+  "capabilities": {
+    "required": ["materializer/v1"]
+  },
   "extensions": {
     "dev.pizzabot.materializer": {
       "entrypoint": "./dist/materialize.mjs",

--- a/plugins/playwright-mcp/.claude-plugin/plugin.json
+++ b/plugins/playwright-mcp/.claude-plugin/plugin.json
@@ -1,6 +1,11 @@
 {
+  "apiVersion": "pizza-bot/v1",
   "name": "playwright-mcp",
   "version": "1.0.0",
+  "engines": { "pizzaBot": ">=1.0.0 <2.0.0" },
+  "capabilities": {
+    "required": ["mcp-servers/v1", "skills/v1"]
+  },
   "displayName": "Playwright Browser Automation",
   "description": "Browser automation and inspection through Playwright MCP.",
   "author": { "name": "Pizza Bot OSS" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "references": [
     { "path": "packages/core" },
     { "path": "packages/logging" },
+    { "path": "packages/plugin-api" },
     { "path": "packages/plugin-sdk" },
     { "path": "packages/storage" },
     { "path": "packages/inference-providers" },


### PR DESCRIPTION
# What and why

Introduce a versioned, browser-safe plugin contract boundary so future contribution types, including MCP Apps, can evolve without coupling plugin authors to the Node host implementation.

- add `@pizza-bot/plugin-api` for manifest schemas and browser-safe contract types
- distinguish plugin release versions from manifest API versions
- gate activation on host engines and required capabilities
- report loaded, disabled, incompatible, and failed plugins through `GET /plugins` and the Plugins UI
- add plugin-qualified contribution IDs and harden plugin management identity validation
- keep product versions and bundled/example compatibility declarations under test

Related to #34. This prepares the contract and lifecycle surface; it does not implement MCP Apps.

## Compatibility

No data migration or cleanup is required. Existing manifests without `apiVersion`, `enabled`, `engines`, or `capabilities` continue to load as enabled v1 plugins. No persisted database or data-root format changes.

`@pizza-bot/plugin-sdk` is private, but its manifest contract re-export is intentionally removed. Source consumers should import those schemas and types directly from `@pizza-bot/plugin-api`.

## Gates

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run backend:bundle && npm run backend:smoke`

## Verified how

- [x] Drove the Plugins view at 1440x900 and 390x844 against loaded, disabled, incompatible, and failed reports; all status cards rendered without overflow.
- [x] Exercised a packaged backend artifact through the remote backend smoke test.

## Layering

- [x] `packages/core` gained no `node:*`, DOM, `deepagents`, or `@langchain/langgraph` import
- [x] Only `packages/runtime-langgraph` imports the graph engine
- [x] `apps/web` imports no runtime and no model binding
- [x] Docs touched by this change were updated (README / AGENTS.md / docs/ARCHITECTURE.md)