### PR TITLE
fix: specify package and binary names for Linux desktop makers

### DIFF
--- a/apps/desktop-shell/forge.config.ts
+++ b/apps/desktop-shell/forge.config.ts
@@ -149,8 +149,20 @@ const config: ForgeConfig = {
     }),
     new MakerZIP({}, ["darwin"]),
     new MakerDMG({ format: "ULFO", icon: path.join(iconsDir, "icon-mac.icns") }, ["darwin"]),
-    new MakerRpm({ options: { icon: path.join(iconsDir, "icon.png") } }),
-    new MakerDeb({ options: { icon: path.join(iconsDir, "icon.png") } }),
+    new MakerRpm({
+      options: {
+        name: "pizza-bot-oss",
+        bin: "pizza-bot-oss",
+        icon: path.join(iconsDir, "icon.png"),
+      },
+    }),
+    new MakerDeb({
+      options: {
+        name: "pizza-bot-oss",
+        bin: "pizza-bot-oss",
+        icon: path.join(iconsDir, "icon.png"),
+      },
+    }),
   ],
 
   plugins: [new AutoUnpackNativesPlugin({})],


### PR DESCRIPTION
# What and why

Fixes #43

Electron Forge Linux makers (`MakerDeb` and `MakerRpm`) defaulted `options.bin` and `options.name` to `package.json`'s `name` (`@pizza-bot/desktop-shell`). However, `packagerConfig` packages the binary using `executableName: "pizza-bot-oss"`, causing Forge to fail with:
`Error: could not find the Electron app binary at ".../out/Pizza Bot OSS-linux-x64/@pizza-bot/desktop-shell"`.

This change explicitly configures `name: "pizza-bot-oss"` and `bin: "pizza-bot-oss"` on both `MakerDeb` and `MakerRpm` in `apps/desktop-shell/forge.config.ts`.

## Gates

Run these checks locally before opening the PR:

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

## Verified how

- [x] Drove the change in a real app (web/desktop/CLI) - describe what you saw
  - Ran `npm run desktop:make -- --targets deb` on Linux x64, verifying that `pizza-bot-oss_1.0.0_amd64.deb` was built cleanly, including `/usr/bin/pizza-bot-oss` symlink and `.desktop` entry.

## Layering

- [x] `packages/core` gained no `node:*`, DOM, `deepagents`, or `@langchain/langgraph` import
- [x] Only `packages/runtime-langgraph` imports the graph engine
- [x] `apps/web` imports no runtime and no model binding
- [x] Docs touched by this change were updated (README / AGENTS.md / docs/ARCHITECTURE.md)
