### PR TITLE
fix: show a delegation awaiting approval as paused, not failed

### DIFF
--- a/apps/web/src/components/ActivityRail.test.tsx
+++ b/apps/web/src/components/ActivityRail.test.tsx
@@ -1,0 +1,62 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { DelegationInfo } from "@/projection";
+import { ActivityRail } from "./ActivityRail.js";
+
+function delegation(overrides: Partial<DelegationInfo> = {}): DelegationInfo {
+  return {
+    delegationId: "task-1",
+    subagent: "mail-assistant",
+    title: "send the note",
+    status: "running",
+    depth: 0,
+    parentId: null,
+    ...overrides,
+  };
+}
+
+function render(delegations: DelegationInfo[], isRunning = false): string {
+  return renderToStaticMarkup(
+    <ActivityRail
+      delegations={Object.fromEntries(delegations.map((d) => [d.delegationId, d]))}
+      isRunning={isRunning}
+    />,
+  );
+}
+
+describe("ActivityRail delegation status", () => {
+  it("shows a delegation waiting on approval as awaiting input, not failed", () => {
+    const html = render([delegation({ status: "awaiting-input" })]);
+
+    expect(html).toContain("activity-icon-await");
+    expect(html).toContain("Awaiting approval");
+    expect(html).not.toContain("activity-icon-error");
+  });
+
+  it("still marks a genuinely failed delegation with the error icon", () => {
+    const html = render([delegation({ status: "error", errorText: "worker crashed" })]);
+
+    expect(html).toContain("activity-icon-error");
+    expect(html).not.toContain("activity-icon-await");
+  });
+
+  it("reports a batch as awaiting input when any member waits on approval", () => {
+    const html = render([
+      delegation({ delegationId: "task-1", status: "awaiting-input", batchId: "b1" }),
+      delegation({ delegationId: "task-2", subagent: "sfdc-assistant", status: "running", batchId: "b1" }),
+    ]);
+
+    expect(html).toContain("activity-icon-await");
+    expect(html).not.toContain("activity-icon-error");
+  });
+
+  it("keeps an errored batch member from turning the batch into a failure while one waits", () => {
+    const awaiting = render([
+      delegation({ delegationId: "task-1", status: "awaiting-input", batchId: "b1" }),
+      delegation({ delegationId: "task-2", status: "error", errorText: "boom", batchId: "b1" }),
+    ]);
+
+    // The batch head reads awaiting; only the failed child keeps its error icon.
+    expect(awaiting.indexOf("activity-icon-await")).toBeLessThan(awaiting.indexOf("activity-icon-error"));
+  });
+});

--- a/apps/web/src/components/ActivityRail.tsx
+++ b/apps/web/src/components/ActivityRail.tsx
@@ -1,5 +1,5 @@
 import { useState, type KeyboardEvent } from "react";
-import { CheckCircle2, ChevronDown, ChevronRight, Loader2, X, XCircle } from "lucide-react";
+import { CheckCircle2, ChevronDown, ChevronRight, Clock, Loader2, X, XCircle } from "lucide-react";
 import type { DelegationInfo, UIMessageLike, UIPartLike } from "@/projection";
 import { Avatar } from "./Avatar.js";
 import { useSubagentTranscript } from "../use-thread-slice.js";
@@ -74,6 +74,10 @@ export function ActivityRail({
   );
 }
 
+function inFlight(status: DelegationInfo["status"]): boolean {
+  return status === "running" || status === "awaiting-input";
+}
+
 interface Batch {
   key: string;
   items: DelegationInfo[];
@@ -113,14 +117,21 @@ function DelegationBatch({
   const names = [...new Set(items.map((i) => i.subagent))];
   const label = names.join(" · ");
   const showCount = items.length !== names.length;
+  const awaiting = items.some((i) => i.status === "awaiting-input");
   const running = items.some((i) => i.status === "running");
   const errored = items.some((i) => i.status === "error");
-  const status: DelegationInfo["status"] = running ? "running" : errored ? "error" : "completed";
+  const status: DelegationInfo["status"] = awaiting
+    ? "awaiting-input"
+    : running
+      ? "running"
+      : errored
+        ? "error"
+        : "completed";
   const starts = items.map((i) => i.startedAt).filter((n): n is number => n !== undefined);
   const ends = items.map((i) => i.completedAt).filter((n): n is number => n !== undefined);
   // SDK completion timestamps can move until the parent run settles.
   const duration =
-    !runSettled || running || !starts.length || ends.length < items.length
+    !runSettled || inFlight(status) || !starts.length || ends.length < items.length
       ? undefined
       : formatDuration(Math.min(...starts), Math.max(...ends));
 
@@ -183,10 +194,10 @@ function DelegationGroup({
   const transcript = useSubagentTranscript(threadId ?? "", g.delegationId, open && !!threadId);
   const detail = g.status === "error" ? g.errorText : outputText(g.output);
   const canExpand =
-    g.status === "running" || (transcript?.length ?? 0) > 0 || (detail !== undefined && detail.length > 0);
+    inFlight(g.status) || (transcript?.length ?? 0) > 0 || (detail !== undefined && detail.length > 0);
   // Batch rows own their shared duration; solo timestamps settle with the run.
   const duration =
-    inBatch || !runSettled || g.status === "running"
+    inBatch || !runSettled || inFlight(g.status)
       ? undefined
       : formatDuration(g.startedAt, g.completedAt);
   const rel = (g.depth ?? 0) - baseDepth;
@@ -232,12 +243,16 @@ function DelegationGroup({
       )}
       {open &&
         (transcript && transcript.length > 0 ? (
-          <SubagentTranscript messages={transcript} settled={g.status !== "running"} />
+          <SubagentTranscript messages={transcript} settled={!inFlight(g.status)} />
         ) : detail !== undefined && detail.length > 0 ? (
           <pre className={`delegation-detail${g.status === "error" ? " error" : ""}`}>{detail}</pre>
         ) : (
           <div className="delegation-detail muted">
-            {g.status === "running" ? "Waiting for the subagent to report…" : "No transcript available."}
+            {g.status === "awaiting-input"
+              ? "Waiting for your approval…"
+              : g.status === "running"
+                ? "Waiting for the subagent to report…"
+                : "No transcript available."}
           </div>
         ))}
     </li>
@@ -332,6 +347,13 @@ function CallIndicator({ status }: { status: DelegationInfo["status"] }) {
   }
   if (status === "error") {
     return <XCircle className="activity-icon activity-icon-error" size={13} />;
+  }
+  if (status === "awaiting-input") {
+    return (
+      <Clock className="activity-icon activity-icon-await" size={13} aria-label="Awaiting approval">
+        <title>Awaiting approval</title>
+      </Clock>
+    );
   }
   return <Loader2 className="activity-icon activity-icon-active spin" size={13} />;
 }

--- a/apps/web/src/projection/thread-slice.ts
+++ b/apps/web/src/projection/thread-slice.ts
@@ -8,7 +8,7 @@ export interface DelegationInfo {
   delegationId: string;
   subagent: string;
   title?: string;
-  status: "running" | "completed" | "error";
+  status: "running" | "awaiting-input" | "completed" | "error";
   output?: unknown;
   errorText?: string;
   startedAt?: number;

--- a/apps/web/src/protocol-stream-store.test.ts
+++ b/apps/web/src/protocol-stream-store.test.ts
@@ -580,6 +580,74 @@ describe("ProtocolStreamStore steering-enqueue", () => {
     });
   });
 
+  it("marks an in-flight delegation as awaiting input while an approval is pending", async () => {
+    await store.attach(TID, false);
+    last.subagents = new Map([[
+      "task-1",
+      {
+        id: "task-1",
+        name: "mail-assistant",
+        status: "running",
+        taskInput: "send the note",
+        namespace: [],
+        parentId: null,
+        depth: 0,
+      },
+    ]]);
+    last.notify();
+
+    expect(store.getSlice(TID).delegations["task-1"]).toMatchObject({ status: "running" });
+
+    last.interrupt = { id: "int-1", value: { action_requests: [] } };
+    last.notify();
+
+    expect(store.getSlice(TID).delegations["task-1"]).toMatchObject({ status: "awaiting-input" });
+    expect(store.getSlice(TID).delegations["task-1"]!.errorText).toBeUndefined();
+
+    // Approval resolves the pause; the delegation resumes as ordinary work.
+    last.interrupt = undefined;
+    last.notify();
+
+    expect(store.getSlice(TID).delegations["task-1"]).toMatchObject({ status: "running" });
+  });
+
+  it("keeps a settled delegation's own outcome while an approval is pending", async () => {
+    await store.attach(TID, false);
+    last.subagents = new Map([
+      [
+        "task-1",
+        {
+          id: "task-1",
+          name: "mail-assistant",
+          status: "complete",
+          taskInput: "send the note",
+          namespace: [],
+          parentId: null,
+          depth: 0,
+        },
+      ],
+      [
+        "task-2",
+        {
+          id: "task-2",
+          name: "sfdc-assistant",
+          status: "error",
+          error: "search_accounts rejected its arguments",
+          taskInput: "look up accounts",
+          namespace: [],
+          parentId: null,
+          depth: 0,
+        },
+      ],
+    ]);
+    last.interrupt = { id: "int-1", value: { action_requests: [] } };
+    last.notify();
+
+    const { delegations } = store.getSlice(TID);
+    expect(delegations["task-1"]).toMatchObject({ status: "completed" });
+    expect(delegations["task-2"]).toMatchObject({ status: "error" });
+  });
+
   it("acquires a hydrated subagent transcript after namespace resolution", async () => {
     await store.attach(TID, true);
     let resolveNamespace!: () => void;

--- a/apps/web/src/protocol-stream-store.ts
+++ b/apps/web/src/protocol-stream-store.ts
@@ -333,12 +333,16 @@ export class ProtocolStreamStore {
         delegationId: s.id,
         subagent: s.name,
         ...(s.taskInput ? { title: s.taskInput } : {}),
+        // A pending interrupt halts the whole graph, so no in-flight delegation
+        // is making progress: it is blocked on the user, not merely running.
         status:
           taskError !== undefined || s.status === "error"
             ? "error"
             : s.status === "complete"
               ? "completed"
-              : "running",
+              : root.interrupt
+                ? "awaiting-input"
+                : "running",
         ...(s.output !== undefined ? { output: s.output } : {}),
         ...(s.error || taskError ? { errorText: s.error ?? taskError } : {}),
         ...(live && s.startedAt ? { startedAt: s.startedAt.getTime() } : {}),

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -547,6 +547,7 @@ button.sidebar-folder-row:hover,
 .activity-icon-done { color: var(--brand); }
 .activity-icon-active { color: var(--brand); }
 .activity-icon-error { color: var(--danger, #f87171); }
+.activity-icon-await { color: var(--warning, #f5a623); }
 .spin { animation: spin 1s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 

--- a/packages/runtime-langgraph/src/stream-protocol.test.ts
+++ b/packages/runtime-langgraph/src/stream-protocol.test.ts
@@ -135,6 +135,54 @@ describe("streamProtocolEvents — content-block reindex", () => {
   });
 });
 
+function toolErrorFrame(message: string, toolCallId = "task-1"): ProtocolEvent {
+  return {
+    type: "event",
+    seq: 0,
+    method: "tools",
+    params: {
+      namespace: ["tools:abc"],
+      timestamp: 0,
+      data: { event: "tool-error", tool_call_id: toolCallId, message },
+    },
+  } as ProtocolEvent;
+}
+
+describe("streamProtocolEvents — interrupt bubble-up", () => {
+  async function collect(frames: ProtocolEvent[]): Promise<ProtocolEvent[]> {
+    const out: ProtocolEvent[] = [];
+    for await (const ev of streamProtocolEvents(fakeGraphYielding(frames), { messages: [] }, { threadId: "t" })) {
+      out.push(ev);
+    }
+    return out;
+  }
+
+  it("drops the parent task tool-error a worker's approval pause raises", async () => {
+    const interrupts = JSON.stringify(
+      [{
+        id: "int-1",
+        value: { actionRequests: [{ name: "mailer__send", args: {} }] },
+      }],
+      null,
+      2,
+    );
+    const out = await collect([toolErrorFrame(interrupts), COMPLETED]);
+    expect(out).toEqual([COMPLETED]);
+  });
+
+  it("keeps a genuine tool failure on the tools channel", async () => {
+    const failure = toolErrorFrame("kaboom inside subagent", "boom-1");
+    const out = await collect([failure, COMPLETED]);
+    expect(out).toEqual([failure, COMPLETED]);
+  });
+
+  it("keeps a tool failure whose message merely parses as JSON", async () => {
+    const failure = toolErrorFrame('["retry", "later"]', "boom-2");
+    const out = await collect([failure, COMPLETED]);
+    expect(out).toEqual([failure, COMPLETED]);
+  });
+});
+
 describe("streamProtocolEvents — tool-call rejection drain", () => {
   const seen: unknown[] = [];
   const onReject = (reason: unknown) => seen.push(reason);

--- a/packages/runtime-langgraph/src/stream-protocol.ts
+++ b/packages/runtime-langgraph/src/stream-protocol.ts
@@ -107,6 +107,7 @@ export async function* streamProtocolEvents(
   drainProjectionRejections(stream);
   const reindexer = new ContentBlockReindexer();
   for await (const event of stream) {
+    if (isInterruptBubbleUpFrame(event)) continue;
     yield reindexer.process(event);
   }
   // Cancellation takes precedence over an interrupt observed during teardown.
@@ -118,6 +119,37 @@ export async function* streamProtocolEvents(
     }
     yield interruptedLifecycleFrame();
   }
+}
+
+/**
+ * A worker's approval pause bubbles a `GraphInterrupt` out through the parent
+ * `task` tool, which LangGraph reports as `tool-error` carrying the serialized
+ * interrupts as its message. Forwarding that tells every consumer the delegation
+ * failed, when the run is only waiting for the user; the terminal
+ * `input.requested` + `interrupted` frames carry the pause instead.
+ */
+function isInterruptBubbleUpFrame(event: ProtocolEvent): boolean {
+  if (event.method !== "tools") return false;
+  const data = event.params.data as { event?: unknown; message?: unknown } | undefined;
+  if (data?.event !== "tool-error" || typeof data.message !== "string") return false;
+  return isSerializedInterrupts(data.message);
+}
+
+/** `GraphInterrupt`'s message is `JSON.stringify` of its `Interrupt[]`. */
+function isSerializedInterrupts(message: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(message);
+  } catch {
+    return false;
+  }
+  return (
+    Array.isArray(parsed) &&
+    parsed.length > 0 &&
+    parsed.every(
+      (entry) => typeof entry === "object" && entry !== null && !Array.isArray(entry) && "value" in entry,
+    )
+  );
 }
 
 /**

--- a/tests/langgraph-compat/protocol-stream-conformance.test.ts
+++ b/tests/langgraph-compat/protocol-stream-conformance.test.ts
@@ -2,8 +2,9 @@
 import { describe, it, expect } from "vitest";
 import { createPizzaBotAgent } from "@pizza-bot/runtime-langgraph";
 import { PIZZA_BOT_AGENT } from "@pizza-bot/core";
-import type { RunInput, RunOptions, SkillCatalog } from "@pizza-bot/core";
+import type { RunInput, RunOptions, SkillCatalog, SkillInterruptOn } from "@pizza-bot/core";
 import type { ProtocolEvent } from "@langchain/langgraph";
+import { MemorySaver } from "@langchain/langgraph";
 import { AIMessage } from "@langchain/core/messages";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { tool } from "@langchain/core/tools";
@@ -45,6 +46,7 @@ function skillCatalog(
   description: string,
   body: string,
   declaredTools: string[],
+  interruptOn: SkillInterruptOn = {},
 ): SkillCatalog {
   return new Map([[
     id,
@@ -54,7 +56,7 @@ function skillCatalog(
       description,
       source: "user",
       declaredTools,
-      interruptOn: {},
+      interruptOn,
       files: [{
         path: `/skills/${id}/SKILL.md`,
         content: `---\nname: ${id}\ndescription: ${description}\n---\n\n${body}\n`,
@@ -247,6 +249,84 @@ describe("createPizzaBotAgent().streamProtocol() yields SDK-decodable ProtocolEv
         channelOf(e) === "lifecycle" &&
         e.params.namespace.length === 0 &&
         (e.params.data as { event?: string }).event === "failed",
+    )).toBe(false);
+  });
+
+  it("a worker's approval pause reports no error on the delegating task call", async () => {
+    const sendTool = tool(() => "sent", {
+      name: "mailer__send",
+      description: "send mail",
+      schema: z.object({}),
+    });
+    const skills = skillCatalog(
+      "specialist",
+      "Handles delegated sends.",
+      "Send the mail.",
+      ["mcp:mailer:send"],
+      { "mcp:mailer:send": { allowedDecisions: ["approve", "reject"] } },
+    );
+    const agent = await createPizzaBotAgent(PIZZA_BOT_AGENT.systemPrompt, {
+      model: new ScriptedModel([
+        new AIMessage({
+          content: "",
+          tool_calls: [{
+            id: "task-1",
+            name: "task",
+            args: { description: "send the mail", subagent_type: "specialist" },
+            type: "tool_call",
+          }],
+        }),
+        new AIMessage({
+          content: "",
+          tool_calls: [{ id: "send-1", name: "mailer__send", args: {}, type: "tool_call" }],
+        }),
+        new AIMessage({ content: "Sent." }),
+        new AIMessage({ content: "Delegation completed." }),
+      ]),
+      tools: { "mcp:mailer:send": sendTool },
+      catalog: { mailer: ["send"] },
+      skills,
+      checkpointer: new MemorySaver(),
+    });
+
+    const threadId = `proto_subagent_hitl_${Math.random().toString(36).slice(2)}`;
+    const paused: ProtocolEvent[] = [];
+    for await (const ev of agent.streamProtocol(
+      { messages: [{ id: "u1", role: "user", parts: [{ type: "text", text: "send it" }] }] },
+      { threadId },
+    )) {
+      paused.push(ev);
+    }
+
+    const toolErrors = paused.filter(
+      (e) => channelOf(e) === "tools" && (e.params.data as { event?: string }).event === "tool-error",
+    );
+    expect(toolErrors).toEqual([]);
+    const requested = paused.find((e) => channelOf(e) === "input.requested");
+    expect(requested).toBeDefined();
+    const interruptId = (requested!.params.data as { interrupt_id: string }).interrupt_id;
+    expect(paused.some(
+      (e) =>
+        channelOf(e) === "lifecycle" &&
+        (e.params.data as { event?: string }).event === "interrupted",
+    )).toBe(true);
+
+    // Approving finishes the same task call, so the delegation reads as completed.
+    const resumed: ProtocolEvent[] = [];
+    for await (const ev of agent.streamProtocol(
+      { command: { interruptId, decisions: [{ decision: "approve" }] } },
+      { threadId },
+    )) {
+      resumed.push(ev);
+    }
+    expect(resumed.some(
+      (e) =>
+        channelOf(e) === "tools" &&
+        (e.params.data as { event?: string; tool_call_id?: string }).event === "tool-finished" &&
+        (e.params.data as { tool_call_id?: string }).tool_call_id === "task-1",
+    )).toBe(true);
+    expect(resumed.some(
+      (e) => channelOf(e) === "tools" && (e.params.data as { event?: string }).event === "tool-error",
     )).toBe(false);
   });
 


### PR DESCRIPTION
Fixes #54.

## Root cause

A skill worker's approval pause raises a `GraphInterrupt` that bubbles out through the orchestrator's `task` tool. LangGraph's v3 converter turns any throw inside a tool into a `tools`/`tool-error` frame whose `message` is `JSON.stringify(interrupts)`, and the SDK's `SubagentDiscovery` marks the subagent `status: "error"` on any `tool-error`. The Activity rail therefore showed a red X plus a bogus duration for a delegation that had merely paused.

## Changes

- `runtime-langgraph/src/stream-protocol.ts` drops tool-error frames whose message is a serialized `Interrupt[]`; the terminal `input.requested` + `interrupted` frames already carry the pause. The error class is gone by that point in the pipeline, so detection is shape-based and commented as such.
- Delegations gain an `awaiting-input` status (`projection/thread-slice.ts`), derived in `protocol-stream-store.ts` when a pending interrupt is halting the graph. A delegation's own settled outcome (completed or error) still wins.
- `ActivityRail.tsx` renders it as an amber clock labelled "Awaiting approval", aggregates batches to awaiting, and suppresses the duration while in flight. This also fixes the same red X one level down: the pending tool inside the drill-down transcript was being sealed as `output-error`.

## Verification

- Offline conformance through the real DeepAgents graph: no tool-error at the pause, and after approving, `task-1` reports `tool-finished`.
- Unit coverage that genuine tool failures still pass through, including a failure message that merely parses as JSON.
- Store-projection tests for the derivation, and a new `ActivityRail.test.tsx`.
- Driven live in the browser against Bedrock with a scratch data root: pre-fix the delegation shows a red X and a duration while the approval card is open; post-fix an amber clock and no duration, flipping to the green check with the real duration after approving.
- `npm test`, `npm run lint`, `npm run typecheck` green.