### PR TITLE
fix: route the user's request when delegating, and relay the worker's report

### DIFF
--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.1.0",
-    "@langchain/core": "^1.2.1",
+    "@langchain/core": "^1.2.9",
     "@langchain/langgraph-sdk": "~1.9.28",
     "@pizza-bot/core": "*",
     "@pizza-bot/logging": "*",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -240,13 +240,31 @@ in `core/src/protocol-types.ts`:
 Delegation is **routing, not rewriting**: the skill owns the procedure and the
 output shape, so a dispatch extracts the user's ask rather than composing a brief
 around it, and the reply relays the worker's report instead of re-summarizing it.
-That contract lives in exactly one place — the `task` tool description
-(`TASK_USAGE_NOTES`) — because it sits in the schema the model is filling out, and
-because it must displace DeepAgents' own usage notes, which tell the model to put
-full detail in the dispatch, state exactly what to get back, and relay a summary
-(advice for a generic subagent, not a skill-scoped worker). Restating it in the
-orchestrator prompt or in each worker's prompt bought nothing and cost tokens, so
-neither does. `taskDispatchMiddleware` owns the tool outright: it passes
+Two layers state it, and a live 2x2 ablation says both earn their place. The
+`task` tool description (`TASK_USAGE_NOTES`) has to, because it must displace
+DeepAgents' own usage notes, which tell the model to put full detail in the
+dispatch, state exactly what to get back, and relay a summary — advice for a
+generic subagent, not a skill-scoped worker — and because it sits in the schema
+the model is filling out. The orchestrator prompt
+(`packages/core/src/agent.ts`) also has to, for the **return** half: measured over
+three runs each, dropping its relay paragraph cut the share of the worker's report
+that reached the user from 0.67 to 0.34, losing exactly the specifics a skill
+exists to produce (attendee names, case ages, identifiers). No tool description
+can reach that path, because by then the tool call is over. A third layer, a
+preamble prepended to each worker's own prompt, was deleted: a worker cannot tell
+the user's own words from the orchestrator's invention, so it can only defer to
+its skill instructions, which is what they already say.
+
+A skill's `description` is the third lever and the strongest one on the dispatch
+itself. It is the only per-skill text the orchestrator ever sees — it never reads
+a `SKILL.md` — so a description that states what the worker decides for itself and
+what it returns removes the uncertainty that makes the orchestrator invent a spec.
+In the same ablation, expanding two descriptions that way cut dispatch length 36%
+(45 to 29 words) and stopped a request from being split across redundant workers.
+Skill authors own that text; see the skill-authoring guidance in
+[skills/README.md](../skills/README.md).
+
+`taskDispatchMiddleware` owns the tool outright: it passes
 its own `createSubAgentMiddleware({ taskDescription, generalPurposeAgent: false })`
 in the `middleware` array, which replaces DeepAgents' entry because
 `mergeMiddlewareStack` matches on the middleware name (`subAgentMiddleware`).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,9 +215,17 @@ in `core/src/protocol-types.ts`:
   a `ResumeCommand` → `Command({ resume })`. Because a node re-runs from the
   top on resume, pre-interrupt tool side effects must be idempotent.
 - **Skill workers**: there is one selectable identity, the built-in **Pizza Bot**.
-  DeepAgents' synchronous `general-purpose` worker and `task` tool remain
-  available by default, including when no skills are installed. The root
-  QuickJS interpreter also exposes `task()` for programmatic fan-out.
+  The `task` roster is exactly the ready skill workers: DeepAgents'
+  `general-purpose` worker is disabled, because it heads the roster claiming
+  "access to all tools as the main agent" while holding only the filesystem — the
+  runtime passes no `tools` to `createDeepAgent`, so its `defaultTools` are empty
+  and it receives no skill, no `eval`, and none of the per-worker guardrails.
+  Dropping it costs no capability: Pizza Bot holds the same filesystem tools and
+  `eval` directly, so the only loss is an isolated context to do noisy filesystem
+  work in. With no ready skills there is nothing to route to, so the `task` tool
+  and the QuickJS `task()` bridge are both absent; readiness is dynamic, so an
+  installed-but-unavailable skill also withholds them. With skills, the root
+  QuickJS interpreter exposes `task()` for programmatic fan-out.
   Each skill catalog entry compiles directly into one worker invoked through the
   `task` tool. Its `SKILL.md` body is the system prompt, its description is the
   routing signal, and its declared `mcp:server:tool` refs are its complete tool
@@ -228,6 +236,25 @@ in `core/src/protocol-types.ts`:
   subagent list and summarized in the root prompt. Workers share the selected
   conversation model and each receive only their own skill bundle. Synchronous
   worker graphs do not contain subagent middleware, so only Pizza Bot can delegate.
+
+Delegation is **routing, not rewriting**: the skill owns the procedure and the
+output shape, so a dispatch extracts the user's ask rather than composing a brief
+around it, and the reply relays the worker's report instead of re-summarizing it.
+That contract lives in exactly one place — the `task` tool description
+(`TASK_USAGE_NOTES`) — because it sits in the schema the model is filling out, and
+because it must displace DeepAgents' own usage notes, which tell the model to put
+full detail in the dispatch, state exactly what to get back, and relay a summary
+(advice for a generic subagent, not a skill-scoped worker). Restating it in the
+orchestrator prompt or in each worker's prompt bought nothing and cost tokens, so
+neither does. `taskDispatchMiddleware` owns the tool outright: it passes
+its own `createSubAgentMiddleware({ taskDescription, generalPurposeAgent: false })`
+in the `middleware` array, which replaces DeepAgents' entry because
+`mergeMiddlewareStack` matches on the middleware name (`subAgentMiddleware`).
+Nothing is written to state, so the Activity drill-down still renders the plain
+dispatch a human could have written. That name match is the one fragile joint: if
+a DeepAgents release renames the entry, theirs survives alongside ours and the
+briefing notes come back, so `skill-dispatch.test.ts` asserts the upstream
+phrasing is absent.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@hono/node-server": "^2.1.0",
-        "@langchain/core": "^1.2.1",
+        "@langchain/core": "^1.2.9",
         "@langchain/langgraph-sdk": "~1.9.28",
         "@pizza-bot/core": "*",
         "@pizza-bot/inference-providers": "*",
@@ -2414,9 +2414,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.5.tgz",
-      "integrity": "sha512-4lXj3fTPQYGdEtOG9gWDnvmp6wpXNMo9MmWzfZxxPUxMcjulZJa93pYAZ90luFLg2YVdVuUl2tuwdD7tY5K9MA==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.9.tgz",
+      "integrity": "sha512-conzSEj9Zu1AyXJLXsSbgrtxtxinmI1yGqQ5CIJZSoV5rvv+yvQE/vgBnoySpBQ/bl3YPgj2FL/gbDjWykLSfg==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -2449,13 +2449,13 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.9.tgz",
-      "integrity": "sha512-EvD9rS66Cya09y6rbMgD3Ir8miAkJQFo7FyJOPRPO736Kz3y5TeyeBDOS8ctff/jRc788bPijHx2NVFM79Qqig==",
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.13.tgz",
+      "integrity": "sha512-LO1ak6jNQ9jR13tm7Ay4Yh2/otrH7LNVUwWTAI7WJigVdW5Fb6LuYSZUzVn4S7sVSiyVFfnrUcDTd8c7eAzPrQ==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.1.3",
-        "@langchain/langgraph-sdk": "~1.9.28",
+        "@langchain/langgraph-checkpoint": "^1.1.5",
+        "@langchain/langgraph-sdk": "~1.10.0",
         "@langchain/protocol": "^0.0.18",
         "@standard-schema/spec": "1.1.0"
       },
@@ -2468,9 +2468,9 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.3.tgz",
-      "integrity": "sha512-wgzdQNeEsdw1e+4lvlj0tdq/RYR/k1vPin10g0ymGoehZDDgd9nvIllGXSXN4TFgF9sf5qQP/KTkOcLfeseIhA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.5.tgz",
+      "integrity": "sha512-BwDwl5VeTOh6CVuiIPgsUgfK51vTJDMSbFcSCUfjJWsl8/DPdK/mbv+ejxJstkSk/BlSPMP4JfXWcN6jD2ea2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2551,6 +2551,71 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.10.0.tgz",
+      "integrity": "sha512-cPPkh+hMNgeOaGtJRrqs1AjZde45cG2+Ma9Sc10wz2RyvT8SKToCKS+VvkS18SsLajnmq6/FKVmthq6rnUVYOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/protocol": "^0.0.19",
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.48",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk/node_modules/@langchain/protocol": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.19.tgz",
+      "integrity": "sha512-9hKcRrH7cBX6gfutdfXPoft1OCchHe4FEpALoDJMl5Qu+n/YG5ynZmyu8+8cxORlPwHBoKTxggvXz+76M1yX1Q==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/langgraph/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/@langchain/langgraph/node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/p-timeout": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
       "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
@@ -8225,9 +8290,9 @@
       "license": "MIT"
     },
     "node_modules/deepagents": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/deepagents/-/deepagents-1.12.3.tgz",
-      "integrity": "sha512-57wsIdBXpYuODC1MJnl9m0OKJ1PFYTomEPNa9dGejINovUyMggq3NryA4g0cu+RqA89C8rm4LOI2uJ0tgmYEkA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/deepagents/-/deepagents-1.13.2.tgz",
+      "integrity": "sha512-OMm+Ark4yaICZhGqC9kYkIx5vw5eH+GqIhzX1PAMmYhdxK5XeBTyn4pdfo1fKrBj2X/8GEg6TPnKS2jORLqJAQ==",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.3",
@@ -8236,12 +8301,12 @@
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.2.0",
-        "@langchain/langgraph": "^1.4.4",
-        "@langchain/langgraph-checkpoint": "^1.1.2",
+        "@langchain/core": "^1.2.9",
+        "@langchain/langgraph": "^1.4.10",
+        "@langchain/langgraph-checkpoint": "^1.1.5",
         "@langchain/langgraph-sdk": "^1.9.23",
-        "langchain": "^1.5.0",
-        "langsmith": "^0.7.1"
+        "langchain": "^1.5.10",
+        "langsmith": ">=0.7.1 <0.10.0"
       }
     },
     "node_modules/delaunator": {
@@ -10887,13 +10952,13 @@
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/langchain": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.5.5.tgz",
-      "integrity": "sha512-KhedvQDRvaLIFMSvEy45U/pqR4G0dEfN7wPyHTBMgMIUXbcrVkaqRVlDSMPfMCwNuiRCfWFUHueYGtgSrwBcBA==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.5.10.tgz",
+      "integrity": "sha512-JaC12C1qyGn985vvjttr4hr8lfFzWhrXp2M1byZJGmNJ2RiIgqnhiYDuLlG/xHDxhKD3onJ5pCuUif/cbdqPhA==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph": "^1.4.8",
-        "@langchain/langgraph-checkpoint": "^1.1.3",
+        "@langchain/langgraph": "^1.4.10",
+        "@langchain/langgraph-checkpoint": "^1.1.5",
         "langsmith": ">=0.5.0 <1.0.0",
         "zod": "^3.25.76 || ^4"
       },
@@ -10901,7 +10966,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.2.5"
+        "@langchain/core": "^1.2.9"
       }
     },
     "node_modules/langsmith": {
@@ -16095,7 +16160,7 @@
       "name": "@pizza-bot/core",
       "version": "1.0.0",
       "dependencies": {
-        "@langchain/core": "^1.2.1",
+        "@langchain/core": "^1.2.9",
         "zod": "^4.0.0"
       }
     },
@@ -16107,7 +16172,7 @@
         "@aws-sdk/credential-providers": "^3.1106.0",
         "@langchain/anthropic": "^1.5.4",
         "@langchain/aws": "^1.4.3",
-        "@langchain/core": "^1.2.1",
+        "@langchain/core": "^1.2.9",
         "@langchain/google": "^0.2.1",
         "@langchain/ollama": "^1.3.0",
         "@langchain/openai": "^1.5.5",
@@ -16137,7 +16202,7 @@
       "name": "@pizza-bot/plugin-sdk",
       "version": "1.0.0",
       "dependencies": {
-        "@langchain/core": "^1.2.1",
+        "@langchain/core": "^1.2.9",
         "@langchain/mcp-adapters": "^1.1.3",
         "@pizza-bot/core": "*",
         "@pizza-bot/logging": "*",
@@ -16155,11 +16220,11 @@
       "name": "@pizza-bot/runtime-langgraph",
       "version": "1.0.0",
       "dependencies": {
-        "@langchain/core": "^1.2.1",
-        "@langchain/langgraph": "^1.4.9",
+        "@langchain/core": "^1.2.9",
+        "@langchain/langgraph": "^1.4.10",
         "@pizza-bot/core": "*",
-        "deepagents": "^1.12.3",
-        "langchain": "^1.5.5"
+        "deepagents": "^1.13.2",
+        "langchain": "^1.5.10"
       },
       "optionalDependencies": {
         "@langchain/quickjs": "0.6.1"
@@ -16169,7 +16234,7 @@
       "name": "@pizza-bot/storage",
       "version": "1.0.0",
       "dependencies": {
-        "@langchain/langgraph": "^1.4.9",
+        "@langchain/langgraph": "^1.4.10",
         "@langchain/langgraph-checkpoint-sqlite": "^1.0.3",
         "@pizza-bot/core": "*",
         "better-sqlite3": "^13.0.0",
@@ -16196,9 +16261,9 @@
         "@pizza-bot/runtime-langgraph": "*"
       },
       "devDependencies": {
-        "@langchain/core": "^1.2.1",
-        "@langchain/langgraph": "^1.4.9",
-        "deepagents": "^1.12.3",
+        "@langchain/core": "^1.2.9",
+        "@langchain/langgraph": "^1.4.10",
+        "deepagents": "^1.13.2",
         "vitest": "^4.1.10"
       }
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "clean": "rimraf dist .turbo tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@langchain/core": "^1.2.1",
+    "@langchain/core": "^1.2.9",
     "zod": "^4.0.0"
   }
 }

--- a/packages/core/src/agent.test.ts
+++ b/packages/core/src/agent.test.ts
@@ -43,10 +43,19 @@ describe("PIZZA_BOT_AGENT", () => {
     expect(PIZZA_BOT_AGENT.systemPrompt).toContain(
       "claim completion only after its tool call succeeds",
     );
+    expect(PIZZA_BOT_AGENT.systemPrompt).not.toContain("in your own words");
     expect(PIZZA_BOT_AGENT.systemPrompt).not.toContain("write_todos");
     expect(PIZZA_BOT_AGENT.systemPrompt).not.toContain(
       "when a task matches one, read its SKILL.md",
     );
+  });
+
+  // The dispatch contract belongs to the `task` tool description, and repeating
+  // it here would cost tokens without reinforcing anything.
+  it("leaves the routing and relay contract to the task tool description", () => {
+    for (const duplicated of ["ROUTING", "RELAY", "verbatim", "output format"]) {
+      expect(PIZZA_BOT_AGENT.systemPrompt).not.toContain(duplicated);
+    }
   });
 
   it("includes durable memory instructions only when memory is enabled", () => {

--- a/packages/core/src/agent.test.ts
+++ b/packages/core/src/agent.test.ts
@@ -43,19 +43,27 @@ describe("PIZZA_BOT_AGENT", () => {
     expect(PIZZA_BOT_AGENT.systemPrompt).toContain(
       "claim completion only after its tool call succeeds",
     );
+    expect(PIZZA_BOT_AGENT.systemPrompt).toContain("ROUTING, not rewriting");
+    expect(PIZZA_BOT_AGENT.systemPrompt).toContain(
+      "copy it verbatim whenever it stands on its own",
+    );
+    expect(PIZZA_BOT_AGENT.systemPrompt).toContain(
+      "do not restate what the worker should return",
+    );
+    expect(PIZZA_BOT_AGENT.systemPrompt).toContain(
+      "keeping each item's original wording",
+    );
+    expect(PIZZA_BOT_AGENT.systemPrompt).toContain(
+      "RELAY the worker's report as the body of your reply",
+    );
+    expect(PIZZA_BOT_AGENT.systemPrompt).toContain(
+      "repeat it rather than compressing it",
+    );
     expect(PIZZA_BOT_AGENT.systemPrompt).not.toContain("in your own words");
     expect(PIZZA_BOT_AGENT.systemPrompt).not.toContain("write_todos");
     expect(PIZZA_BOT_AGENT.systemPrompt).not.toContain(
       "when a task matches one, read its SKILL.md",
     );
-  });
-
-  // The dispatch contract belongs to the `task` tool description, and repeating
-  // it here would cost tokens without reinforcing anything.
-  it("leaves the routing and relay contract to the task tool description", () => {
-    for (const duplicated of ["ROUTING", "RELAY", "verbatim", "output format"]) {
-      expect(PIZZA_BOT_AGENT.systemPrompt).not.toContain(duplicated);
-    }
   });
 
   it("includes durable memory instructions only when memory is enabled", () => {

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -30,9 +30,8 @@ const PIZZA_BOT_PROMPT_PARTS = [
       "reading its SKILL.md first; the worker already receives its full skill " +
       "instructions and scoped tools. `subagent_type` is snake_case. Prefer " +
       "delegation for heavy or noisy work so it stays out of this conversation, and " +
-      "for fanning the same task over a batch. Wait for the result, then summarize " +
-      "it for the user in your own words. Do not delegate trivial requests you can " +
-      "handle yourself.",
+      "for fanning the same task over a batch. Do not delegate trivial requests you " +
+      "can handle yourself.",
     "For a WORKFLOW that spans many independent items — reviewing every file in a " +
       "list, gathering multiple perspectives, fanning the same task over a batch — " +
       "use the `eval` code interpreter and dispatch subagents programmatically with " +
@@ -40,8 +39,9 @@ const PIZZA_BOT_PROMPT_PARTS = [
       "via Promise.all), then combine the results. This is more reliable than many " +
       "one-at-a-time `task` tool calls when coverage must be deterministic. The " +
       "JavaScript helper uses camelCase `subagentType`; only the direct tool uses " +
-      "snake_case `subagent_type`.",
-    "Keep responses concise and practical.",
+      "snake_case `subagent_type`, and its usage notes govern the dispatches you " +
+      "write in code too.",
+    "Keep your own words concise and practical.",
 ];
 
 export function pizzaBotSystemPrompt(enableMemories: boolean): string {

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -32,6 +32,24 @@ const PIZZA_BOT_PROMPT_PARTS = [
       "delegation for heavy or noisy work so it stays out of this conversation, and " +
       "for fanning the same task over a batch. Do not delegate trivial requests you " +
       "can handle yourself.",
+    "When you delegate you are ROUTING, not rewriting. The worker's skill already " +
+      "defines its procedure, its output format, and how much detail to return, so " +
+      "`description` carries the user's request in the user's own words — copy it " +
+      "verbatim whenever it stands on its own. Add only what the worker cannot see " +
+      "for itself: relevant earlier turns, results you already gathered, and exact " +
+      "paths or identifiers. Never invent constraints, steps, acceptance criteria, " +
+      "an output format, a length, or a tone the user did not ask for, and do not " +
+      "restate what the worker should return. Use several dispatches only when the " +
+      "request spans genuinely independent items, keeping each item's original " +
+      "wording.",
+    "Wait for the result, then RELAY the worker's report as the body of your reply. " +
+      "Reproduce its content and formatting — tables, lists, labelled lines such as " +
+      "`Recommendation:` or `Confidence:` — rather than re-summarizing, reordering, " +
+      "or restyling it; that shape is part of the worker's skill and the user is " +
+      "meant to see it. Add your own words only to connect several reports or to " +
+      "flag something the user must act on, and keep each worker's report intact " +
+      "under its own heading. The report reaches the user only through your reply, " +
+      "so repeat it rather than compressing it.",
     "For a WORKFLOW that spans many independent items — reviewing every file in a " +
       "list, gathering multiple perspectives, fanning the same task over a batch — " +
       "use the `eval` code interpreter and dispatch subagents programmatically with " +
@@ -39,9 +57,10 @@ const PIZZA_BOT_PROMPT_PARTS = [
       "via Promise.all), then combine the results. This is more reliable than many " +
       "one-at-a-time `task` tool calls when coverage must be deterministic. The " +
       "JavaScript helper uses camelCase `subagentType`; only the direct tool uses " +
-      "snake_case `subagent_type`, and its usage notes govern the dispatches you " +
-      "write in code too.",
-    "Keep your own words concise and practical.",
+      "snake_case `subagent_type`. The same routing contract governs every " +
+      "`task()` dispatch you write in code.",
+    "Keep your own words concise and practical; brevity never justifies dropping " +
+      "detail a worker reported.",
 ];
 
 export function pizzaBotSystemPrompt(enableMemories: boolean): string {

--- a/packages/inference-providers/package.json
+++ b/packages/inference-providers/package.json
@@ -18,7 +18,7 @@
     "@aws-sdk/credential-providers": "^3.1106.0",
     "@langchain/anthropic": "^1.5.4",
     "@langchain/aws": "^1.4.3",
-    "@langchain/core": "^1.2.1",
+    "@langchain/core": "^1.2.9",
     "@langchain/google": "^0.2.1",
     "@langchain/ollama": "^1.3.0",
     "@langchain/openai": "^1.5.5",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf dist .turbo tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@langchain/core": "^1.2.1",
+    "@langchain/core": "^1.2.9",
     "@langchain/mcp-adapters": "^1.1.3",
     "@pizza-bot/core": "*",
     "@pizza-bot/logging": "*",

--- a/packages/runtime-langgraph/package.json
+++ b/packages/runtime-langgraph/package.json
@@ -14,11 +14,11 @@
     "clean": "rimraf dist .turbo tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@langchain/core": "^1.2.1",
-    "@langchain/langgraph": "^1.4.9",
+    "@langchain/core": "^1.2.9",
+    "@langchain/langgraph": "^1.4.10",
     "@pizza-bot/core": "*",
-    "deepagents": "^1.12.3",
-    "langchain": "^1.5.5"
+    "deepagents": "^1.13.2",
+    "langchain": "^1.5.10"
   },
   "optionalDependencies": {
     "@langchain/quickjs": "0.6.1"

--- a/packages/runtime-langgraph/src/default-delegation.test.ts
+++ b/packages/runtime-langgraph/src/default-delegation.test.ts
@@ -121,8 +121,8 @@ async function boundTools(skills?: SkillCatalog): Promise<string[]> {
 }
 
 describe("Pizza Bot delegation", () => {
-  it("exposes the default general-purpose task worker without skills", async () => {
-    expect(await boundTools()).toContain("task");
+  it("withholds task without skills, since no worker could receive a dispatch", async () => {
+    expect(await boundTools()).not.toContain("task");
   });
 
   it("keeps task available when a skill worker exists", async () => {
@@ -133,6 +133,12 @@ describe("Pizza Bot delegation", () => {
     const model = await captureModel(workerSkill);
     const task = model.boundToolDescriptions[0]?.find((tool) => tool.name === "task");
     expect(task?.description).toContain("- worker: Handles delegated work.");
+  });
+
+  it("offers only skill workers, never DeepAgents' capability-free general-purpose one", async () => {
+    const model = await captureModel(workerSkill);
+    const task = model.boundToolDescriptions[0]?.find((tool) => tool.name === "task");
+    expect(task?.description).not.toContain("general-purpose");
   });
 
   it("keeps run-limit counters local when skill workers run in parallel", async () => {

--- a/packages/runtime-langgraph/src/eval-capability.test.ts
+++ b/packages/runtime-langgraph/src/eval-capability.test.ts
@@ -70,7 +70,7 @@ describe("Pizza Bot graph assembly", () => {
     mocks.toolCallLimitMiddleware.mockReturnValue({ name: "ToolCallLimitMiddleware" });
   });
 
-  it("keeps default delegation and dynamic eval available without skills", async () => {
+  it("keeps eval available without skills, with nothing to dispatch to", async () => {
     await createPizzaBotAgent("prompt", { model: { modelId: "test" } as never });
 
     const params = mocks.createDeepAgent.mock.calls[0]![0] as {
@@ -96,7 +96,7 @@ describe("Pizza Bot graph assembly", () => {
     });
     expect(params.subagents).toBeUndefined();
     expect(mocks.createCodeInterpreterMiddleware).toHaveBeenCalledWith(
-      expect.objectContaining({ subagents: true }),
+      expect.objectContaining({ subagents: false }),
     );
   });
 

--- a/packages/runtime-langgraph/src/index.ts
+++ b/packages/runtime-langgraph/src/index.ts
@@ -41,6 +41,7 @@ import {
 import { attachmentInlineMiddleware } from "./attachment-inline-middleware.js";
 import { currentDateTimeMiddleware } from "./current-date-time-middleware.js";
 import { localFolderContextMiddleware } from "./local-folder-context-middleware.js";
+import { taskDispatchMiddleware } from "./task-dispatch-middleware.js";
 import { streamProtocolEvents, toLangGraphInput, type ProtocolCapableGraph } from "./stream-protocol.js";
 
 // The built-in Codex profile otherwise restores the opt-in planning middleware.
@@ -327,9 +328,6 @@ async function assemblePizzaBot(systemPrompt: string, deps: RuntimeDeps): Promis
   if (deps.attachmentResolver) {
     middleware.push(attachmentInlineMiddleware(deps.attachmentResolver));
   }
-  // DeepAgents always provides its synchronous general-purpose subagent, so the
-  // root interpreter can dispatch through task() even when no skills are loaded.
-  middleware.push(await codeInterpreterMiddleware(true));
 
   const model = deps.model;
   const resolvedSubagents = await resolveSkillSubagents(deps.skills, deps);
@@ -354,6 +352,13 @@ async function assemblePizzaBot(systemPrompt: string, deps: RuntimeDeps): Promis
       ),
     };
   });
+
+  middleware.push(taskDispatchMiddleware({
+    ...(model ? { model } : {}),
+    subagents: subagents ?? [],
+  }));
+  // The sandbox's task() global only has somewhere to dispatch when workers exist.
+  middleware.push(await codeInterpreterMiddleware(Boolean(subagents?.length)));
 
   const params: Record<string, unknown> = {
     systemPrompt,

--- a/packages/runtime-langgraph/src/skill-dispatch.test.ts
+++ b/packages/runtime-langgraph/src/skill-dispatch.test.ts
@@ -1,0 +1,125 @@
+/** Drives the real graph to pin what a skill worker receives on dispatch. */
+import { describe, expect, it } from "vitest";
+import { AIMessage, type BaseMessage } from "@langchain/core/messages";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { MemorySaver } from "@langchain/langgraph";
+import type { SkillCatalog } from "@pizza-bot/core";
+import { createPizzaBotAgent } from "./index.js";
+import { TASK_USAGE_NOTES } from "./task-dispatch-middleware.js";
+
+const skills: SkillCatalog = new Map([[
+  "worker",
+  {
+    id: "worker",
+    name: "Worker",
+    description: "Handles delegated work.",
+    source: "user",
+    declaredTools: [],
+    interruptOn: {},
+    files: [{
+      path: "/skills/worker/SKILL.md",
+      content: "---\nname: worker\ndescription: Handles delegated work.\n---\n\nComplete the task.",
+    }],
+  },
+]]);
+
+/** Dispatches once, then records the human turns every later model call sees. */
+class DispatchingModel extends BaseChatModel<Record<string, never>> {
+  readonly humanTurns: string[][] = [];
+  readonly boundTools: Array<{ name?: unknown; description?: unknown }> = [];
+  private readonly dispatch: string;
+  private call = 0;
+
+  constructor(dispatch: string) {
+    super({});
+    this.dispatch = dispatch;
+  }
+
+  _llmType(): string {
+    return "dispatching";
+  }
+
+  override bindTools(tools: Array<{ name?: unknown; description?: unknown }>): this {
+    this.boundTools.push(...tools);
+    return this;
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+  ): Promise<{ generations: Array<{ message: AIMessage; text: string }> }> {
+    this.humanTurns.push(
+      messages.filter((message) => message.getType() === "human").map((message) => message.text),
+    );
+    const message = this.call++ === 0
+      ? new AIMessage({
+          content: "",
+          tool_calls: [{
+            id: "task-1",
+            name: "task",
+            args: { description: this.dispatch, subagent_type: "worker" },
+            type: "tool_call",
+          }],
+        })
+      : new AIMessage({ content: "done" });
+    return { generations: [{ message, text: message.text }] };
+  }
+}
+
+async function dispatch(
+  userRequest: string,
+  description: string,
+): Promise<{ workerTurn: string; frames: string; taskDescription: string }> {
+  const model = new DispatchingModel(description);
+  const agent = await createPizzaBotAgent("Help the user.", {
+    model,
+    skills,
+    checkpointer: new MemorySaver(),
+  });
+  const frames: unknown[] = [];
+  for await (const frame of agent.streamProtocol(
+    { messages: [{ id: "u1", role: "user", parts: [{ type: "text", text: userRequest }] }] },
+    { threadId: `dispatch_${Math.random().toString(36).slice(2)}` },
+  )) {
+    frames.push(frame);
+  }
+  const task = model.boundTools.find((tool) => tool.name === "task");
+  return {
+    // The orchestrator opens and closes the run; the worker is the call between.
+    workerTurn: model.humanTurns[1]?.join("\n\n") ?? "",
+    frames: JSON.stringify(frames),
+    taskDescription: typeof task?.description === "string" ? task.description : "",
+  };
+}
+
+describe("skill worker dispatch", () => {
+  it("reaches the worker as the orchestrator wrote it", async () => {
+    const { workerTurn } = await dispatch(
+      "Book the cheapest flight to Tokyo.",
+      "Research Tokyo flight prices and return a markdown table sorted by price.",
+    );
+    expect(workerTurn).toBe(
+      "Research Tokyo flight prices and return a markdown table sorted by price.",
+    );
+  });
+
+  it("streams the same text the worker saw, so the UI shows no machinery", async () => {
+    const { workerTurn, frames } = await dispatch(
+      "Book the cheapest flight to Tokyo.",
+      "Research Tokyo flight prices and return a markdown table sorted by price.",
+    );
+    expect(frames).toContain(workerTurn);
+    // Prompt scaffolding belongs to the model call, never to a transcript.
+    expect(frames).not.toContain("user_request");
+    expect(frames).not.toContain("relay instruction");
+  });
+
+  // Our middleware replaces DeepAgents' by name, so a renamed upstream entry would
+  // leave theirs in place and quietly reinstate "put full detail in the prompt".
+  it("offers the task tool with routing notes instead of upstream's briefing notes", async () => {
+    const { taskDescription } = await dispatch("Find flights.", "Find flights.");
+    expect(taskDescription).toContain("- worker: Handles delegated work.");
+    expect(taskDescription).toContain(TASK_USAGE_NOTES);
+    expect(taskDescription).not.toContain("Put full detail in the prompt");
+    expect(taskDescription).not.toContain("relay a summary yourself");
+  });
+});

--- a/packages/runtime-langgraph/src/task-dispatch-middleware.test.ts
+++ b/packages/runtime-langgraph/src/task-dispatch-middleware.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { FakeChatModel } from "@langchain/core/utils/testing";
+import {
+  TASK_USAGE_NOTES,
+  taskDispatchMiddleware,
+  taskToolDescription,
+} from "./task-dispatch-middleware.js";
+
+const worker = { name: "mailer", description: "Sends mail." };
+
+function toolNames(middleware: unknown): string[] {
+  const tools = (middleware as { tools?: Array<{ name?: unknown }> }).tools ?? [];
+  return tools.map((tool) => String(tool.name));
+}
+
+describe("taskToolDescription", () => {
+  it("rosters the workers and states the routing notes", () => {
+    const description = taskToolDescription([worker, { name: "notes", description: "Reads notes." }]);
+    expect(description).toContain("- mailer: Sends mail.");
+    expect(description).toContain("- notes: Reads notes.");
+    expect(description).toContain(TASK_USAGE_NOTES);
+  });
+
+  it("offers no general-purpose worker", () => {
+    expect(taskToolDescription([worker])).not.toContain("general-purpose");
+  });
+
+  // These notes are the only place the dispatch contract is stated, so they have
+  // to carry it in full.
+  it("routes without briefing, inventing, or summarizing", () => {
+    expect(TASK_USAGE_NOTES).toContain("it does not brief the worker");
+    expect(TASK_USAGE_NOTES).toContain("copy them verbatim when they stand on their own");
+    expect(TASK_USAGE_NOTES).toContain(
+      "Do not specify an output format, field list, length, tone, time range, or " +
+        "acceptance criteria the user did not ask for",
+    );
+    expect(TASK_USAGE_NOTES).toContain("keep each item's original wording");
+    expect(TASK_USAGE_NOTES).toContain(
+      "reproduce it in your reply with its formatting intact rather than summarizing it",
+    );
+  });
+});
+
+describe("taskDispatchMiddleware", () => {
+  it("replaces DeepAgents' own subagent middleware by name", () => {
+    const middleware = taskDispatchMiddleware({
+      model: new FakeChatModel({}),
+      subagents: [worker as never],
+    });
+    expect((middleware as { name: string }).name).toBe("subAgentMiddleware");
+    expect(toolNames(middleware)).toEqual(["task"]);
+  });
+
+  it("describes the task tool itself rather than editing upstream's text", () => {
+    const middleware = taskDispatchMiddleware({
+      model: new FakeChatModel({}),
+      subagents: [worker as never],
+    });
+    const task = (middleware as { tools: Array<{ description?: unknown }> }).tools[0];
+    expect(task?.description).toBe(taskToolDescription([worker]));
+  });
+
+  it("withholds the task tool when no worker can receive a dispatch", () => {
+    expect(toolNames(taskDispatchMiddleware({ model: new FakeChatModel({}), subagents: [] })))
+      .toEqual([]);
+    expect(toolNames(taskDispatchMiddleware({ subagents: [worker as never] }))).toEqual([]);
+  });
+});

--- a/packages/runtime-langgraph/src/task-dispatch-middleware.ts
+++ b/packages/runtime-langgraph/src/task-dispatch-middleware.ts
@@ -1,0 +1,72 @@
+/** Owns the `task` tool: its roster is the skill workers and its notes route, not brief. */
+import { createMiddleware } from "langchain";
+import { createSubAgentMiddleware, type CompiledSubAgent, type SubAgent } from "deepagents";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+
+/**
+ * Replaces DeepAgents' default entry by name, so this text is the whole tool
+ * description rather than an edit to theirs.
+ */
+const SUBAGENT_MIDDLEWARE_NAME = "subAgentMiddleware";
+
+export const TASK_USAGE_NOTES = [
+  "Specify subagent_type to select the agent. Usage notes:",
+  "- Launch multiple agents concurrently when their tasks are independent, using a " +
+    "single message with multiple tool calls.",
+  "- `description` routes a request; it does not brief the worker. Carry the user's " +
+    "own words — copy them verbatim when they stand on their own — and add only what " +
+    "the worker cannot see for itself: relevant earlier turns, results you already " +
+    "gathered, exact paths or identifiers.",
+  "- Do not specify an output format, field list, length, tone, time range, or " +
+    "acceptance criteria the user did not ask for. The worker's own instructions " +
+    "govern what it returns and in how much detail.",
+  "- Dispatch a worker once per request unless the request spans genuinely " +
+    "independent items; then keep each item's original wording.",
+  "- Each invocation is stateless: the worker sees only this description and returns " +
+    "one final report.",
+  "- The report is not shown to the user, so reproduce it in your reply with its " +
+    "formatting intact rather than summarizing it.",
+].join("\n");
+
+type RosterEntry = { name: string; description: string };
+
+export function taskToolDescription(subagents: readonly RosterEntry[]): string {
+  return [
+    "Launch an ephemeral subagent to handle a complex, multi-step task in an isolated " +
+      "context window.",
+    "",
+    "Available agent types:",
+    ...subagents.map((subagent) => `- ${subagent.name}: ${subagent.description}`),
+    "",
+    TASK_USAGE_NOTES,
+  ].join("\n");
+}
+
+/**
+ * Upstream's notes tell the model to put full detail in the dispatch, to state
+ * exactly what to get back, and to relay a summary — advice for a generic
+ * subagent that fights a skill-scoped worker, whose own instructions already
+ * govern procedure and output. The system prompt loses this argument on
+ * locality, since those notes sit in the schema the model is filling out.
+ *
+ * `generalPurposeAgent: false` because DeepAgents' auto-added one heads the
+ * roster claiming "access to all tools as the main agent" while holding only the
+ * filesystem — we pass no `tools` to `createDeepAgent`, so its `defaultTools` are
+ * empty, and it gets no skill, no `eval`, and none of the per-worker guardrails.
+ * The base agent already holds the same filesystem tools directly. With no
+ * workers there is nothing to route to, so the tool itself goes away.
+ */
+export function taskDispatchMiddleware(options: {
+  model?: BaseChatModel;
+  subagents: readonly (SubAgent | CompiledSubAgent)[];
+}): unknown {
+  if (!options.model || options.subagents.length === 0) {
+    return createMiddleware({ name: SUBAGENT_MIDDLEWARE_NAME });
+  }
+  return createSubAgentMiddleware({
+    defaultModel: options.model,
+    subagents: options.subagents as (SubAgent | CompiledSubAgent)[],
+    generalPurposeAgent: false,
+    taskDescription: taskToolDescription(options.subagents as readonly RosterEntry[]),
+  });
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@pizza-bot/core": "*",
-    "@langchain/langgraph": "^1.4.9",
+    "@langchain/langgraph": "^1.4.10",
     "@langchain/langgraph-checkpoint-sqlite": "^1.0.3",
     "better-sqlite3": "^13.0.0",
     "zod": "^4.0.0"

--- a/skills/README.md
+++ b/skills/README.md
@@ -39,6 +39,27 @@ Skill API represents binary content as base64 with `encoding: "base64"`.
 2. Add any nested scripts, references, or assets the body references; relative
    paths are preserved and resources load on demand.
 
+## Write the description for two readers
+
+The `description` is the **only** part of a skill Pizza Bot ever sees — it does
+not read `SKILL.md` before delegating. So it does two jobs, and most descriptions
+only do the first:
+
+1. **Selection** — when should this worker be picked? Name the domain and the
+   phrases a user would actually say ("my notes", "my vault").
+2. **Expectation** — what does the worker decide for itself, and what does it
+   return? Without this, Pizza Bot has to guess, and it guesses by writing a spec
+   into the dispatch: an output format, a field list, a time range the user never
+   asked for. Stating that the worker already picks its own time window, or that
+   a task review comes back with source notes and due dates, removes the gap it
+   would otherwise fill.
+
+A live ablation on two skills measured 36% shorter dispatches from adding one
+"decides X itself, returns Y" sentence, and it stopped one request from being
+split across redundant workers. Describe only what the worker really does —
+a description that overpromises makes Pizza Bot dispatch work the skill cannot
+deliver.
+
 The built-in catalog is discovered automatically; there is no orchestrator list
 to edit. A skill with MCP dependencies becomes callable after every declared
 server and tool is enabled and connected.

--- a/tests/langgraph-compat/deepagents-api.test.ts
+++ b/tests/langgraph-compat/deepagents-api.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-/** API surface pins for deepagents@1.12.2 and @langchain/langgraph@1.4.9. */
+/** API surface pins for deepagents@1.13.2 and @langchain/langgraph@1.4.13. */
 describe("DeepAgents API surface pins", () => {
   it("deepagents exports createDeepAgent + the four backends", async () => {
     const m = await import("deepagents");

--- a/tests/langgraph-compat/package.json
+++ b/tests/langgraph-compat/package.json
@@ -14,9 +14,9 @@
     "@pizza-bot/runtime-langgraph": "*"
   },
   "devDependencies": {
-    "@langchain/core": "^1.2.1",
-    "@langchain/langgraph": "^1.4.9",
-    "deepagents": "^1.12.3",
+    "@langchain/core": "^1.2.9",
+    "@langchain/langgraph": "^1.4.10",
+    "deepagents": "^1.13.2",
     "vitest": "^4.1.10"
   }
 }


### PR DESCRIPTION
Makes Pizza Bot **route** the user's request when it delegates instead of rewriting
it, and makes the worker's report actually reach the user.

Closes #51. Closes #52.

## The problem

The orchestrator invented detail when dispatching to a skill worker — output
formats, field lists, time ranges, acceptance criteria the user never asked for —
then re-summarized the worker's report so the user never saw it. It cannot know
better, because it never reads a `SKILL.md`.

## The fix, and where each half lives

A live 2x2 ablation (3 runs per arm, real model + real MCP servers, one request
repeated verbatim) placed each half of the contract. `relayed` is reply chars over
worker-report chars:

| arm | orchestrator prompt | skill descriptions | dispatches/run | mean words | relayed |
|---|---|---|---|---|---|
| A | routing/relay stripped | baseline | 2, 2, **3** | 44.7 | 0.39 |
| B | routing/relay stripped | expanded | 2, 2, 2 | **28.8** | 0.34 |
| D | full | baseline | 2, 2, 2 | 33.8 | 0.66 |
| C | full | expanded | 2, 2, 2 | 30.8 | **0.68** |

**The dispatch half goes in the `task` tool description.** `taskDispatchMiddleware`
now owns the tool, passing our own
`createSubAgentMiddleware({ taskDescription, generalPurposeAgent: false })` in
`createDeepAgent`'s `middleware` array. `mergeMiddlewareStack` replaces DeepAgents'
entry by name (`subAgentMiddleware`), so no internals are hand-replicated — this
corrects #51's assumption that `taskDescription` was unreachable. It has to be ours
rather than an addition elsewhere, because upstream's notes say the opposite ("put
full detail in the prompt and state exactly what it should return") and they sit in
the schema the model is filling out.

**The relay half only works from the system prompt.** An intermediate commit tried
stating the contract in exactly one place and cutting the prompt paragraphs; that
halved relay fidelity (0.67 → 0.34) and the loss was the specifics a skill exists
to produce. No tool description can reach the return path, because by then the tool
call is over. Measured, reverted, and documented so it isn't retried.

**Skill descriptions are the strongest lever on the dispatch itself** — 36% shorter,
and they stopped the over-split arm A produced. The orchestrator never reads a
`SKILL.md`, so a description that omits what the worker decides and returns leaves a
gap it fills by inventing. `skills/README.md` now documents writing descriptions for
both readers: selection *and* expectation.

**DeepAgents' general-purpose worker is dropped.** It headed the roster claiming
"access to all tools as the main agent" while holding only the filesystem — the
runtime passes no `tools` to `createDeepAgent`, so its `defaultTools` are empty and
it gets no skill, no `eval`, and none of the per-worker guardrails. No capability is
lost. With no ready skills there is nothing to route to, so `task` and the sandbox
`task()` bridge are both absent.

## On #52 (eval fan-out)

Filed as a gap, then tested and found unfounded. The `eval` `task()` path carries
the user's clauses **character-for-character** into the dispatch array and relays at
0.91–0.96 — better than the direct-tool path. Writing code suppresses invention
rather than inviting it: an array literal is a structural framing of "N independent
things," so the natural element is the user's own clause. Full data in that issue.

## Verification

- 1246 tests / 21 workspaces, typecheck, and lint green.
- Live-verified on real Bedrock with 17 real MCP servers across 12 runs: 4 ablation
  arms, an enumerated five-item request (all five clauses verbatim), and two forced
  `eval` fan-outs. Per `AGENTS.md`, prompt changes pass unit tests while behaving
  differently against a real model, so the behavioral claims here rest on the live
  runs, not assertions on prompt substrings.
- Probe transcripts contain real personal data and stay local; only aggregate
  metrics and placeholdered shapes are written up.

## Known limits

Relay is 0.68, not 1.0, and falls to ~0.35 with five separate workers; what drops is
section scaffolding and hedging rather than facts. Closing the rest is a rendering
change — showing the report in the transcript — not more prompt text. The report is
durably in thread state as the `task` `ToolMessage`, so it already answers follow-up
questions; it is unshown, not lost.
