### PR TITLE
fix: preserve subagent results at call limits

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,8 +175,10 @@ in `core/src/protocol-types.ts`:
 - **Runaway-call limits** are per agent invocation, with no combined parent/child
   budget. The orchestrator allows 20 model calls and 40 tool calls; each
   `task`-invoked skill worker independently allows 20 model calls and 80 tool
-  calls. A delegation counts as one orchestrator tool call, while the worker's
-  calls count only against that worker. Parallel calls are counted individually.
+  calls. A worker's last model call is tool-free and reserved for returning
+  verified results with an incomplete-coverage disclaimer when necessary. A
+  delegation counts as one orchestrator tool call, while the worker's calls count
+  only against that worker. Parallel calls are counted individually.
 - **Checkpointer** and **store** are passed *into* `createDeepAgent` (never set
   post-hoc). Checkpointer = short-term, thread-scoped; store = long-term,
   cross-thread.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16159,7 +16159,8 @@
         "@langchain/langgraph": "^1.4.9",
         "@pizza-bot/core": "*",
         "deepagents": "^1.12.2",
-        "langchain": "^1.5.5"
+        "langchain": "^1.5.5",
+        "zod": "^4.0.0"
       },
       "optionalDependencies": {
         "@langchain/quickjs": "0.6.1"

--- a/packages/runtime-langgraph/package.json
+++ b/packages/runtime-langgraph/package.json
@@ -18,7 +18,8 @@
     "@langchain/langgraph": "^1.4.9",
     "@pizza-bot/core": "*",
     "deepagents": "^1.12.2",
-    "langchain": "^1.5.5"
+    "langchain": "^1.5.5",
+    "zod": "^4.0.0"
   },
   "optionalDependencies": {
     "@langchain/quickjs": "0.6.1"

--- a/packages/runtime-langgraph/src/index.ts
+++ b/packages/runtime-langgraph/src/index.ts
@@ -34,6 +34,10 @@ import { modelCallLimitMiddleware, toolCallLimitMiddleware } from "langchain";
 import { buildBackend } from "./backend.js";
 import { toolErrorRecoveryMiddleware } from "./tool-error-middleware.js";
 import { outputTruncationMiddleware } from "./output-truncation-middleware.js";
+import {
+  SUBAGENT_MODEL_CALL_COUNT,
+  subagentFinalizationMiddleware,
+} from "./subagent-finalization-middleware.js";
 import { attachmentInlineMiddleware } from "./attachment-inline-middleware.js";
 import { currentDateTimeMiddleware } from "./current-date-time-middleware.js";
 import { streamProtocolEvents, toLangGraphInput, type ProtocolCapableGraph } from "./stream-protocol.js";
@@ -88,6 +92,7 @@ const SUBAGENT_STATE_EXCLUSIONS = [
   "runModelCallCount",
   "threadToolCallCount",
   "runToolCallCount",
+  SUBAGENT_MODEL_CALL_COUNT,
 ] as const;
 
 function excludeSubagentLocalState(state: Record<string, unknown>): Record<string, unknown> {
@@ -216,6 +221,7 @@ export async function resolveSkillSubagents(
     try {
       const middleware: unknown[] = [
         ...runLimitMiddleware(AGENT_RUN_LIMITS.subagent),
+        subagentFinalizationMiddleware(AGENT_RUN_LIMITS.subagent.modelCalls),
         toolErrorRecoveryMiddleware(),
         outputTruncationMiddleware(),
         currentDateTimeMiddleware(),

--- a/packages/runtime-langgraph/src/skill-workers.test.ts
+++ b/packages/runtime-langgraph/src/skill-workers.test.ts
@@ -51,6 +51,7 @@ describe("resolveSkillSubagents", () => {
     expect(resolved![0]!.middleware?.map((middleware) => middleware.name)).toEqual([
       "ModelCallLimitMiddleware",
       "ToolCallLimitMiddleware",
+      "subagentFinalization",
       "toolErrorRecovery",
       "outputTruncation",
       "DynamicSystemPromptMiddleware",
@@ -106,6 +107,7 @@ describe("resolveSkillSubagents", () => {
     expect(resolved![0]!.middleware?.map((middleware) => middleware.name)).toEqual([
       "ModelCallLimitMiddleware",
       "ToolCallLimitMiddleware",
+      "subagentFinalization",
       "toolErrorRecovery",
       "outputTruncation",
       "DynamicSystemPromptMiddleware",

--- a/packages/runtime-langgraph/src/subagent-finalization-middleware.test.ts
+++ b/packages/runtime-langgraph/src/subagent-finalization-middleware.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+  type BaseMessage,
+} from "@langchain/core/messages";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { tool } from "@langchain/core/tools";
+import { createSubAgent } from "deepagents";
+import { modelCallLimitMiddleware, type AnyAgentMiddleware } from "langchain";
+import {
+  SUBAGENT_MODEL_CALL_COUNT,
+  SUBAGENT_FINALIZATION_INSTRUCTION,
+  subagentFinalizationMiddleware,
+} from "./subagent-finalization-middleware.js";
+
+function wrapModelCall(runLimit = 20) {
+  const middleware = subagentFinalizationMiddleware(runLimit) as unknown as {
+    wrapModelCall: (
+      request: {
+        state: { runSubagentModelCallCount: number };
+        messages: BaseMessage[];
+        systemMessage: SystemMessage;
+        tools: unknown[];
+      },
+      handler: (request: {
+        state: { runSubagentModelCallCount: number };
+        messages: BaseMessage[];
+        systemMessage: SystemMessage;
+        tools: unknown[];
+      }) => Promise<AIMessage>,
+    ) => Promise<AIMessage>;
+  };
+  return middleware.wrapModelCall;
+}
+
+interface TestModelRequest {
+  state: { runSubagentModelCallCount: number };
+  messages: BaseMessage[];
+  systemMessage: SystemMessage;
+  tools: unknown[];
+}
+
+function request(runModelCallCount: number): TestModelRequest {
+  return {
+    state: { [SUBAGENT_MODEL_CALL_COUNT]: runModelCallCount },
+    messages: [new HumanMessage("research")],
+    systemMessage: new SystemMessage("You are a researcher."),
+    tools: [{ name: "search" }],
+  };
+}
+
+interface FinalizingTrace {
+  calls: number;
+  lookupCalls: number;
+  sawFinalizationInstruction: boolean;
+  finalCallHadToolProtocol: boolean;
+}
+
+class FinalizingModel extends BaseChatModel<Record<string, never>> {
+  private boundToolCount = 0;
+
+  constructor(private readonly trace: FinalizingTrace) {
+    super({});
+  }
+
+  _llmType(): string {
+    return "finalizing";
+  }
+
+  override bindTools(tools: Array<{ name: string }>): this {
+    const bound = new FinalizingModel(this.trace);
+    bound.boundToolCount = tools.length;
+    return bound as this;
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+  ): Promise<{ generations: Array<{ message: AIMessage; text: string }> }> {
+    this.trace.calls += 1;
+    this.trace.sawFinalizationInstruction ||= messages.some(
+      (message) =>
+        SystemMessage.isInstance(message) &&
+        message.text.includes(SUBAGENT_FINALIZATION_INSTRUCTION),
+    );
+    if (this.boundToolCount === 0) {
+      this.trace.finalCallHadToolProtocol ||= messages.some(
+        (message) =>
+          ToolMessage.isInstance(message) ||
+          (AIMessage.isInstance(message) && Boolean(message.tool_calls?.length)),
+      );
+    }
+    const message = this.boundToolCount > 0
+      ? new AIMessage({
+          content: "",
+          tool_calls: [{
+            id: "lookup-1",
+            name: "lookup",
+            args: {},
+            type: "tool_call",
+          }],
+        })
+      : new AIMessage(
+          messages.some((message) => message.text.includes("verified finding"))
+            ? "Partial result: verified finding"
+            : "Partial result: nothing found",
+        );
+    return { generations: [{ message, text: message.text }] };
+  }
+}
+
+describe("subagentFinalizationMiddleware", () => {
+  it("leaves ordinary worker calls unchanged", async () => {
+    const wrap = wrapModelCall();
+    const input = request(18);
+    const handler = vi.fn(async (_request: ReturnType<typeof request>) =>
+      new AIMessage("continue")
+    );
+
+    await wrap(input, handler);
+
+    expect(handler).toHaveBeenCalledWith(input);
+  });
+
+  it("makes the final allowed worker call tool-free and requests partial results", async () => {
+    const wrap = wrapModelCall();
+    const input = request(19);
+    input.messages.push(
+      new AIMessage({
+        content: "",
+        tool_calls: [{
+          id: "lookup-1",
+          name: "search",
+          args: {},
+          type: "tool_call",
+        }],
+      }),
+      new ToolMessage({
+        content: "verified finding",
+        tool_call_id: "lookup-1",
+        name: "search",
+      }),
+    );
+    const handler = vi.fn(async (_request: ReturnType<typeof request>) =>
+      new AIMessage("verified partial result")
+    );
+
+    const result = await wrap(input, handler);
+
+    expect(result.text).toBe("verified partial result");
+    const finalRequest = handler.mock.calls[0]![0];
+    expect(finalRequest.tools).toEqual([]);
+    expect(finalRequest.systemMessage.text).toContain(SUBAGENT_FINALIZATION_INSTRUCTION);
+    expect(finalRequest.messages.some(ToolMessage.isInstance)).toBe(false);
+    expect(finalRequest.messages.some(
+      (message) => AIMessage.isInstance(message) && Boolean(message.tool_calls?.length),
+    )).toBe(false);
+    expect(finalRequest.messages.at(-1)?.text).toContain("verified finding");
+  });
+
+  it("rejects invalid limits", () => {
+    expect(() => subagentFinalizationMiddleware(0)).toThrow("positive integer");
+  });
+
+  it("returns accumulated worker results on the last invocation-local model call", async () => {
+    const trace: FinalizingTrace = {
+      calls: 0,
+      lookupCalls: 0,
+      sawFinalizationInstruction: false,
+      finalCallHadToolProtocol: false,
+    };
+    const lookup = tool(
+      () => {
+        trace.lookupCalls += 1;
+        return "verified finding";
+      },
+      {
+        name: "lookup",
+        description: "Find a fact.",
+        schema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+      },
+    );
+    const worker = createSubAgent({
+      name: "researcher",
+      description: "Researches facts.",
+      systemPrompt: "Use lookup before answering.",
+      model: new FinalizingModel(trace),
+      tools: [lookup],
+      middleware: [
+        (modelCallLimitMiddleware as unknown as (options: {
+          runLimit: number;
+          exitBehavior: "end";
+        }) => AnyAgentMiddleware)({
+          runLimit: 2,
+          exitBehavior: "end",
+        }),
+        subagentFinalizationMiddleware(2),
+      ],
+    });
+
+    for (const prompt of ["Find the fact.", "Find it again."]) {
+      const result = await worker.invoke({
+        messages: [new HumanMessage(prompt)],
+      });
+      const final = result.messages.at(-1);
+
+      expect(final).toBeInstanceOf(AIMessage);
+      expect(final?.text).toBe("Partial result: verified finding");
+      expect(final?.text).not.toContain("Model call limits exceeded");
+    }
+    expect(trace).toEqual({
+      calls: 4,
+      lookupCalls: 2,
+      sawFinalizationInstruction: true,
+      finalCallHadToolProtocol: false,
+    });
+  });
+});

--- a/packages/runtime-langgraph/src/subagent-finalization-middleware.ts
+++ b/packages/runtime-langgraph/src/subagent-finalization-middleware.ts
@@ -1,0 +1,91 @@
+/** Reserves a worker's last model call for a useful, tool-free response. */
+import {
+  AIMessage,
+  HumanMessage,
+  ToolMessage,
+  type BaseMessage,
+} from "@langchain/core/messages";
+import { createMiddleware } from "langchain";
+import { z } from "zod";
+
+export const SUBAGENT_FINALIZATION_INSTRUCTION =
+  "This is the final model call available for this delegated task. " +
+  "Do not call tools. Return the most useful answer supported by results already " +
+  "in the conversation. Clearly disclose unavailable sources, failed searches, " +
+  "uncertainty, and incomplete coverage. Do not return only a call-limit notice.";
+
+export const SUBAGENT_MODEL_CALL_COUNT = "runSubagentModelCallCount";
+
+const stateSchema = z.object({
+  [SUBAGENT_MODEL_CALL_COUNT]: z.number().default(0),
+});
+
+export function subagentFinalizationMiddleware(runLimit: number) {
+  if (!Number.isInteger(runLimit) || runLimit < 1) {
+    throw new Error("Subagent finalization requires a positive integer run limit.");
+  }
+
+  return createMiddleware({
+    name: "subagentFinalization",
+    stateSchema,
+    wrapModelCall: async (request, handler) => {
+      if (request.state[SUBAGENT_MODEL_CALL_COUNT] !== runLimit - 1) {
+        return handler(request);
+      }
+      return handler({
+        ...request,
+        messages: toolHistoryAsText(request.messages),
+        tools: [],
+        systemMessage: request.systemMessage.concat(SUBAGENT_FINALIZATION_INSTRUCTION),
+      });
+    },
+    afterModel: (state) => ({
+      [SUBAGENT_MODEL_CALL_COUNT]: state[SUBAGENT_MODEL_CALL_COUNT] + 1,
+    }),
+    afterAgent: () => ({
+      [SUBAGENT_MODEL_CALL_COUNT]: 0,
+    }),
+  });
+}
+
+function toolHistoryAsText(messages: BaseMessage[]): BaseMessage[] {
+  const converted: BaseMessage[] = [];
+  let toolResults: string[] = [];
+
+  const flushToolResults = () => {
+    if (toolResults.length === 0) return;
+    converted.push(new HumanMessage(toolResults.join("\n\n")));
+    toolResults = [];
+  };
+
+  for (const message of messages) {
+    if (ToolMessage.isInstance(message)) {
+      const content = message.text.trim() || JSON.stringify(message.content);
+      toolResults.push(`Tool result from "${message.name ?? "unknown"}":\n${content}`);
+      continue;
+    }
+
+    flushToolResults();
+    if (AIMessage.isInstance(message) && hasToolProtocol(message)) {
+      converted.push(new AIMessage(
+        message.text.trim() || "Tool calls completed; results follow.",
+      ));
+      continue;
+    }
+    converted.push(message);
+  }
+
+  flushToolResults();
+  return converted;
+}
+
+function hasToolProtocol(message: AIMessage): boolean {
+  if (message.tool_calls?.length) return true;
+  return Array.isArray(message.content) && message.content.some(
+    (block) =>
+      typeof block === "object" &&
+      block !== null &&
+      "type" in block &&
+      (block.type === "tool_call" || block.type === "tool_use"),
+  );
+}

--- a/packages/runtime-langgraph/src/tool-error-middleware.test.ts
+++ b/packages/runtime-langgraph/src/tool-error-middleware.test.ts
@@ -37,6 +37,38 @@ describe("toolErrorRecoveryMiddleware", () => {
     expect(String(out.content)).toContain("try again");
   });
 
+  it("tells the model to stop retrying a persistently rate-limited source", async () => {
+    const wrap = wrapToolCall();
+    const rateLimit = Object.assign(new Error("request rejected"), {
+      code: "RATE_LIMIT",
+    });
+    const out = (await wrap(request("search", "call_rate"), async () => {
+      throw rateLimit;
+    })) as ToolMessage;
+
+    expect(String(out.content)).toContain("rate-limited");
+    expect(String(out.content)).toContain("Retry this tool at most once");
+    expect(String(out.content)).toContain("partial results");
+    expect(String(out.content)).not.toContain("fix the arguments");
+  });
+
+  it("recognizes a nested HTTP 429 without relying on provider message text", async () => {
+    const wrap = wrapToolCall();
+    const rateLimit = Object.assign(new Error("request rejected"), { status: 429 });
+    const invocationError = new ToolInvocationError(rateLimit, {
+      id: "call_rate",
+      name: "search",
+      args: {},
+      type: "tool_call",
+    });
+    const out = (await wrap(request("search", "call_rate"), async () => {
+      throw invocationError;
+    })) as ToolMessage;
+
+    expect(String(out.content)).toContain("rate-limited");
+    expect(String(out.content)).not.toContain("fix the arguments");
+  });
+
   it("RE-THROWS a graph interrupt (HITL must still pause, not be swallowed)", async () => {
     const wrap = wrapToolCall();
     const interrupt = new GraphInterrupt([{ value: "approve?", id: "i1" }]);

--- a/packages/runtime-langgraph/src/tool-error-middleware.ts
+++ b/packages/runtime-langgraph/src/tool-error-middleware.ts
@@ -2,6 +2,12 @@
 import { createMiddleware, ToolInvocationError } from "langchain";
 import { ToolMessage } from "@langchain/core/messages";
 import { isGraphInterrupt } from "@langchain/langgraph";
+import { classifyError } from "@pizza-bot/core";
+
+const RATE_LIMIT_GUIDANCE =
+  "The tool's source is rate-limited. Retry this tool at most once. If it is " +
+  "still unavailable, stop using this source for this run and return verified " +
+  "partial results with a clear coverage disclaimer.";
 
 /**
  * In langchain@1.5.2/deepagents@1.12.1, inner wrappers turn tool failures into
@@ -21,9 +27,13 @@ export function toolErrorRecoveryMiddleware() {
         if (isGraphInterrupt(err)) throw err;
         const { id, name } = request.toolCall;
         const detail = toolErrorDetail(err);
+        const guidance =
+          toolErrorCode(err) === "RATE_LIMIT"
+            ? RATE_LIMIT_GUIDANCE
+            : "Please fix the arguments and try again.";
         return new ToolMessage({
           status: "error",
-          content: `Error running tool "${name}": ${detail}\nPlease fix the arguments and try again.`,
+          content: `Error running tool "${name}": ${detail}\n${guidance}`,
           tool_call_id: id ?? "",
           name,
         });
@@ -41,4 +51,26 @@ function toolErrorDetail(error: unknown): string {
     current = current.cause;
   }
   return error instanceof Error ? error.message : String(error);
+}
+
+function toolErrorCode(error: unknown) {
+  let current = error;
+  const seen = new Set<unknown>();
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    if (classifyError(current) === "RATE_LIMIT" || httpStatusOf(current) === 429) {
+      return "RATE_LIMIT";
+    }
+    current =
+      current instanceof ToolInvocationError
+        ? current.toolError
+        : (current as { cause?: unknown }).cause;
+  }
+  return classifyError(toolErrorDetail(error));
+}
+
+function httpStatusOf(error: object): number | undefined {
+  const value = error as { status?: unknown; statusCode?: unknown };
+  const status = value.status ?? value.statusCode;
+  return typeof status === "number" ? status : undefined;
 }


### PR DESCRIPTION
## Summary

- reserve each skill worker final model call for tool-free partial-result synthesis
- convert historical tool protocol to provider-safe text before Bedrock finalization
- classify rate limits structurally and tell workers to stop retrying unavailable sources
- keep finalization accounting local to each worker invocation

## Verification

- `npm run build -w @pizza-bot/runtime-langgraph`
- `npm run lint`
- `npm run typecheck`
- `npm test`

Closes #45