### PR TITLE
Allow confirmed local access to Pizza Bot data root

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -104,8 +104,12 @@ use a SQLite-aware snapshot when backing up live databases.
   is a separate explicit choice that allows creating, changing, and deleting
   files beneath that root. DeepAgents virtual mode provides lexical confinement,
   and Pizza Bot also validates canonical paths and mutation parents to reject
-  traversal and symlink or junction escapes. The Pizza Bot data root and its
-  ancestors and descendants cannot be granted.
+  traversal and symlink or junction escapes.
+- **Data-root access requires confirmation.** A grant that overlaps the Pizza Bot
+  data root triggers an additional warning before it is created. If confirmed,
+  read access can expose conversations, memories, attachments, configuration,
+  logs, and stored credentials. Write access can also corrupt or delete
+  application state.
 - **Folder contents can leave the machine.** The agent may read any accessible
   file below a granted root and include it in prompts or tool calls sent to the
   configured model and MCP providers. Review a folder's complete contents

--- a/apps/api-server/src/routes-local-folders.test.ts
+++ b/apps/api-server/src/routes-local-folders.test.ts
@@ -127,13 +127,13 @@ describe("local folder routes", () => {
     },
   );
 
-  it("rejects protected or inaccessible browse roots at startup", () => {
+  it("accepts data-root browse paths and rejects inaccessible roots at startup", () => {
     expect(() =>
       buildApp(host, {
         allowLocalFolderConfiguration: true,
         localFolderBrowseRoots: [dataRoot],
       })
-    ).toThrow("cannot include the Pizza Bot data directory");
+    ).not.toThrow();
     expect(() =>
       buildApp(host, {
         allowLocalFolderConfiguration: true,
@@ -237,19 +237,61 @@ describe("local folder routes", () => {
     expect((await create(otherParent, true)).status).toBe(201);
   });
 
-  it("rejects relative, missing, file, and Pizza Bot data paths", async () => {
+  it("warns before granting paths that overlap the Pizza Bot data root", async () => {
     const app = buildApp(host, { allowLocalFolderConfiguration: true });
     const nested = join(dataRoot, "nested");
-    const file = join(allowed, "file.txt");
     mkdirSync(nested);
+
+    for (const folderPath of [dataRoot, nested, join(dataRoot, "..")]) {
+      const response = await app.request("/local-folders", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ path: folderPath, readOnly: false }),
+      });
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({
+        error: "data_root_access_requires_confirmation",
+      });
+    }
+
+    const confirmedReadOnly = await app.request("/local-folders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        path: dataRoot,
+        acknowledgeDataRootAccess: true,
+      }),
+    });
+    expect(confirmedReadOnly.status).toBe(201);
+    const readOnlyFolder = await confirmedReadOnly.json() as {
+      id: string;
+      path: string;
+      readOnly: boolean;
+    };
+    expect(readOnlyFolder).toMatchObject({
+      path: realpathSync.native(dataRoot),
+      readOnly: true,
+    });
+
+    await app.request(`/local-folders/${readOnlyFolder.id}`, { method: "DELETE" });
+    const confirmedWritable = await app.request("/local-folders", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        path: join(dataRoot, ".."),
+        readOnly: false,
+        acknowledgeDataRootAccess: true,
+      }),
+    });
+    expect(confirmedWritable.status).toBe(201);
+    expect(await confirmedWritable.json()).toMatchObject({ readOnly: false });
+  });
+
+  it("rejects relative, missing, file, and invalid-access paths", async () => {
+    const app = buildApp(host, { allowLocalFolderConfiguration: true });
+    const file = join(allowed, "file.txt");
     writeFileSync(file, "not a directory", "utf8");
-    for (const folderPath of [
-      "relative",
-      join(allowed, "missing"),
-      file,
-      dataRoot,
-      nested,
-    ]) {
+    for (const folderPath of ["relative", join(allowed, "missing"), file]) {
       const response = await app.request("/local-folders", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -257,13 +299,6 @@ describe("local folder routes", () => {
       });
       expect(response.status).toBe(400);
     }
-
-    const protectedParent = await app.request("/local-folders", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ path: join(dataRoot, "..") }),
-    });
-    expect(protectedParent.status).toBe(400);
 
     const invalidAccess = await app.request("/local-folders", {
       method: "POST",

--- a/apps/api-server/src/routes-local-folders.ts
+++ b/apps/api-server/src/routes-local-folders.ts
@@ -130,10 +130,8 @@ function overlappingGrantError(
 }
 
 function canonicalBrowseRoots(
-  host: AgentHost,
   configuredRoots: readonly string[],
 ): string[] {
-  const dataRoot = canonicalDataRoot(host);
   const roots = configuredRoots.map((configured) => {
     if (!path.isAbsolute(configured)) {
       throw new Error(
@@ -149,11 +147,6 @@ function canonicalBrowseRoots(
         `PIZZA_LOCAL_FOLDER_BROWSE_ROOTS directory is not accessible: ${configured}`,
       );
     }
-    if (isProtectedPath(dataRoot, canonical)) {
-      throw new Error(
-        "PIZZA_LOCAL_FOLDER_BROWSE_ROOTS cannot include the Pizza Bot data directory or its ancestors or descendants",
-      );
-    }
     return canonical;
   });
   return [...new Set(roots)];
@@ -165,7 +158,7 @@ export function localFolderRoutes(
 ): Hono {
   const app = new Hono();
   const configurable = options.configurable;
-  const browseRoots = canonicalBrowseRoots(host, options.browseRoots ?? []);
+  const browseRoots = canonicalBrowseRoots(options.browseRoots ?? []);
   const dataRoot = canonicalDataRoot(host);
 
   app.get("/local-folders", (c) => {
@@ -276,13 +269,17 @@ export function localFolderRoutes(
       return c.json({ error: "invalid_path", detail: directory.detail }, 400);
     }
 
-    if (isProtectedPath(dataRoot, directory.path)) {
+    if (
+      isProtectedPath(dataRoot, directory.path) &&
+      raw.acknowledgeDataRootAccess !== true
+    ) {
       return c.json(
         {
-          error: "protected_path",
-          detail: "The Pizza Bot data directory cannot be exposed as a local folder.",
+          error: "data_root_access_requires_confirmation",
+          detail:
+            "This folder overlaps the Pizza Bot data directory. Confirm access to continue.",
         },
-        400,
+        409,
       );
     }
     if (host.localFolders.hasPath(directory.path)) {

--- a/apps/web/src/api-client.test.ts
+++ b/apps/web/src/api-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
-import { ApiClient } from "./api-client.js";
+import { ApiClient, ApiError } from "./api-client.js";
 
 describe("ApiClient", () => {
   afterEach(() => {
@@ -629,7 +629,12 @@ describe("ApiClient", () => {
           status: 503,
         })) as unknown as typeof fetch,
     });
-    await expect(client.listModels()).rejects.toThrow("list models failed: 503 backend unavailable");
+    const error = await client.listModels().catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({
+      code: "boom",
+      message: "list models failed: 503 backend unavailable",
+    });
   });
 
   it("requests an unfiltered forced model catalog refresh", async () => {

--- a/apps/web/src/api-client.ts
+++ b/apps/web/src/api-client.ts
@@ -40,6 +40,7 @@ export class ApiError extends Error {
     readonly status: number,
     readonly statusText: string,
     detail?: string,
+    readonly code?: string,
   ) {
     super(`${action} failed: ${status} ${detail ?? statusText}`);
     this.name = "ApiError";
@@ -661,18 +662,27 @@ async function readSseChunk(
 export const SECRET_UNCHANGED = "__unchanged__";
 
 async function apiError(action: string, res: Response): Promise<ApiError> {
-  const detail = await res
+  const body = await res
     .clone()
     .json()
     .then((body: unknown) => {
       if (body && typeof body === "object") {
         const b = body as { detail?: string; error?: string; message?: string };
-        return b.detail ?? b.message ?? b.error;
+        return {
+          detail: b.detail ?? b.message ?? b.error,
+          code: b.error,
+        };
       }
       return undefined;
     })
     .catch(() => undefined);
-  return new ApiError(action, res.status, res.statusText, detail);
+  return new ApiError(
+    action,
+    res.status,
+    res.statusText,
+    body?.detail,
+    body?.code,
+  );
 }
 
 function deletedFlag(body: unknown): boolean {

--- a/apps/web/src/components/settings/LocalFoldersSettings.tsx
+++ b/apps/web/src/components/settings/LocalFoldersSettings.tsx
@@ -8,7 +8,7 @@ import {
 } from "lucide-react";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import type { LocalFolder, LocalFolderList } from "@pizza-bot/core";
-import type { ApiClient } from "@/api-client";
+import { ApiError, type ApiClient } from "@/api-client";
 import { ConfirmationDialog } from "../ConfirmationDialog.js";
 import { BackendDirectoryPicker } from "./BackendDirectoryPicker.js";
 
@@ -40,7 +40,13 @@ function AddFolderDialog({
   const [readOnly, setReadOnly] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string>();
+  const [dataRootWarning, setDataRootWarning] = useState(false);
   const [showBackendPicker, setShowBackendPicker] = useState(false);
+
+  const updatePath = (nextPath: string) => {
+    setPath(nextPath);
+    setDataRootWarning(false);
+  };
 
   const pickDirectory = async () => {
     setError(undefined);
@@ -51,7 +57,7 @@ function AddFolderDialog({
     try {
       const selected = await window.__PIZZA_LOCAL_FOLDERS__.pickDirectory();
       if (!selected) return;
-      setPath(selected);
+      updatePath(selected);
     } catch (cause) {
       setError(message(cause));
     }
@@ -64,11 +70,19 @@ function AddFolderDialog({
       await client.createLocalFolder({
         path: path.trim(),
         readOnly,
+        ...(dataRootWarning ? { acknowledgeDataRootAccess: true } : {}),
       });
       await onAdded();
       onClose();
     } catch (cause) {
-      setError(message(cause));
+      if (
+        cause instanceof ApiError &&
+        cause.code === "data_root_access_requires_confirmation"
+      ) {
+        setDataRootWarning(true);
+      } else {
+        setError(message(cause));
+      }
     } finally {
       setBusy(false);
     }
@@ -96,7 +110,7 @@ function AddFolderDialog({
               <input
                 aria-label="Folder path on backend"
                 value={path}
-                onChange={(event) => setPath(event.target.value)}
+                onChange={(event) => updatePath(event.target.value)}
                 placeholder="Absolute path on backend"
               />
               {((canPickDirectory && window.__PIZZA_LOCAL_FOLDERS__) ||
@@ -159,6 +173,17 @@ function AddFolderDialog({
               </p>
             )}
 
+            {dataRootWarning && (
+              <p className="local-folder-write-warning" role="note">
+                This folder overlaps Pizza Bot&apos;s private data. The agent may
+                access conversations, memories, attachments, configuration, logs,
+                and stored credentials
+                {readOnly
+                  ? "."
+                  : ", and may corrupt or delete application state."}
+              </p>
+            )}
+
             {error && (
               <div className="sidebar-modal-error" role="alert">
                 {error}
@@ -176,7 +201,7 @@ function AddFolderDialog({
                 disabled={busy || !path.trim()}
                 onClick={() => void add()}
               >
-                Add folder
+                {dataRootWarning ? "Add anyway" : "Add folder"}
               </button>
             </div>
           </DialogPrimitive.Content>
@@ -188,7 +213,7 @@ function AddFolderDialog({
           client={client}
           onCancel={() => setShowBackendPicker(false)}
           onSelect={(selected) => {
-            setPath(selected);
+            updatePath(selected);
             setShowBackendPicker(false);
           }}
         />

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,7 +197,8 @@ in `core/src/protocol-types.ts`:
   the backend reverses that encoding before using the granted filesystem root.
   Read-only lookups may recover a uniquely NFKC-equivalent on-disk path when a
   model changes a compatibility character; mutations always require the exact
-  virtual path.
+  virtual path. Grants that overlap the application data root require explicit
+  acknowledgement because they can expose or modify private application state.
   Standalone directory browsing is a separate, operator-configured capability:
   the API lists directories only beneath canonical
   `PIZZA_LOCAL_FOLDER_BROWSE_ROOTS` and never follows symlinks while browsing.

--- a/docs/STANDALONE_BACKEND.md
+++ b/docs/STANDALONE_BACKEND.md
@@ -225,8 +225,8 @@ cannot leave those canonical roots. Display labels and virtual path ids are
 derived from the selected directory name. While configuration is enabled,
 anyone with the backend bearer token can enumerate directory names beneath the
 browse roots and grant read or write access to directories accessible by the
-backend process, except the Pizza Bot data root and its ancestors or
-descendants.
+backend process. Grants that overlap the Pizza Bot data root require an explicit
+acknowledgement because they can expose or modify private application state.
 
 For example, this stores an Anthropic environment reference without sending the
 secret over the API:

--- a/packages/core/src/local-folder.ts
+++ b/packages/core/src/local-folder.ts
@@ -23,6 +23,8 @@ export interface CreateLocalFolderInput {
   path: string;
   /** Defaults to true when omitted. */
   readOnly?: boolean;
+  /** Confirms access when the grant overlaps Pizza Bot's data directory. */
+  acknowledgeDataRootAccess?: boolean;
 }
 
 export interface LocalFolderBrowseEntry {


### PR DESCRIPTION
## Summary

- replace the hard data-root overlap rejection with an explicit acknowledgement challenge
- show an inline private-data warning before retrying read-only or read-write grants
- allow overlapping standalone browse roots and document the resulting security boundary
- cover data-root, ancestor, descendant, read-only, and writable grant behavior

## Verification

- `npm run build`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- browser verification at desktop and 390px mobile widths

Closes #47