### PR TITLE
fix: avoid skill worker instruction rereads

### DIFF
--- a/packages/runtime-langgraph/src/eval-capability.test.ts
+++ b/packages/runtime-langgraph/src/eval-capability.test.ts
@@ -113,12 +113,18 @@ describe("Pizza Bot graph assembly", () => {
     expect(mocks.createSubAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: [send],
-        skills: ["/skills/mailer/"],
         interruptOn: {
           outlook__send: { allowedDecisions: ["approve", "edit", "reject"] },
         },
       }),
     );
+    const subagentParams = mocks.createSubAgent.mock.calls[0]![0] as {
+      middleware: Array<{ name?: string }>;
+      skills?: string[];
+    };
+    expect(subagentParams).not.toHaveProperty("skills");
+    expect(subagentParams.middleware.map((middleware) => middleware.name))
+      .not.toContain("SkillsMiddleware");
     expect(mocks.modelCallLimitMiddleware.mock.calls).toEqual([
       [{ runLimit: 20, exitBehavior: "end" }],
       [{ runLimit: 20, exitBehavior: "end" }],

--- a/packages/runtime-langgraph/src/index.ts
+++ b/packages/runtime-langgraph/src/index.ts
@@ -2,7 +2,6 @@
 import {
   createDeepAgent,
   createFilesystemMiddleware,
-  createSkillsMiddleware,
   createSubAgent,
   registerHarnessProfile,
   type CompiledSubAgent,
@@ -10,7 +9,6 @@ import {
 } from "deepagents";
 import {
   collectSkillFiles,
-  collectSkillPaths,
   normalizeSkillFile,
   resolveToolReferences,
   splitSkillMd,
@@ -241,7 +239,6 @@ export async function resolveSkillSubagents(
         description: entry.description,
         systemPrompt: skillBody(entry) || entry.description,
         tools,
-        skills: collectSkillPaths([entry.id], skills),
         middleware,
         ...(interruptOn && Object.keys(interruptOn).length > 0 ? { interruptOn } : {}),
       } as unknown as SubAgent;
@@ -271,8 +268,7 @@ export interface StateFile {
 }
 
 /**
- * Materialize all equipped skills in shared run state. Each participant receives
- * only its own skill paths, so shared seeding does not leak skills into prompts.
+ * Materialize equipped skill files in shared run state for explicit reference reads.
  */
 export function buildSkillSeed(deps: RuntimeDeps): Record<string, StateFile> {
   const contentByPath = collectSkillFiles(
@@ -338,9 +334,6 @@ async function assemblePizzaBot(systemPrompt: string, deps: RuntimeDeps): Promis
           tools: subagent.tools ?? [],
           middleware: [
             createFilesystemMiddleware({ backend }),
-            ...(subagent.skills?.length
-              ? [createSkillsMiddleware({ backend, sources: subagent.skills })]
-              : []),
             ...(subagent.middleware ?? []),
           ],
         }),

--- a/packages/runtime-langgraph/src/skill-file-access.test.ts
+++ b/packages/runtime-langgraph/src/skill-file-access.test.ts
@@ -130,7 +130,7 @@ const skills: SkillCatalog = new Map([
 ]);
 
 describe("skill worker files", () => {
-  it("reads its sibling reference without exposing another skill", async () => {
+  it("reads its sibling reference without rereading its own skill", async () => {
     const model = new SkillFileReadingModel({});
     const agent = await createPizzaBotAgent("Delegate this request.", { model, skills });
 
@@ -150,7 +150,11 @@ describe("skill worker files", () => {
     expect(model.readResult).toContain(REFERENCE_CONTENT);
     expect(model.delegationResult).toContain(REFERENCE_CONTENT);
     expect(model.workerSystemPrompt).toContain("/skills/reader/references/oven.txt");
-    expect(model.workerSystemPrompt).toContain("Reads its bundled oven reference.");
+    expect(model.workerSystemPrompt).not.toContain("/skills/reader/SKILL.md");
+    expect(model.workerSystemPrompt).not.toContain("## Skills System");
+    expect(
+      model.workerSystemPrompt.match(/Read \/skills\/reader\/references\/oven\.txt/g),
+    ).toHaveLength(1);
     expect(model.workerSystemPrompt).not.toContain(HIDDEN_MARKER);
   });
 });

--- a/packages/runtime-langgraph/src/skill-workers.test.ts
+++ b/packages/runtime-langgraph/src/skill-workers.test.ts
@@ -45,7 +45,6 @@ describe("resolveSkillSubagents", () => {
     expect(resolved![0]).toMatchObject({
       name: "mailer",
       tools: [send],
-      skills: ["/skills/mailer/"],
       systemPrompt: "Follow mailer.",
     });
     expect(resolved![1]).toMatchObject({ name: "plain", tools: [] });


### PR DESCRIPTION
# What and why

Preselected skill workers already receive their `SKILL.md` body as their system prompt. Remove `SkillsMiddleware` from those workers so it does not instruct them to read the same file again and duplicate the instructions in subsequent model context. Keep `FilesystemMiddleware` so workers can still read bundled reference files explicitly.

Adds regression coverage that verifies the skill body appears once, no Skills System prompt is injected, and sibling reference reads still work.

## Gates

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

## Verified how

- [ ] Drove the change in a real app (web/desktop/CLI) - describe what you saw
- [x] Tests only: the runtime integration test compiles an actual DeepAgents skill worker with a model probe, inspects its assembled system prompt, and exercises a bundled reference read without requiring a live provider.

## Layering

- [x] `packages/core` gained no `node:*`, DOM, `deepagents`, or `@langchain/langgraph` import
- [x] Only `packages/runtime-langgraph` imports the graph engine
- [x] `apps/web` imports no runtime and no model binding
- [x] Docs remain accurate; no documentation change was required