### PR TITLE
fix: surface partial Bedrock catalogs and keep the automatic default sticky

### DIFF
--- a/apps/api-server/src/agent-host.test.ts
+++ b/apps/api-server/src/agent-host.test.ts
@@ -230,6 +230,90 @@ writeFileSync(
     });
   });
 
+  it("keeps the remembered automatic model while the catalog is incomplete", async () => {
+    const selectAutomaticModel = (
+      host as unknown as {
+        selectAutomaticModel(
+          catalog: () => Promise<{ ids: string[]; healthy: boolean }>,
+          build: (id: string) => Promise<unknown>,
+        ): Promise<{ modelId: string; model: unknown }>;
+      }
+    ).selectAutomaticModel.bind(host);
+    const build = async (modelId: string) => ({ modelId });
+
+    const healthy = await selectAutomaticModel(
+      async () => ({ ids: ["bedrock:global.anthropic.claude-sonnet-5", "bedrock:amazon.nova-pro"], healthy: true }),
+      build,
+    );
+    expect(healthy.modelId).toBe("bedrock:global.anthropic.claude-sonnet-5");
+    expect(host.providerConfigs.getAutomaticModel()).toBe(
+      "bedrock:global.anthropic.claude-sonnet-5",
+    );
+
+    // The Sonnet profiles are missing from the degraded catalog, but the
+    // remembered pick still builds, so scheduled runs keep their model.
+    const degraded = await selectAutomaticModel(
+      async () => ({ ids: ["bedrock:amazon.nova-pro"], healthy: false }),
+      build,
+    );
+
+    expect(degraded.modelId).toBe("bedrock:global.anthropic.claude-sonnet-5");
+  });
+
+  it("re-picks the automatic model once the catalog is complete again", async () => {
+    const selectAutomaticModel = (
+      host as unknown as {
+        selectAutomaticModel(
+          catalog: () => Promise<{ ids: string[]; healthy: boolean }>,
+          build: (id: string) => Promise<unknown>,
+        ): Promise<{ modelId: string; model: unknown }>;
+      }
+    ).selectAutomaticModel.bind(host);
+    const build = async (modelId: string) => ({ modelId });
+
+    await selectAutomaticModel(
+      async () => ({ ids: ["bedrock:amazon.nova-pro"], healthy: true }),
+      build,
+    );
+    const upgraded = await selectAutomaticModel(
+      async () => ({ ids: ["bedrock:global.anthropic.claude-sonnet-5"], healthy: true }),
+      build,
+    );
+
+    expect(upgraded.modelId).toBe("bedrock:global.anthropic.claude-sonnet-5");
+    expect(host.providerConfigs.getAutomaticModel()).toBe(
+      "bedrock:global.anthropic.claude-sonnet-5",
+    );
+  });
+
+  it("skips a remembered automatic model that no longer builds", async () => {
+    host.providerConfigs.setAutomaticModel("bedrock:global.anthropic.claude-sonnet-5");
+    const selectAutomaticModel = (
+      host as unknown as {
+        selectAutomaticModel(
+          catalog: () => Promise<{ ids: string[]; healthy: boolean }>,
+          build: (id: string) => Promise<unknown>,
+        ): Promise<{ modelId: string; model: unknown }>;
+      }
+    ).selectAutomaticModel.bind(host);
+
+    const selected = await selectAutomaticModel(
+      async () => ({ ids: ["bedrock:amazon.nova-pro"], healthy: false }),
+      async (modelId) => {
+        if (modelId === "bedrock:global.anthropic.claude-sonnet-5") {
+          throw new Error("not entitled");
+        }
+        return { modelId };
+      },
+    );
+
+    expect(selected.modelId).toBe("bedrock:amazon.nova-pro");
+    // A degraded catalog must not overwrite the remembered pick.
+    expect(host.providerConfigs.getAutomaticModel()).toBe(
+      "bedrock:global.anthropic.claude-sonnet-5",
+    );
+  });
+
   it("pins the resolved model to a thread and reuses it on later turns", async () => {
     const agentFor = vi.spyOn(host, "agentFor").mockResolvedValue(host.agent);
     const resolveTurn = (

--- a/apps/api-server/src/agent-host.test.ts
+++ b/apps/api-server/src/agent-host.test.ts
@@ -54,6 +54,33 @@ function materializerPlugin(
   };
 }
 
+type AutomaticCatalog = (
+  remembered?: string,
+) => Promise<{ ids: string[]; complete: boolean; keeping?: string }>;
+
+/** Mirrors how `automaticModelCatalog` leads with the remembered pick. */
+function catalogOf(ids: string[], complete: boolean): AutomaticCatalog {
+  return async (remembered) =>
+    complete || !remembered
+      ? { ids, complete }
+      : {
+          ids: [remembered, ...ids.filter((id) => id !== remembered)],
+          complete,
+          keeping: remembered,
+        };
+}
+
+function automaticSelector(host: AgentHost) {
+  return (
+    host as unknown as {
+      selectAutomaticModel(
+        catalog: AutomaticCatalog,
+        build: (id: string) => Promise<unknown>,
+      ): Promise<{ modelId: string; model: unknown }>;
+    }
+  ).selectAutomaticModel.bind(host);
+}
+
 describe("AgentHost lifecycle and identity", () => {
   let dataRoot: string;
   let pluginsDir: string;
@@ -231,21 +258,14 @@ writeFileSync(
   });
 
   it("keeps the remembered automatic model while the catalog is incomplete", async () => {
-    const selectAutomaticModel = (
-      host as unknown as {
-        selectAutomaticModel(
-          catalog: () => Promise<{ ids: string[]; healthy: boolean }>,
-          build: (id: string) => Promise<unknown>,
-        ): Promise<{ modelId: string; model: unknown }>;
-      }
-    ).selectAutomaticModel.bind(host);
+    const selectAutomaticModel = automaticSelector(host);
     const build = async (modelId: string) => ({ modelId });
 
-    const healthy = await selectAutomaticModel(
-      async () => ({ ids: ["bedrock:global.anthropic.claude-sonnet-5", "bedrock:amazon.nova-pro"], healthy: true }),
+    const whole = await selectAutomaticModel(
+      catalogOf(["bedrock:global.anthropic.claude-sonnet-5", "bedrock:amazon.nova-pro"], true),
       build,
     );
-    expect(healthy.modelId).toBe("bedrock:global.anthropic.claude-sonnet-5");
+    expect(whole.modelId).toBe("bedrock:global.anthropic.claude-sonnet-5");
     expect(host.providerConfigs.getAutomaticModel()).toBe(
       "bedrock:global.anthropic.claude-sonnet-5",
     );
@@ -253,30 +273,23 @@ writeFileSync(
     // The Sonnet profiles are missing from the degraded catalog, but the
     // remembered pick still builds, so scheduled runs keep their model.
     const degraded = await selectAutomaticModel(
-      async () => ({ ids: ["bedrock:amazon.nova-pro"], healthy: false }),
+      catalogOf(["bedrock:amazon.nova-pro"], false),
       build,
     );
 
     expect(degraded.modelId).toBe("bedrock:global.anthropic.claude-sonnet-5");
+    expect(host.providerConfigs.getAutomaticModel()).toBe(
+      "bedrock:global.anthropic.claude-sonnet-5",
+    );
   });
 
   it("re-picks the automatic model once the catalog is complete again", async () => {
-    const selectAutomaticModel = (
-      host as unknown as {
-        selectAutomaticModel(
-          catalog: () => Promise<{ ids: string[]; healthy: boolean }>,
-          build: (id: string) => Promise<unknown>,
-        ): Promise<{ modelId: string; model: unknown }>;
-      }
-    ).selectAutomaticModel.bind(host);
+    const selectAutomaticModel = automaticSelector(host);
     const build = async (modelId: string) => ({ modelId });
 
-    await selectAutomaticModel(
-      async () => ({ ids: ["bedrock:amazon.nova-pro"], healthy: true }),
-      build,
-    );
+    await selectAutomaticModel(catalogOf(["bedrock:amazon.nova-pro"], true), build);
     const upgraded = await selectAutomaticModel(
-      async () => ({ ids: ["bedrock:global.anthropic.claude-sonnet-5"], healthy: true }),
+      catalogOf(["bedrock:global.anthropic.claude-sonnet-5"], true),
       build,
     );
 
@@ -288,17 +301,10 @@ writeFileSync(
 
   it("skips a remembered automatic model that no longer builds", async () => {
     host.providerConfigs.setAutomaticModel("bedrock:global.anthropic.claude-sonnet-5");
-    const selectAutomaticModel = (
-      host as unknown as {
-        selectAutomaticModel(
-          catalog: () => Promise<{ ids: string[]; healthy: boolean }>,
-          build: (id: string) => Promise<unknown>,
-        ): Promise<{ modelId: string; model: unknown }>;
-      }
-    ).selectAutomaticModel.bind(host);
+    const selectAutomaticModel = automaticSelector(host);
 
     const selected = await selectAutomaticModel(
-      async () => ({ ids: ["bedrock:amazon.nova-pro"], healthy: false }),
+      catalogOf(["bedrock:amazon.nova-pro"], false),
       async (modelId) => {
         if (modelId === "bedrock:global.anthropic.claude-sonnet-5") {
           throw new Error("not entitled");

--- a/apps/api-server/src/agent-host.ts
+++ b/apps/api-server/src/agent-host.ts
@@ -3,10 +3,11 @@ import {
   ModelRegistry,
   ModelUnavailableError,
   projectSkillReadiness,
-  recommendedModelCatalog,
+  automaticModelCatalog,
   selectModel,
   skillMcpServerIds,
   skillInfoOf,
+  type AutomaticModelCatalog,
   type McpDependencyState,
   type ProviderInfo,
   type ProviderModelPreferences,
@@ -781,31 +782,22 @@ export class AgentHost {
   /**
    * Automatic selection re-runs on every warm-up, so a catalog that is missing a
    * source would otherwise silently re-point scheduled runs at another model.
-   * The remembered pick leads while the catalog is incomplete, and only a
-   * complete catalog is allowed to change it.
+   * Only a complete catalog is allowed to change the remembered pick.
    */
-  private async automaticCandidateIds(
-    catalog: () => Promise<{ ids: string[]; healthy: boolean }>,
-  ): Promise<{ candidateIds: string[]; healthy: boolean }> {
-    const { ids, healthy } = await catalog();
-    const remembered = this.providerConfigs.getAutomaticModel();
-    if (healthy || !remembered) return { candidateIds: ids, healthy };
-    console.warn(
-      `[model] model catalog is incomplete — keeping "${remembered}" as the automatic default`,
-    );
-    return {
-      candidateIds: [remembered, ...ids.filter((id) => id !== remembered)],
-      healthy,
-    };
-  }
-
   private async selectAutomaticModel(
-    catalog: () => Promise<{ ids: string[]; healthy: boolean }>,
+    catalog: (remembered?: string) => Promise<AutomaticModelCatalog>,
     build: (qualified: string) => Promise<BaseChatModel>,
   ): Promise<{ modelId: string; model: BaseChatModel }> {
-    const { candidateIds, healthy } = await this.automaticCandidateIds(catalog);
-    const selected = await this.buildAutomaticModel(candidateIds, build);
-    if (healthy) this.providerConfigs.setAutomaticModel(selected.modelId);
+    const { ids, complete, keeping } = await catalog(
+      this.providerConfigs.getAutomaticModel(),
+    );
+    if (keeping) {
+      console.warn(
+        `[model] model catalog is incomplete — keeping "${keeping}" as the automatic default`,
+      );
+    }
+    const selected = await this.buildAutomaticModel(ids, build);
+    if (complete) this.providerConfigs.setAutomaticModel(selected.modelId);
     return selected;
   }
 
@@ -871,7 +863,7 @@ export class AgentHost {
           ),
         }
       : await this.selectAutomaticModel(
-          () => this.graphs!.recommendedModels(),
+          (remembered) => this.graphs!.automaticModels(remembered),
           (modelId) => this.graphs!.buildModel(modelId),
         );
     this.providerConfigs.setDefaultModel(qualified);
@@ -1714,7 +1706,7 @@ export class AgentHost {
             ),
           }
         : await host.selectAutomaticModel(
-            () => recommendedModelCatalog(registry),
+            (remembered) => automaticModelCatalog(registry, remembered),
             (modelId) => registry.buildModel(modelId),
           );
       host.modelId = selected.modelId;

--- a/apps/api-server/src/agent-host.ts
+++ b/apps/api-server/src/agent-host.ts
@@ -3,7 +3,7 @@ import {
   ModelRegistry,
   ModelUnavailableError,
   projectSkillReadiness,
-  recommendedModelCandidates,
+  recommendedModelCatalog,
   selectModel,
   skillMcpServerIds,
   skillInfoOf,
@@ -778,6 +778,37 @@ export class AgentHost {
     });
   }
 
+  /**
+   * Automatic selection re-runs on every warm-up, so a catalog that is missing a
+   * source would otherwise silently re-point scheduled runs at another model.
+   * The remembered pick leads while the catalog is incomplete, and only a
+   * complete catalog is allowed to change it.
+   */
+  private async automaticCandidateIds(
+    catalog: () => Promise<{ ids: string[]; healthy: boolean }>,
+  ): Promise<{ candidateIds: string[]; healthy: boolean }> {
+    const { ids, healthy } = await catalog();
+    const remembered = this.providerConfigs.getAutomaticModel();
+    if (healthy || !remembered) return { candidateIds: ids, healthy };
+    console.warn(
+      `[model] model catalog is incomplete — keeping "${remembered}" as the automatic default`,
+    );
+    return {
+      candidateIds: [remembered, ...ids.filter((id) => id !== remembered)],
+      healthy,
+    };
+  }
+
+  private async selectAutomaticModel(
+    catalog: () => Promise<{ ids: string[]; healthy: boolean }>,
+    build: (qualified: string) => Promise<BaseChatModel>,
+  ): Promise<{ modelId: string; model: BaseChatModel }> {
+    const { candidateIds, healthy } = await this.automaticCandidateIds(catalog);
+    const selected = await this.buildAutomaticModel(candidateIds, build);
+    if (healthy) this.providerConfigs.setAutomaticModel(selected.modelId);
+    return selected;
+  }
+
   private async buildAutomaticModel(
     candidateIds: readonly string[],
     build: (qualified: string) => Promise<BaseChatModel>,
@@ -839,8 +870,8 @@ export class AgentHost {
             (modelId) => this.graphs!.buildModel(modelId),
           ),
         }
-      : await this.buildAutomaticModel(
-          await this.graphs!.recommendedModelIds(),
+      : await this.selectAutomaticModel(
+          () => this.graphs!.recommendedModels(),
           (modelId) => this.graphs!.buildModel(modelId),
         );
     this.providerConfigs.setDefaultModel(qualified);
@@ -1682,10 +1713,8 @@ export class AgentHost {
               (modelId) => registry.buildModel(modelId),
             ),
           }
-        : await host.buildAutomaticModel(
-            recommendedModelCandidates(await registry.listAll()).map(
-              (descriptor) => `${descriptor.provider}:${descriptor.id}`,
-            ),
+        : await host.selectAutomaticModel(
+            () => recommendedModelCatalog(registry),
             (modelId) => registry.buildModel(modelId),
           );
       host.modelId = selected.modelId;

--- a/apps/api-server/src/graph-manager.ts
+++ b/apps/api-server/src/graph-manager.ts
@@ -1,6 +1,6 @@
 import {
   pizzaBotSystemPrompt,
-  recommendedModelCandidates,
+  recommendedModelCatalog,
   type ModelCatalogStatus,
   type ModelAvailability,
   type ModelRegistry,
@@ -134,11 +134,8 @@ export class GraphManager {
     };
   }
 
-  async recommendedModelIds(): Promise<string[]> {
-    const descriptors = await this.models.listAll();
-    return recommendedModelCandidates(descriptors).map(
-      (descriptor) => `${descriptor.provider}:${descriptor.id}`,
-    );
+  recommendedModels(): Promise<{ ids: string[]; healthy: boolean }> {
+    return recommendedModelCatalog(this.models);
   }
 
   async contextWindow(): Promise<number | undefined> {

--- a/apps/api-server/src/graph-manager.ts
+++ b/apps/api-server/src/graph-manager.ts
@@ -1,6 +1,7 @@
 import {
   pizzaBotSystemPrompt,
-  recommendedModelCatalog,
+  automaticModelCatalog,
+  type AutomaticModelCatalog,
   type ModelCatalogStatus,
   type ModelAvailability,
   type ModelRegistry,
@@ -134,8 +135,8 @@ export class GraphManager {
     };
   }
 
-  recommendedModels(): Promise<{ ids: string[]; healthy: boolean }> {
-    return recommendedModelCatalog(this.models);
+  automaticModels(remembered?: string): Promise<AutomaticModelCatalog> {
+    return automaticModelCatalog(this.models, remembered);
   }
 
   async contextWindow(): Promise<number | undefined> {

--- a/apps/web/src/components/settings/ProvidersSettings.test.ts
+++ b/apps/web/src/components/settings/ProvidersSettings.test.ts
@@ -100,6 +100,23 @@ describe("getProviderStatus", () => {
     ).toEqual({ label: "Unavailable", tone: "unavailable" });
   });
 
+  it("keeps a partially listed provider usable while surfacing the gap separately", () => {
+    expect(
+      getProviderStatus(
+        provider({ id: "bedrock", config: { method: "aws-profile", values: {} } }),
+        {
+          provider: "bedrock",
+          status: "degraded",
+          modelCount: 55,
+          stale: true,
+          code: "unavailable",
+          message: "Amazon Bedrock inference profiles could not be listed.",
+          retryable: true,
+        },
+      ),
+    ).toEqual({ label: "Configured", tone: "configured" });
+  });
+
   it("uses live health before catalog status is available", () => {
     expect(
       getProviderStatus(

--- a/apps/web/src/components/settings/ProvidersSettings.tsx
+++ b/apps/web/src/components/settings/ProvidersSettings.tsx
@@ -396,7 +396,7 @@ function ProviderRow({
           onQueryChange={setModelQuery}
           onChange={setModelPreferences}
           onRetry={
-            catalog?.status === "error" && catalog.retryable
+            catalog && catalog.status !== "ready" && catalog.retryable
               ? async () => {
                   setRetrying(true);
                   try {
@@ -484,12 +484,17 @@ function ProviderModelsField({
     <div className="provider-models-field">
       <div className="provider-models-heading">
         <div className="field-label">Models</div>
-        {catalog?.status === "error" && catalog.stale && (
+        {catalog && catalog.status !== "ready" && catalog.stale && (
           <span className="provenance-badge">{L.modelCatalogStaleBadge}</span>
         )}
       </div>
-      {catalog?.status === "error" && (
-        <div className={`provider-model-catalog-error ${catalogTone}`} role="status">
+      {catalog && catalog.status !== "ready" && (
+        <div
+          className={`provider-model-catalog-error ${
+            catalog.status === "degraded" ? "unavailable" : catalogTone
+          }`}
+          role="status"
+        >
           <span>{catalog.message}</span>
           {onRetry && (
             <button

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -581,6 +581,17 @@ The Ollama adapter reads daemon capabilities per model. For vision models it
 projects tool-returned images into Ollama's supported user-image representation;
 for other models it replaces the binary payload with a capability notice.
 
+A provider that fans out to several catalog APIs reports a lost source instead of
+a quietly shorter list. The Bedrock adapter logs every rejected source, keeps a
+per-source last-good list so one flaky API cannot shrink the session's catalog,
+and publishes `catalogDegradation()`; the registry turns that into
+`ModelCatalogStatus` `degraded` and — unlike a `ready` listing — never adopts a
+partial result as the last-good baseline. Automatic default selection goes
+through `recommendedModelCatalog`, and an incomplete or empty catalog keeps the
+remembered pick (`automatic_model` in `app_defaults`) at the head of the
+candidate list rather than re-resolving, so a degraded warm-up cannot re-point
+scheduled automations at a different model.
+
 Skill workers mark terminal responses whose provider metadata reports an
 output-token limit with an `OUTPUT_TRUNCATED` notice. DeepAgents carries that
 notice in the task result so Pizza Bot can distinguish incomplete delegated work

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -584,13 +584,18 @@ for other models it replaces the binary payload with a capability notice.
 A provider that fans out to several catalog APIs reports a lost source instead of
 a quietly shorter list. The Bedrock adapter logs every rejected source, keeps a
 per-source last-good list so one flaky API cannot shrink the session's catalog,
-and publishes `catalogDegradation()`; the registry turns that into
-`ModelCatalogStatus` `degraded` and — unlike a `ready` listing — never adopts a
-partial result as the last-good baseline. Automatic default selection goes
-through `recommendedModelCatalog`, and an incomplete or empty catalog keeps the
-remembered pick (`automatic_model` in `app_defaults`) at the head of the
+and publishes `catalogDegradation(models)` keyed on the listing it describes, so
+overlapping listings cannot cross-report each other's gaps; the registry turns
+that into `ModelCatalogStatus` `degraded` and — unlike a `ready` listing — never
+adopts a partial result as the last-good baseline. Automatic default selection
+goes through `automaticModelCatalog`, and an incomplete or empty catalog keeps
+the remembered pick (`automatic_model` in `app_defaults`) at the head of the
 candidate list rather than re-resolving, so a degraded warm-up cannot re-point
-scheduled automations at a different model.
+scheduled automations at a different model. Most installations leave providers
+unconfigured, so one listing nothing is normal — but the remembered pick's own
+provider is stricter: only a ready listing, or an unconfigured one that voids the
+pick outright, may resolve a different default, since a failed listing may simply
+be hiding the remembered model.
 
 Skill workers mark terminal responses whose provider metadata reports an
 output-token limit with an `OUTPUT_TRUNCATED` notice. DeepAgents carries that

--- a/packages/core/src/model-provider.test.ts
+++ b/packages/core/src/model-provider.test.ts
@@ -5,6 +5,7 @@ import {
   ModelRegistry,
   ModelUnavailableError,
   recommendedModelCandidates,
+  recommendedModelCatalog,
   type ModelDescriptor,
   type ModelProvider,
 } from "./model-provider.js";
@@ -269,6 +270,150 @@ describe("ModelRegistry.listAll", () => {
     });
     await expect(registry.listCatalog()).resolves.toMatchObject({
       models: [expect.objectContaining({ id: "new" })],
+    });
+  });
+});
+
+describe("ModelRegistry degraded catalogs", () => {
+  it("reports a provider that lost a catalog source without discarding its models", async () => {
+    const provider = stubProvider({});
+    provider.catalogDegradation = () => ({
+      code: "unavailable",
+      message: "Amazon Bedrock inference profiles could not be listed.",
+      retryable: true,
+      stale: false,
+    });
+    const registry = new ModelRegistry();
+    registry.register(provider);
+
+    const snapshot = await registry.listCatalog();
+
+    expect(snapshot.models).toEqual([expect.objectContaining({ id: "model-a" })]);
+    expect(snapshot.providers).toEqual([
+      expect.objectContaining({
+        status: "degraded",
+        code: "unavailable",
+        modelCount: 1,
+        stale: false,
+        retryable: true,
+      }),
+    ]);
+  });
+
+  it("never lets a partial catalog become the last-good fallback", async () => {
+    let degraded = false;
+    const provider = stubProvider({});
+    provider.listModels = async () =>
+      degraded
+        ? [{ id: "model-a", provider: "stub", displayName: "Model A" }]
+        : [
+            { id: "model-a", provider: "stub", displayName: "Model A" },
+            { id: "model-b", provider: "stub", displayName: "Model B" },
+          ];
+    provider.catalogDegradation = () =>
+      degraded
+        ? { code: "network", message: "One source timed out.", retryable: true, stale: false }
+        : undefined;
+    const registry = new ModelRegistry();
+    registry.register(provider);
+
+    await registry.listCatalog();
+    degraded = true;
+    await registry.listCatalog({ refresh: true });
+    provider.listModels = async () => {
+      throw new ModelCatalogError("network", "Temporarily offline.", true);
+    };
+    const stale = await registry.listCatalog({ refresh: true });
+
+    expect(stale.models.map((model) => model.id)).toEqual(["model-a", "model-b"]);
+    expect(stale.providers).toEqual([
+      expect.objectContaining({ status: "error", stale: true, modelCount: 2 }),
+    ]);
+  });
+});
+
+describe("recommendedModelCatalog", () => {
+  it("reports a healthy catalog when every listing provider is ready", async () => {
+    const registry = new ModelRegistry();
+    registry.register(stubProvider({
+      id: "stub",
+      models: [{ id: "claude-sonnet-5", provider: "stub", displayName: "Claude Sonnet 5" }],
+    }));
+
+    await expect(recommendedModelCatalog(registry)).resolves.toEqual({
+      ids: ["stub:claude-sonnet-5"],
+      healthy: true,
+    });
+  });
+
+  it("treats an unconfigured provider that lists nothing as no loss", async () => {
+    const registry = new ModelRegistry();
+    registry.register(stubProvider({
+      id: "stub",
+      models: [{ id: "claude-sonnet-5", provider: "stub", displayName: "Claude Sonnet 5" }],
+    }));
+    const unconfigured = stubProvider({ id: "openai" });
+    unconfigured.listModels = async () => {
+      throw new ModelCatalogError("credentials", "OpenAI credentials are not available.", false);
+    };
+    registry.register(unconfigured);
+
+    await expect(recommendedModelCatalog(registry)).resolves.toEqual({
+      ids: ["stub:claude-sonnet-5"],
+      healthy: true,
+    });
+  });
+
+  it("reports an unhealthy catalog while a provider serves its last known models", async () => {
+    let fail = false;
+    const provider = stubProvider({ id: "stub" });
+    provider.listModels = async () => {
+      if (fail) throw new ModelCatalogError("authentication", "Credentials expired.", false);
+      return [{ id: "claude-sonnet-5", provider: "stub", displayName: "Claude Sonnet 5" }];
+    };
+    const registry = new ModelRegistry();
+    registry.register(provider);
+
+    await recommendedModelCatalog(registry);
+    fail = true;
+    await registry.listCatalog({ refresh: true });
+
+    await expect(recommendedModelCatalog(registry)).resolves.toMatchObject({
+      ids: ["stub:claude-sonnet-5"],
+      healthy: false,
+    });
+  });
+
+  it("reports an empty catalog as unhealthy so a remembered pick still leads", async () => {
+    const provider = stubProvider({ id: "stub" });
+    provider.listModels = async () => {
+      throw new ModelCatalogError("authentication", "Credentials expired.", false);
+    };
+    const registry = new ModelRegistry();
+    registry.register(provider);
+
+    await expect(recommendedModelCatalog(registry)).resolves.toEqual({
+      ids: [],
+      healthy: false,
+    });
+  });
+
+  it("reports an unhealthy catalog while a provider is degraded", async () => {
+    const provider = stubProvider({
+      id: "stub",
+      models: [{ id: "claude-sonnet-5", provider: "stub", displayName: "Claude Sonnet 5" }],
+    });
+    provider.catalogDegradation = () => ({
+      code: "authentication",
+      message: "Credentials expired.",
+      retryable: false,
+      stale: true,
+    });
+    const registry = new ModelRegistry();
+    registry.register(provider);
+
+    await expect(recommendedModelCatalog(registry)).resolves.toMatchObject({
+      healthy: false,
     });
   });
 });

--- a/packages/core/src/model-provider.test.ts
+++ b/packages/core/src/model-provider.test.ts
@@ -4,8 +4,8 @@ import {
   ModelCatalogError,
   ModelRegistry,
   ModelUnavailableError,
+  automaticModelCatalog,
   recommendedModelCandidates,
-  recommendedModelCatalog,
   type ModelDescriptor,
   type ModelProvider,
 } from "./model-provider.js";
@@ -300,6 +300,24 @@ describe("ModelRegistry degraded catalogs", () => {
     ]);
   });
 
+  it("asks about the exact listing it received rather than provider-wide state", async () => {
+    const provider = stubProvider({});
+    const listing = [{ id: "model-a", provider: "stub", displayName: "Model A" }];
+    provider.listModels = async () => listing;
+    const asked: unknown[] = [];
+    provider.catalogDegradation = (models) => {
+      asked.push(models);
+      return undefined;
+    };
+    const registry = new ModelRegistry();
+    registry.register(provider);
+
+    await registry.listCatalog();
+
+    expect(asked).toEqual([listing]);
+    expect(asked[0]).toBe(listing);
+  });
+
   it("never lets a partial catalog become the last-good fallback", async () => {
     let degraded = false;
     const provider = stubProvider({});
@@ -332,59 +350,68 @@ describe("ModelRegistry degraded catalogs", () => {
   });
 });
 
-describe("recommendedModelCatalog", () => {
-  it("reports a healthy catalog when every listing provider is ready", async () => {
-    const registry = new ModelRegistry();
-    registry.register(stubProvider({
-      id: "stub",
-      models: [{ id: "claude-sonnet-5", provider: "stub", displayName: "Claude Sonnet 5" }],
-    }));
+describe("automaticModelCatalog", () => {
+  function sonnetProvider(id: string): ModelProvider {
+    return stubProvider({
+      id,
+      models: [{ id: "claude-sonnet-5", provider: id, displayName: "Claude Sonnet 5" }],
+    });
+  }
 
-    await expect(recommendedModelCatalog(registry)).resolves.toEqual({
+  it("reports a complete catalog when every listing provider is ready", async () => {
+    const registry = new ModelRegistry();
+    registry.register(sonnetProvider("stub"));
+
+    await expect(automaticModelCatalog(registry)).resolves.toEqual({
       ids: ["stub:claude-sonnet-5"],
-      healthy: true,
+      complete: true,
     });
   });
 
   it("treats an unconfigured provider that lists nothing as no loss", async () => {
     const registry = new ModelRegistry();
-    registry.register(stubProvider({
-      id: "stub",
-      models: [{ id: "claude-sonnet-5", provider: "stub", displayName: "Claude Sonnet 5" }],
-    }));
+    registry.register(sonnetProvider("stub"));
     const unconfigured = stubProvider({ id: "openai" });
     unconfigured.listModels = async () => {
       throw new ModelCatalogError("credentials", "OpenAI credentials are not available.", false);
     };
     registry.register(unconfigured);
 
-    await expect(recommendedModelCatalog(registry)).resolves.toEqual({
+    await expect(automaticModelCatalog(registry)).resolves.toEqual({
       ids: ["stub:claude-sonnet-5"],
-      healthy: true,
+      complete: true,
     });
   });
 
-  it("reports an unhealthy catalog while a provider serves its last known models", async () => {
+  it("keeps the remembered pick while a provider serves its last known models", async () => {
     let fail = false;
-    const provider = stubProvider({ id: "stub" });
+    const provider = stubProvider({
+      id: "stub",
+      models: [
+        { id: "claude-sonnet-5", provider: "stub", displayName: "Claude Sonnet 5" },
+        { id: "claude-opus-5", provider: "stub", displayName: "Claude Opus 5" },
+      ],
+    });
+    const listModels = provider.listModels.bind(provider);
     provider.listModels = async () => {
       if (fail) throw new ModelCatalogError("authentication", "Credentials expired.", false);
-      return [{ id: "claude-sonnet-5", provider: "stub", displayName: "Claude Sonnet 5" }];
+      return listModels();
     };
     const registry = new ModelRegistry();
     registry.register(provider);
 
-    await recommendedModelCatalog(registry);
+    await registry.listCatalog();
     fail = true;
     await registry.listCatalog({ refresh: true });
 
-    await expect(recommendedModelCatalog(registry)).resolves.toMatchObject({
-      ids: ["stub:claude-sonnet-5"],
-      healthy: false,
+    await expect(automaticModelCatalog(registry, "stub:claude-opus-5")).resolves.toEqual({
+      ids: ["stub:claude-opus-5", "stub:claude-sonnet-5"],
+      complete: false,
+      keeping: "stub:claude-opus-5",
     });
   });
 
-  it("reports an empty catalog as unhealthy so a remembered pick still leads", async () => {
+  it("reports an empty catalog as incomplete", async () => {
     const provider = stubProvider({ id: "stub" });
     provider.listModels = async () => {
       throw new ModelCatalogError("authentication", "Credentials expired.", false);
@@ -392,17 +419,14 @@ describe("recommendedModelCatalog", () => {
     const registry = new ModelRegistry();
     registry.register(provider);
 
-    await expect(recommendedModelCatalog(registry)).resolves.toEqual({
+    await expect(automaticModelCatalog(registry)).resolves.toEqual({
       ids: [],
-      healthy: false,
+      complete: false,
     });
   });
 
-  it("reports an unhealthy catalog while a provider is degraded", async () => {
-    const provider = stubProvider({
-      id: "stub",
-      models: [{ id: "claude-sonnet-5", provider: "stub", displayName: "Claude Sonnet 5" }],
-    });
+  it("reports an incomplete catalog while a provider is degraded", async () => {
+    const provider = sonnetProvider("stub");
     provider.catalogDegradation = () => ({
       code: "authentication",
       message: "Credentials expired.",
@@ -412,8 +436,67 @@ describe("recommendedModelCatalog", () => {
     const registry = new ModelRegistry();
     registry.register(provider);
 
-    await expect(recommendedModelCatalog(registry)).resolves.toMatchObject({
-      healthy: false,
+    await expect(automaticModelCatalog(registry)).resolves.toMatchObject({
+      complete: false,
+    });
+  });
+
+  it("does not repick when the remembered provider failed outright beside a healthy one", async () => {
+    const registry = new ModelRegistry();
+    registry.register(sonnetProvider("anthropic"));
+    const bedrock = stubProvider({ id: "bedrock" });
+    bedrock.listModels = async () => {
+      throw new ModelCatalogError("authentication", "The security token is expired.", true);
+    };
+    registry.register(bedrock);
+
+    await expect(
+      automaticModelCatalog(registry, "bedrock:global.anthropic.claude-sonnet-5"),
+    ).resolves.toEqual({
+      ids: ["bedrock:global.anthropic.claude-sonnet-5", "anthropic:claude-sonnet-5"],
+      complete: false,
+      keeping: "bedrock:global.anthropic.claude-sonnet-5",
+    });
+  });
+
+  it("lets an unconfigured remembered provider void its own pick", async () => {
+    const registry = new ModelRegistry();
+    registry.register(sonnetProvider("anthropic"));
+    const bedrock = stubProvider({ id: "bedrock" });
+    bedrock.listModels = async () => {
+      throw new ModelCatalogError("credentials", "Bedrock credentials are not available.", false);
+    };
+    registry.register(bedrock);
+
+    await expect(
+      automaticModelCatalog(registry, "bedrock:global.anthropic.claude-sonnet-5"),
+    ).resolves.toEqual({
+      ids: ["anthropic:claude-sonnet-5"],
+      complete: true,
+    });
+  });
+
+  it("does not resurrect a remembered model the user has since disabled", async () => {
+    const registry = new ModelRegistry();
+    const provider = stubProvider({
+      id: "stub",
+      models: [
+        { id: "claude-sonnet-5", provider: "stub", displayName: "Claude Sonnet 5" },
+        { id: "claude-opus-5", provider: "stub", displayName: "Claude Opus 5" },
+      ],
+    });
+    provider.catalogDegradation = () => ({
+      code: "network",
+      message: "One source timed out.",
+      retryable: true,
+      stale: false,
+    });
+    registry.register(provider);
+    registry.setEnabledModels("stub", ["claude-sonnet-5"]);
+
+    await expect(automaticModelCatalog(registry, "stub:claude-opus-5")).resolves.toEqual({
+      ids: ["stub:claude-sonnet-5"],
+      complete: false,
     });
   });
 });

--- a/packages/core/src/model-provider.ts
+++ b/packages/core/src/model-provider.ts
@@ -40,6 +40,16 @@ export type ModelCatalogStatus =
     }
   | {
       provider: string;
+      /** Some models were listed, but at least one catalog source failed. */
+      status: "degraded";
+      modelCount: number;
+      stale: boolean;
+      code: ModelCatalogErrorCode;
+      message: string;
+      retryable: boolean;
+    }
+  | {
+      provider: string;
       status: "error";
       modelCount: number;
       stale: boolean;
@@ -47,6 +57,18 @@ export type ModelCatalogStatus =
       message: string;
       retryable: boolean;
     };
+
+/**
+ * Reported by providers that fan out to several catalog APIs, so one failing
+ * source degrades loudly instead of silently shrinking the model list.
+ */
+export interface ModelCatalogDegradation {
+  code: ModelCatalogErrorCode;
+  message: string;
+  retryable: boolean;
+  /** Some listed models come from an earlier response rather than this one. */
+  stale: boolean;
+}
 
 export interface ModelCatalogSnapshot {
   models: ModelDescriptor[];
@@ -70,6 +92,30 @@ export function recommendedModelCandidates(
       qualifiedModelId(a.model).localeCompare(qualifiedModelId(b.model))
     )
     .map(({ model }) => model);
+}
+
+/**
+ * Recommendation order plus whether this catalog is trustworthy enough to
+ * re-pick an automatic default from.
+ */
+export async function recommendedModelCatalog(
+  registry: Pick<ModelRegistry, "listCatalog">,
+): Promise<{ ids: string[]; healthy: boolean }> {
+  const snapshot = await registry.listCatalog();
+  const ids = recommendedModelCandidates(snapshot.models).map(qualifiedModelId);
+  return {
+    ids,
+    healthy: ids.length > 0 && snapshot.providers.every(providerCatalogIsComplete),
+  };
+}
+
+/**
+ * Most installations leave several providers unconfigured, so a provider that
+ * lists nothing is normal and has nothing to lose. One serving a partial or
+ * last-known list is what makes the catalog too incomplete to re-pick from.
+ */
+function providerCatalogIsComplete(status: ModelCatalogStatus): boolean {
+  return status.status === "ready" || status.modelCount === 0;
 }
 
 function bedrockGlobalPreference(model: ModelDescriptor): number {
@@ -152,6 +198,8 @@ export interface ModelProvider {
   readonly authSchema?: readonly ProviderAuthMethod[];
   /** The provider can use ambient credentials or defaults without saved config. */
   readonly availableWithoutConfig?: boolean;
+  /** Set when the last `listModels` served an incomplete catalog. */
+  catalogDegradation?(): ModelCatalogDegradation | undefined;
   /** Applies persisted configuration at registration and on later settings updates. */
   configure?(cfg: ResolvedProviderConfig): void;
   /**
@@ -323,6 +371,23 @@ export class ModelRegistry {
       [...this.providers.values()].map(async (provider) => {
         try {
           const models = await provider.listModels();
+          const degradation = provider.catalogDegradation?.();
+          if (degradation) {
+            // A partial catalog must never become the last-good baseline.
+            return {
+              models,
+              fresh: false,
+              status: {
+                provider: provider.id,
+                status: "degraded",
+                modelCount: models.length,
+                stale: degradation.stale,
+                code: degradation.code,
+                message: degradation.message,
+                retryable: degradation.retryable,
+              } satisfies ModelCatalogStatus,
+            };
+          }
           return {
             models,
             fresh: true,

--- a/packages/core/src/model-provider.ts
+++ b/packages/core/src/model-provider.ts
@@ -94,18 +94,36 @@ export function recommendedModelCandidates(
     .map(({ model }) => model);
 }
 
+export interface AutomaticModelCatalog {
+  /** Recommendation order, led by the remembered pick on an incomplete catalog. */
+  ids: string[];
+  /** The catalog may be trusted to record a new automatic default. */
+  complete: boolean;
+  /** Set when the remembered pick leads because the catalog is incomplete. */
+  keeping?: string;
+}
+
 /**
- * Recommendation order plus whether this catalog is trustworthy enough to
- * re-pick an automatic default from.
+ * Candidate order for automatic selection. A catalog missing models it should
+ * have keeps the remembered pick rather than resolving a different default.
  */
-export async function recommendedModelCatalog(
-  registry: Pick<ModelRegistry, "listCatalog">,
-): Promise<{ ids: string[]; healthy: boolean }> {
+export async function automaticModelCatalog(
+  registry: Pick<ModelRegistry, "listCatalog" | "isModelEnabled">,
+  remembered?: string,
+): Promise<AutomaticModelCatalog> {
   const snapshot = await registry.listCatalog();
   const ids = recommendedModelCandidates(snapshot.models).map(qualifiedModelId);
+  const complete =
+    ids.length > 0 &&
+    snapshot.providers.every(providerCatalogIsComplete) &&
+    mayReplaceRemembered(snapshot.providers, remembered);
+  if (complete || !remembered || !registry.isModelEnabled(remembered)) {
+    return { ids, complete };
+  }
   return {
-    ids,
-    healthy: ids.length > 0 && snapshot.providers.every(providerCatalogIsComplete),
+    ids: [remembered, ...ids.filter((id) => id !== remembered)],
+    complete,
+    keeping: remembered,
   };
 }
 
@@ -116,6 +134,22 @@ export async function recommendedModelCatalog(
  */
 function providerCatalogIsComplete(status: ModelCatalogStatus): boolean {
   return status.status === "ready" || status.modelCount === 0;
+}
+
+/**
+ * A provider whose own listing failed may simply be hiding the remembered
+ * model, so only a ready provider — or one holding no credentials at all, which
+ * voids the pick — may resolve a different default.
+ */
+function mayReplaceRemembered(
+  statuses: readonly ModelCatalogStatus[],
+  remembered: string | undefined,
+): boolean {
+  if (!remembered) return true;
+  const provider = remembered.slice(0, remembered.indexOf(":"));
+  const status = statuses.find((candidate) => candidate.provider === provider);
+  if (!status || status.status === "ready") return true;
+  return status.code === "credentials" && status.modelCount === 0;
 }
 
 function bedrockGlobalPreference(model: ModelDescriptor): number {
@@ -198,8 +232,10 @@ export interface ModelProvider {
   readonly authSchema?: readonly ProviderAuthMethod[];
   /** The provider can use ambient credentials or defaults without saved config. */
   readonly availableWithoutConfig?: boolean;
-  /** Set when the last `listModels` served an incomplete catalog. */
-  catalogDegradation?(): ModelCatalogDegradation | undefined;
+  /** Set when the given listing was served with at least one source missing. */
+  catalogDegradation?(
+    models: readonly ModelDescriptor[],
+  ): ModelCatalogDegradation | undefined;
   /** Applies persisted configuration at registration and on later settings updates. */
   configure?(cfg: ResolvedProviderConfig): void;
   /**
@@ -279,6 +315,14 @@ export class ModelRegistry {
   setEnabledModels(providerId: string, modelIds: readonly string[] | undefined): void {
     if (modelIds === undefined) this.enabledModels.delete(providerId);
     else this.enabledModels.set(providerId, new Set(modelIds));
+  }
+
+  /** Preference-filtered availability for callers that bypass `listCatalog`. */
+  isModelEnabled(qualified: string): boolean {
+    const parsed = this.parse(qualified);
+    if (!parsed) return false;
+    const enabled = this.enabledModels.get(parsed.provider);
+    return enabled === undefined || enabled.has(parsed.modelId);
   }
 
   private parse(qualified: string): { provider: string; modelId: string } | undefined {
@@ -371,7 +415,7 @@ export class ModelRegistry {
       [...this.providers.values()].map(async (provider) => {
         try {
           const models = await provider.listModels();
-          const degradation = provider.catalogDegradation?.();
+          const degradation = provider.catalogDegradation?.(models);
           if (degradation) {
             // A partial catalog must never become the last-good baseline.
             return {

--- a/packages/core/src/provider-config.ts
+++ b/packages/core/src/provider-config.ts
@@ -27,6 +27,12 @@ export interface ProviderConfigPort {
   removeConfig(providerId: string): void;
   getDefaultModel(): string | undefined;
   setDefaultModel(qualified: string | null): void;
+  /**
+   * The model automatic selection last resolved to. Remembering it keeps a
+   * degraded catalog from re-pointing scheduled runs at a different model.
+   */
+  getAutomaticModel(): string | undefined;
+  setAutomaticModel(qualified: string | null): void;
   getModelPreferences(providerId: string): ProviderModelPreferences | undefined;
   setModelPreferences(providerId: string, preferences: ProviderModelPreferences): void;
   removeModelPreferences(providerId: string): void;

--- a/packages/inference-providers/src/providers/bedrock/langchain.test.ts
+++ b/packages/inference-providers/src/providers/bedrock/langchain.test.ts
@@ -110,10 +110,10 @@ describe("BedrockLangChainModelProvider authentication", () => {
 
     await provider.buildModel("global.anthropic.claude-sonnet-5");
 
-    expect(sdk.fromIni).toHaveBeenCalledTimes(3);
-    expect(sdk.fromIni).toHaveBeenNthCalledWith(1, { profile: "production" });
-    expect(sdk.fromIni).toHaveBeenNthCalledWith(2, { profile: "production" });
-    expect(sdk.fromIni).toHaveBeenNthCalledWith(3, { profile: "production" });
+    // Catalog sources and models share one credential source, so they cannot
+    // disagree about whether the credentials are still valid.
+    expect(sdk.fromIni).toHaveBeenCalledTimes(1);
+    expect(sdk.fromIni).toHaveBeenCalledWith({ profile: "production" });
     expect(sdk.fromNodeProviderChain).not.toHaveBeenCalled();
     expect(sdk.chatConfig?.credentials).toBe(sdk.iniCredentials);
   });
@@ -284,7 +284,7 @@ describe("BedrockLangChainModelProvider authentication", () => {
     });
   });
 
-  it("reuses the Mantle signer until provider configuration changes", async () => {
+  it("reuses the Mantle signer and credential source until configuration changes", async () => {
     sdk.fromIni.mockReturnValue({
       accessKeyId: "access-key",
       secretAccessKey: "secret-key",
@@ -298,16 +298,16 @@ describe("BedrockLangChainModelProvider authentication", () => {
     provider.configure({ method: "aws-profile", values: { profile: "production" } });
 
     await provider.listModels();
-    expect(sdk.fromIni).toHaveBeenCalledTimes(2);
+    expect(sdk.fromIni).toHaveBeenCalledTimes(1);
 
     await provider.buildModel("openai.gpt-5.6-sol");
 
-    expect(sdk.fromIni).toHaveBeenCalledTimes(2);
+    expect(sdk.fromIni).toHaveBeenCalledTimes(1);
 
     provider.configure({ method: "aws-profile", values: { profile: "production" } });
     await provider.listModels();
 
-    expect(sdk.fromIni).toHaveBeenCalledTimes(4);
+    expect(sdk.fromIni).toHaveBeenCalledTimes(2);
   });
 
   it("clears credentials from the previously selected method", async () => {
@@ -411,6 +411,126 @@ describe("BedrockLangChainModelProvider authentication", () => {
         supportsVision: true,
       }),
     ]);
+  });
+});
+
+describe("Bedrock catalog source failures", () => {
+  const profileSummaries = {
+    inferenceProfileSummaries: [
+      {
+        inferenceProfileId: "global.anthropic.claude-sonnet-5",
+        inferenceProfileName: "Global Claude Sonnet 5",
+        status: "ACTIVE",
+        models: [{ modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-5" }],
+      },
+    ],
+  };
+  const foundationSummaries = {
+    modelSummaries: [{ modelId: "amazon.nova-pro-v1:0", modelName: "Nova Pro", inputModalities: ["TEXT"] }],
+  };
+
+  function configuredProvider(
+    send: (command: unknown) => Promise<unknown>,
+  ): BedrockLangChainModelProvider {
+    const provider = new BedrockLangChainModelProvider({
+      profiles: ["production"],
+      client: { send },
+      modelsDevFetch: vi.fn(async () => new Response("{}", { status: 200 })),
+    });
+    provider.configure({ method: "aws-profile", values: { profile: "production" } });
+    return provider;
+  }
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    sdk.fromIni.mockReset().mockReturnValue({
+      accessKeyId: "access-key",
+      secretAccessKey: "secret-key",
+    });
+    // A Response body reads once, so every catalog pass needs a fresh one.
+    sdk.mantleFetch.mockReset().mockImplementation(
+      async () => new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", sdk.mantleFetch);
+  });
+
+  it("keeps models from a previously listed source and reports the gap", async () => {
+    let failProfiles = false;
+    const provider = configuredProvider(async (command) => {
+      if (command?.constructor.name === "ListInferenceProfilesCommand") {
+        if (failProfiles) throw Object.assign(new Error("ThrottlingException"), { name: "ThrottlingException" });
+        return profileSummaries;
+      }
+      return foundationSummaries;
+    });
+
+    const first = await provider.listModels();
+    expect(first.map((model) => model.id)).toEqual([
+      "global.anthropic.claude-sonnet-5",
+      "amazon.nova-pro-v1:0",
+    ]);
+    expect(provider.catalogDegradation()).toBeUndefined();
+
+    failProfiles = true;
+    const second = await provider.listModels();
+
+    expect(second.map((model) => model.id)).toEqual(first.map((model) => model.id));
+    expect(provider.catalogDegradation()).toMatchObject({
+      code: "unavailable",
+      retryable: true,
+      stale: true,
+    });
+    expect(provider.catalogDegradation()?.message).toContain("inference profiles");
+  });
+
+  it("reports a partial catalog when a source fails before ever succeeding", async () => {
+    const provider = configuredProvider(async (command) => {
+      if (command?.constructor.name === "ListInferenceProfilesCommand") {
+        throw new Error("ExpiredTokenException: token expired");
+      }
+      return foundationSummaries;
+    });
+
+    await expect(provider.listModels()).resolves.toMatchObject([
+      expect.objectContaining({ id: "amazon.nova-pro-v1:0" }),
+    ]);
+    expect(provider.catalogDegradation()).toMatchObject({
+      code: "authentication",
+      retryable: false,
+      stale: false,
+    });
+  });
+
+  it("clears the degradation once every source answers again", async () => {
+    let failProfiles = true;
+    const provider = configuredProvider(async (command) => {
+      if (command?.constructor.name === "ListInferenceProfilesCommand") {
+        if (failProfiles) throw new Error("ThrottlingException");
+        return profileSummaries;
+      }
+      return foundationSummaries;
+    });
+
+    await provider.listModels();
+    expect(provider.catalogDegradation()).toBeDefined();
+
+    failProfiles = false;
+    await provider.listModels();
+
+    expect(provider.catalogDegradation()).toBeUndefined();
+  });
+
+  it("classifies expired credentials when every source fails", async () => {
+    sdk.mantleFetch.mockImplementation(async () => new Response("{}", { status: 403 }));
+    const provider = configuredProvider(async () => {
+      throw new Error("ExpiredTokenException: the security token included in the request is expired");
+    });
+
+    await expect(provider.listModels()).rejects.toMatchObject({
+      name: "ModelCatalogError",
+      code: "authentication",
+      retryable: false,
+    });
   });
 });
 

--- a/packages/inference-providers/src/providers/bedrock/langchain.test.ts
+++ b/packages/inference-providers/src/providers/bedrock/langchain.test.ts
@@ -469,18 +469,19 @@ describe("Bedrock catalog source failures", () => {
       "global.anthropic.claude-sonnet-5",
       "amazon.nova-pro-v1:0",
     ]);
-    expect(provider.catalogDegradation()).toBeUndefined();
+    expect(provider.catalogDegradation(first)).toBeUndefined();
 
     failProfiles = true;
     const second = await provider.listModels();
 
     expect(second.map((model) => model.id)).toEqual(first.map((model) => model.id));
-    expect(provider.catalogDegradation()).toMatchObject({
+    expect(provider.catalogDegradation(second)).toMatchObject({
       code: "unavailable",
       retryable: true,
       stale: true,
     });
-    expect(provider.catalogDegradation()?.message).toContain("inference profiles");
+    expect(provider.catalogDegradation(second)?.message).toContain("inference profiles");
+    expect(provider.catalogDegradation(first)).toBeUndefined();
   });
 
   it("reports a partial catalog when a source fails before ever succeeding", async () => {
@@ -491,10 +492,10 @@ describe("Bedrock catalog source failures", () => {
       return foundationSummaries;
     });
 
-    await expect(provider.listModels()).resolves.toMatchObject([
-      expect.objectContaining({ id: "amazon.nova-pro-v1:0" }),
-    ]);
-    expect(provider.catalogDegradation()).toMatchObject({
+    const models = await provider.listModels();
+
+    expect(models).toMatchObject([expect.objectContaining({ id: "amazon.nova-pro-v1:0" })]);
+    expect(provider.catalogDegradation(models)).toMatchObject({
       code: "authentication",
       retryable: false,
       stale: false,
@@ -511,13 +512,33 @@ describe("Bedrock catalog source failures", () => {
       return foundationSummaries;
     });
 
-    await provider.listModels();
-    expect(provider.catalogDegradation()).toBeDefined();
+    const degraded = await provider.listModels();
+    expect(provider.catalogDegradation(degraded)).toBeDefined();
 
     failProfiles = false;
-    await provider.listModels();
+    const whole = await provider.listModels();
 
-    expect(provider.catalogDegradation()).toBeUndefined();
+    expect(provider.catalogDegradation(whole)).toBeUndefined();
+  });
+
+  it("binds a lost source to the listing it belongs to when calls overlap", async () => {
+    let profileCalls = 0;
+    const provider = configuredProvider(async (command) => {
+      if (command?.constructor.name === "ListInferenceProfilesCommand") {
+        profileCalls += 1;
+        if (profileCalls === 1) throw new Error("ThrottlingException");
+        return profileSummaries;
+      }
+      return foundationSummaries;
+    });
+
+    const [degraded, whole] = await Promise.all([
+      provider.listModels(),
+      provider.listModels(),
+    ]);
+
+    expect(provider.catalogDegradation(degraded)).toMatchObject({ code: "unavailable" });
+    expect(provider.catalogDegradation(whole)).toBeUndefined();
   });
 
   it("classifies expired credentials when every source fails", async () => {

--- a/packages/inference-providers/src/providers/bedrock/langchain.ts
+++ b/packages/inference-providers/src/providers/bedrock/langchain.ts
@@ -81,7 +81,14 @@ export class BedrockLangChainModelProvider implements ModelProvider {
   private readonly learnedMaxTokens = new Map<string, number>();
   /** One failing source must not shrink the catalog for the rest of the session. */
   private readonly lastGoodSources = new Map<CatalogSource, RoutedModel[]>();
-  private degradation: ModelCatalogDegradation | undefined;
+  /**
+   * Keyed by the listing it describes: concurrent `listModels` calls overlap, so
+   * a single field would report one call's gap against another call's models.
+   */
+  private readonly degradations = new WeakMap<
+    readonly ModelDescriptor[],
+    ModelCatalogDegradation
+  >();
   private mantleFetchPromise: Promise<typeof fetch> | undefined;
   private credentialsPromise: Promise<AwsCredentialSource> | undefined;
   private region: string;
@@ -201,14 +208,15 @@ export class BedrockLangChainModelProvider implements ModelProvider {
     this.credentialsPromise = undefined;
     // Cached source lists belong to the previous credentials.
     this.lastGoodSources.clear();
-    this.degradation = undefined;
     if (!this.models) this.descriptors.clear();
     if (!this.models) this.protocols.clear();
   }
 
-  /** Set when the last `listModels` lost a source; read by the model registry. */
-  catalogDegradation(): ModelCatalogDegradation | undefined {
-    return this.degradation;
+  /** Set when the listing lost a source; read by the model registry. */
+  catalogDegradation(
+    models: readonly ModelDescriptor[],
+  ): ModelCatalogDegradation | undefined {
+    return this.degradations.get(models);
   }
 
   async listModels(): Promise<ModelDescriptor[]> {
@@ -257,7 +265,7 @@ export class BedrockLangChainModelProvider implements ModelProvider {
         (value) => value,
         failures,
       );
-      this.degradation = describeDegradation(failures);
+      const degradation = describeDegradation(failures);
       const routed = mergeRoutedModels([
         ...inferenceProfiles,
         ...foundationModels,
@@ -278,6 +286,7 @@ export class BedrockLangChainModelProvider implements ModelProvider {
         const protocol = routed[index]?.protocol;
         if (protocol) this.protocols.set(descriptor.id, protocol);
       }
+      if (degradation) this.degradations.set(descriptors, degradation);
       return descriptors;
     } catch (cause) {
       throw catalogConnectionError("Amazon Bedrock", cause);

--- a/packages/inference-providers/src/providers/bedrock/langchain.ts
+++ b/packages/inference-providers/src/providers/bedrock/langchain.ts
@@ -1,11 +1,13 @@
 /** Amazon Bedrock provider with native Converse and Mantle protocol routing. */
 import type { BaseMessage } from "@langchain/core/messages";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import type {
-  ModelProvider,
-  ModelDescriptor,
-  ProviderAuthMethod,
-  ResolvedProviderConfig,
+import {
+  ModelCatalogError,
+  type ModelProvider,
+  type ModelCatalogDegradation,
+  type ModelDescriptor,
+  type ProviderAuthMethod,
+  type ResolvedProviderConfig,
 } from "@pizza-bot/core";
 import {
   REASONING_REQUEST_FIELDS,
@@ -40,6 +42,15 @@ import { createSigV4Fetch, mantleEndpoint } from "./mantle.js";
 
 type BedrockProtocol = "converse" | "responses" | "chat-completions" | "messages";
 
+/**
+ * Every current Anthropic model is reachable only through an inference profile,
+ * so all three sources get the same deadline: a fast source must not be the only
+ * one that can time out.
+ */
+const CATALOG_TIMEOUT_MS = 15_000;
+
+type CatalogSource = "foundation models" | "inference profiles" | "Mantle";
+
 interface RoutedModel {
   descriptor: ModelDescriptor;
   protocol: BedrockProtocol;
@@ -68,7 +79,11 @@ export class BedrockLangChainModelProvider implements ModelProvider {
   private readonly descriptors = new Map<string, ModelDescriptor>();
   private readonly protocols = new Map<string, BedrockProtocol>();
   private readonly learnedMaxTokens = new Map<string, number>();
+  /** One failing source must not shrink the catalog for the rest of the session. */
+  private readonly lastGoodSources = new Map<CatalogSource, RoutedModel[]>();
+  private degradation: ModelCatalogDegradation | undefined;
   private mantleFetchPromise: Promise<typeof fetch> | undefined;
+  private credentialsPromise: Promise<AwsCredentialSource> | undefined;
   private region: string;
   private authMethod: "aws-profile" | "access-keys" | "bedrock-api-key" | undefined;
   private profile: string | undefined;
@@ -183,8 +198,17 @@ export class BedrockLangChainModelProvider implements ModelProvider {
       ? cfg.values.apiKey?.trim() || undefined
       : undefined;
     this.mantleFetchPromise = undefined;
+    this.credentialsPromise = undefined;
+    // Cached source lists belong to the previous credentials.
+    this.lastGoodSources.clear();
+    this.degradation = undefined;
     if (!this.models) this.descriptors.clear();
     if (!this.models) this.protocols.clear();
+  }
+
+  /** Set when the last `listModels` lost a source; read by the model registry. */
+  catalogDegradation(): ModelCatalogDegradation | undefined {
+    return this.degradation;
   }
 
   async listModels(): Promise<ModelDescriptor[]> {
@@ -206,22 +230,34 @@ export class BedrockLangChainModelProvider implements ModelProvider {
         client.send(new ListInferenceProfilesCommand({ maxResults: 1000 })),
         this.listMantleModels(),
       ]);
-      const foundationModels = foundationResult.status === "fulfilled"
-        ? foundationDescriptors(foundationResult.value).map(withDefaultProtocol)
-        : [];
-      const inferenceProfiles = profileResult.status === "fulfilled"
-        ? profileDescriptors(profileResult.value).map(withConverseProtocol)
-        : [];
-      const mantleModels = mantleResult.status === "fulfilled"
-        ? mantleResult.value
-        : [];
       if (
         foundationResult.status === "rejected" &&
         profileResult.status === "rejected" &&
         mantleResult.status === "rejected"
       ) {
-        throw foundationResult.reason;
+        throw credentialFailure([foundationResult, profileResult, mantleResult]) ??
+          foundationResult.reason;
       }
+      const failures: SourceFailure[] = [];
+      const foundationModels = this.sourceModels(
+        "foundation models",
+        foundationResult,
+        (value) => foundationDescriptors(value).map(withDefaultProtocol),
+        failures,
+      );
+      const inferenceProfiles = this.sourceModels(
+        "inference profiles",
+        profileResult,
+        (value) => profileDescriptors(value).map(withConverseProtocol),
+        failures,
+      );
+      const mantleModels = this.sourceModels(
+        "Mantle",
+        mantleResult,
+        (value) => value,
+        failures,
+      );
+      this.degradation = describeDegradation(failures);
       const routed = mergeRoutedModels([
         ...inferenceProfiles,
         ...foundationModels,
@@ -391,6 +427,27 @@ export class BedrockLangChainModelProvider implements ModelProvider {
     });
   }
 
+  private sourceModels<T>(
+    source: CatalogSource,
+    result: PromiseSettledResult<T>,
+    project: (value: T) => RoutedModel[],
+    failures: SourceFailure[],
+  ): RoutedModel[] {
+    if (result.status === "fulfilled") {
+      const models = project(result.value);
+      this.lastGoodSources.set(source, models);
+      return models;
+    }
+    const cached = this.lastGoodSources.get(source);
+    console.warn(
+      `[model] bedrock ${source} catalog unavailable` +
+        (cached ? ` — serving ${cached.length} cached model(s)` : "") +
+        `: ${errorText(result.reason)}`,
+    );
+    failures.push({ source, reason: result.reason, servedFromCache: cached !== undefined });
+    return cached ?? [];
+  }
+
   private async listMantleModels(): Promise<RoutedModel[]> {
     const response = await (await this.mantleFetch())(
       `${mantleEndpoint(this.region)}/v1/models`,
@@ -398,7 +455,7 @@ export class BedrockLangChainModelProvider implements ModelProvider {
         ...(this.bedrockApiKey
           ? { headers: { authorization: `Bearer ${this.bedrockApiKey}` } }
           : {}),
-        signal: AbortSignal.timeout(5_000),
+        signal: AbortSignal.timeout(CATALOG_TIMEOUT_MS),
       },
     );
     if (!response.ok) throw catalogHttpError("Amazon Bedrock Mantle", response.status);
@@ -424,7 +481,11 @@ export class BedrockLangChainModelProvider implements ModelProvider {
     return this.mantleFetchPromise;
   }
 
-  private async credentials() {
+  /**
+   * One provider instance for every catalog source and model, so all of them see
+   * the same credential state instead of resolving the chain independently.
+   */
+  private async credentials(): Promise<AwsCredentialSource> {
     if (this.accessKeyId && this.secretAccessKey) {
       return {
         accessKeyId: this.accessKeyId,
@@ -432,22 +493,33 @@ export class BedrockLangChainModelProvider implements ModelProvider {
         ...(this.sessionToken ? { sessionToken: this.sessionToken } : {}),
       };
     }
-    const { fromIni, fromNodeProviderChain } = await import("@aws-sdk/credential-providers");
-    return this.profile ? fromIni({ profile: this.profile }) : fromNodeProviderChain();
+    this.credentialsPromise ??= (async () => {
+      const { fromIni, fromNodeProviderChain } = await import("@aws-sdk/credential-providers");
+      return this.profile ? fromIni({ profile: this.profile }) : fromNodeProviderChain();
+    })();
+    return this.credentialsPromise;
   }
 
   private async clientConfig() {
+    // Control-plane calls have no deadline of their own; without one a hung
+    // request outlives the Mantle source and looks like a shrunken catalog.
+    const requestHandler = {
+      requestTimeout: CATALOG_TIMEOUT_MS,
+      connectionTimeout: CATALOG_TIMEOUT_MS,
+    };
     if (this.bedrockApiKey) {
       const token = this.bedrockApiKey;
       return {
         region: this.region,
         authSchemePreference: ["httpBearerAuth"],
         token: async () => ({ token }),
+        requestHandler,
       };
     }
     return {
       region: this.region,
       credentials: await this.credentials(),
+      requestHandler,
     };
   }
 
@@ -459,6 +531,58 @@ export class BedrockLangChainModelProvider implements ModelProvider {
     if (this.authMethod === "bedrock-api-key") return Boolean(this.bedrockApiKey);
     return false;
   }
+}
+
+type AwsCredentialSource =
+  | { accessKeyId: string; secretAccessKey: string; sessionToken?: string }
+  | (() => Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string }>);
+
+interface SourceFailure {
+  source: CatalogSource;
+  reason: unknown;
+  servedFromCache: boolean;
+}
+
+function errorText(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason);
+}
+
+const EXPIRED_CREDENTIALS_HINT =
+  "AWS credentials are expired or invalid — refresh them (for SSO, run `aws sso login`).";
+
+/** Losing every source to expired credentials must not read as a network fault. */
+function credentialFailure(
+  results: readonly PromiseSettledResult<unknown>[],
+): ModelCatalogError | undefined {
+  const expired = results.find(
+    (result) =>
+      result.status === "rejected" && translateBedrockError(result.reason) === "AUTH_EXPIRED",
+  );
+  if (!expired || expired.status !== "rejected") return undefined;
+  return new ModelCatalogError("authentication", EXPIRED_CREDENTIALS_HINT, false, {
+    cause: expired.reason,
+  });
+}
+
+function describeDegradation(failures: readonly SourceFailure[]): ModelCatalogDegradation | undefined {
+  if (failures.length === 0) return undefined;
+  const sources = failures.map((failure) => failure.source).join(" and ");
+  const expired = failures.some(
+    (failure) => translateBedrockError(failure.reason) === "AUTH_EXPIRED",
+  );
+  const timedOut = failures.some(
+    (failure) =>
+      failure.reason instanceof Error &&
+      (failure.reason.name === "TimeoutError" || failure.reason.name === "AbortError"),
+  );
+  return {
+    code: expired ? "authentication" : timedOut ? "network" : "unavailable",
+    retryable: !expired,
+    stale: failures.some((failure) => failure.servedFromCache),
+    message:
+      `Amazon Bedrock ${sources} could not be listed, so some models are missing. ` +
+      (expired ? EXPIRED_CREDENTIALS_HINT : errorText(failures[0]?.reason)),
+  };
 }
 
 interface FoundationModelsResponse {

--- a/packages/storage/src/provider-configs.test.ts
+++ b/packages/storage/src/provider-configs.test.ts
@@ -21,6 +21,24 @@ describe("ProviderConfigStore model preferences", () => {
     db.close();
   });
 
+  it("keeps the remembered automatic pick separate from the explicit default", () => {
+    const db = new Database(":memory:");
+    const store = new ProviderConfigStore(db);
+
+    expect(store.getAutomaticModel()).toBeUndefined();
+
+    store.setDefaultModel("bedrock:global.anthropic.claude-opus-5");
+    store.setAutomaticModel("bedrock:global.anthropic.claude-sonnet-5");
+
+    expect(store.getDefaultModel()).toBe("bedrock:global.anthropic.claude-opus-5");
+    expect(store.getAutomaticModel()).toBe("bedrock:global.anthropic.claude-sonnet-5");
+
+    store.setAutomaticModel(null);
+    expect(store.getAutomaticModel()).toBeUndefined();
+    expect(store.getDefaultModel()).toBe("bedrock:global.anthropic.claude-opus-5");
+    db.close();
+  });
+
   it("ignores corrupt persisted preferences", () => {
     const db = new Database(":memory:");
     const store = new ProviderConfigStore(db);

--- a/packages/storage/src/provider-configs.ts
+++ b/packages/storage/src/provider-configs.ts
@@ -12,6 +12,7 @@ interface ConfigRow {
 }
 
 const DEFAULT_MODEL_KEY = "default_model";
+const AUTOMATIC_MODEL_KEY = "automatic_model";
 
 export class ProviderConfigStore implements ProviderConfigPort {
   private readonly db: Database.Database;
@@ -79,9 +80,25 @@ export class ProviderConfigStore implements ProviderConfigPort {
   }
 
   getDefaultModel(): string | undefined {
+    return this.getAppDefault(DEFAULT_MODEL_KEY);
+  }
+
+  setDefaultModel(qualified: string | null): void {
+    this.setAppDefault(DEFAULT_MODEL_KEY, qualified);
+  }
+
+  getAutomaticModel(): string | undefined {
+    return this.getAppDefault(AUTOMATIC_MODEL_KEY);
+  }
+
+  setAutomaticModel(qualified: string | null): void {
+    this.setAppDefault(AUTOMATIC_MODEL_KEY, qualified);
+  }
+
+  private getAppDefault(key: string): string | undefined {
     const row = this.db
       .prepare<[string], { value: string }>("SELECT value FROM app_defaults WHERE key = ?")
-      .get(DEFAULT_MODEL_KEY);
+      .get(key);
     if (!row) return undefined;
     try {
       const parsed = JSON.parse(row.value);
@@ -91,9 +108,9 @@ export class ProviderConfigStore implements ProviderConfigPort {
     }
   }
 
-  setDefaultModel(qualified: string | null): void {
-    if (qualified === null) {
-      this.db.prepare("DELETE FROM app_defaults WHERE key = ?").run(DEFAULT_MODEL_KEY);
+  private setAppDefault(key: string, value: string | null): void {
+    if (value === null) {
+      this.db.prepare("DELETE FROM app_defaults WHERE key = ?").run(key);
       return;
     }
     this.db
@@ -102,7 +119,7 @@ export class ProviderConfigStore implements ProviderConfigPort {
          VALUES (@key, @value, @updated_at)
          ON CONFLICT(key) DO UPDATE SET value = @value, updated_at = @updated_at`,
       )
-      .run({ key: DEFAULT_MODEL_KEY, value: JSON.stringify(qualified), updated_at: new Date().toISOString() });
+      .run({ key, value: JSON.stringify(value), updated_at: new Date().toISOString() });
   }
 
   getModelPreferences(providerId: string): ProviderModelPreferences | undefined {


### PR DESCRIPTION
Fixes #49.

A Bedrock catalog source that fails is no longer dropped silently, and a catalog missing models it should have can no longer re-point scheduled automations at a different model.

## What changed

**Report the gap instead of shrinking the list** (`packages/inference-providers/src/providers/bedrock/langchain.ts`, `packages/core/src/model-provider.ts`)

- Every rejected source is logged (`[model] bedrock <source> catalog unavailable: …`) and the provider keeps a per-source last-good list, so one flaky API cannot shrink the session's catalog.
- The provider publishes `catalogDegradation(models)`; the registry turns that into a new `ModelCatalogStatus` variant `degraded` and — unlike a `ready` listing — never adopts a partial result as `lastGoodModels`.
- Degradation is keyed on the listing it describes (a `WeakMap` on the returned descriptor array). Bedrock has no listing cache, so every `validate()` on an explicit-model turn re-runs the whole fan-out; a shared mutable field would let one call report its gap against another call's models, laundering a partial listing into `ready`.

**Keep the automatic default sticky** (`packages/core/src/model-provider.ts`, `apps/api-server`, `packages/storage`)

- `automaticModelCatalog(registry, remembered) → {ids, complete, keeping?}` replaces `recommendedModelCatalog`. An incomplete or empty catalog keeps the remembered pick at the head of the candidate list rather than re-resolving.
- The pick persists in `app_defaults` under `automatic_model`, separate from the explicit `default_model`, and is only rewritten when the catalog is complete.
- Most installs leave providers unconfigured, so one listing nothing is normal — but the remembered pick's own provider is stricter: only a ready listing, or an unconfigured one that voids the pick outright, may resolve a different default, since a failed listing may simply be hiding the remembered model.
- A remembered model the user has since disabled does not lead the candidates (`ModelRegistry.isModelEnabled`).

**Even out the transport** (`packages/inference-providers`)

- Request/connection timeouts on the control-plane calls, Mantle's abort raised to match, and one memoized credential provider shared across sources — so SSO expiry surfaces as one auth error instead of an assortment of unrelated-looking failures.

**Surface it in Settings** (`apps/web/src/components/settings/ProvidersSettings.tsx`)

- A degraded provider stays usable and keeps its "Configured" badge, while showing the message, a Retry action, and a "Last known" badge when some models come from an earlier response.

## Verification

`npm run typecheck`, `npm run lint`, and `npm test` (21 tasks) are green.

Verified live against real Bedrock in a scratch data root (`ap-northeast-3` has no Mantle host, which yields a genuine partial catalog):

- Unconfigured start → all providers `error: credentials` with 0 models, nothing persisted, warm falls back to the last-resort model.
- `us-east-1` → `bedrock ready 144`; recorded `automatic_model|"bedrock:global.anthropic.claude-sonnet-5"`.
- `ap-northeast-3` → `bedrock degraded 22 unavailable`, logged `[model] bedrock Mantle catalog unavailable: fetch failed` and `[model] model catalog is incomplete — keeping "bedrock:global.anthropic.claude-sonnet-5" as the automatic default`; the stored row was untouched. Settings showed the message and Retry with the badge still reading "Configured".
- Same degraded region with the remembered model disabled via model preferences → warm resolved `bedrock:global.anthropic.claude-sonnet-4-6` with no `keeping` warning, and still did not overwrite the row.

## Not merging yet

Opened for review only — please do not merge until you have looked it over.
