### PR TITLE
fix: keep MCP union schemas intact and stop blaming tool arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9463,9 +9463,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -13742,9 +13742,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/packages/plugin-sdk/src/__fixtures__/mcp-union-schema-server.mjs
+++ b/packages/plugin-sdk/src/__fixtures__/mcp-union-schema-server.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/** Advertises the recursive `anyOf` filter shape common to record-search MCP tools. */
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server(
+  { name: "union-schema", version: "1.0.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "search_records",
+      description: "Search records with a simple or compound filter.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          queryTerm: { type: "string", description: "Free-text search" },
+          condition: {
+            allOf: [
+              { description: "simple or compound conditions", $ref: "#/definitions/__schema0" },
+            ],
+          },
+          aliases: {
+            description: "One alias or several",
+            anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+          },
+        },
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+        definitions: {
+          __schema0: {
+            anyOf: [
+              {
+                type: "object",
+                properties: {
+                  field: { type: "string", minLength: 1 },
+                  operator: { type: "string", enum: ["EXACT_MATCH", "CONTAINS", "GT"] },
+                  value: { type: "string", minLength: 1 },
+                },
+                required: ["field", "operator"],
+              },
+              {
+                type: "object",
+                properties: {
+                  operator: { type: "string", enum: ["AND", "OR"] },
+                  conditions: { type: "array", items: { $ref: "#/definitions/__schema0" } },
+                },
+                required: ["operator", "conditions"],
+              },
+            ],
+          },
+        },
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => ({
+  content: [{ type: "text", text: JSON.stringify(request.params.arguments ?? {}) }],
+}));
+
+await server.connect(new StdioServerTransport());
+process.stderr.write("[union-schema] stdio server ready\n");

--- a/packages/plugin-sdk/src/mcp-connect.test.ts
+++ b/packages/plugin-sdk/src/mcp-connect.test.ts
@@ -17,6 +17,7 @@ const STATUS_SERVER = resolve(
 );
 const EMPTY_DESC_SERVER = resolve(__dirname, "__fixtures__/mcp-empty-desc-server.mjs");
 const DELAYED_SERVER = resolve(__dirname, "__fixtures__/mcp-delayed-server.mjs");
+const UNION_SCHEMA_SERVER = resolve(__dirname, "__fixtures__/mcp-union-schema-server.mjs");
 
 describe("connectMcpServers", () => {
   it("returns an empty result (no client) for no entries", async () => {
@@ -79,6 +80,43 @@ describe("connectMcpServers", () => {
           value: { type: "string" },
         },
       });
+    } finally {
+      await r.client?.close().catch(() => {});
+    }
+  }, 20_000);
+
+  it("calls a tool with either branch of a union its server accepts", async () => {
+    const r = await connectMcpServers(
+      { union: { command: "node", args: [UNION_SCHEMA_SERVER] } },
+      undefined,
+    );
+    try {
+      const tool = r.tools["mcp:union:search_records"];
+      expect(tool).toBeDefined();
+
+      const leaf = { condition: { field: "accountId", operator: "EXACT_MATCH", value: "a-1" } };
+      const compound = {
+        condition: { operator: "AND", conditions: [leaf.condition] },
+      };
+      await expect(tool!.invoke(leaf)).resolves.toContain("EXACT_MATCH");
+      await expect(tool!.invoke(compound)).resolves.toContain("AND");
+      await expect(tool!.invoke({ aliases: "solo" })).resolves.toContain("solo");
+      await expect(tool!.invoke({ aliases: ["a", "b"] })).resolves.toContain("b");
+    } finally {
+      await r.client?.close().catch(() => {});
+    }
+  }, 20_000);
+
+  it("names the failing constraint when a tool call really is malformed", async () => {
+    const r = await connectMcpServers(
+      { union: { command: "node", args: [UNION_SCHEMA_SERVER] } },
+      undefined,
+    );
+    try {
+      const tool = r.tools["mcp:union:search_records"];
+      await expect(
+        tool!.invoke({ condition: { field: "accountId", operator: "NOPE", value: "a-1" } }),
+      ).rejects.toThrow(/operator/);
     } finally {
       await r.client?.close().catch(() => {});
     }

--- a/packages/plugin-sdk/src/mcp-schema.test.ts
+++ b/packages/plugin-sdk/src/mcp-schema.test.ts
@@ -1,7 +1,89 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
 import { describe, expect, it } from "vitest";
-import { restoreNullableSchemaTypes } from "./mcp-schema.js";
+import { restoreFlattenedUnions } from "./mcp-schema.js";
 
-describe("restoreNullableSchemaTypes", () => {
+/**
+ * The filter shape common to record-search MCP tools: a recursive definition
+ * whose two branches are a leaf comparison and a compound group.
+ */
+const filterSource = {
+  type: "object",
+  properties: {
+    queryTerm: { type: "string" },
+    condition: {
+      allOf: [
+        { description: "simple or compound conditions", $ref: "#/definitions/__schema0" },
+      ],
+    },
+  },
+  $schema: "http://json-schema.org/draft-07/schema#",
+  additionalProperties: false,
+  definitions: {
+    __schema0: {
+      anyOf: [
+        {
+          type: "object",
+          properties: {
+            field: { type: "string", minLength: 1 },
+            operator: { type: "string", enum: ["EXACT_MATCH", "CONTAINS", "GT", "EXISTS"] },
+            value: { type: "string", minLength: 1 },
+          },
+          required: ["field", "operator"],
+        },
+        {
+          type: "object",
+          properties: {
+            operator: { type: "string", enum: ["AND", "OR"] },
+            conditions: { type: "array", items: { $ref: "#/definitions/__schema0" } },
+          },
+          required: ["operator", "conditions"],
+        },
+      ],
+    },
+  },
+};
+
+/** What mcp-adapters hands the model for `filterSource`: both branches merged into one. */
+const filterAdapted = {
+  type: "object",
+  properties: {
+    queryTerm: { type: "string" },
+    condition: {
+      description: "simple or compound conditions",
+      type: "object",
+      properties: {
+        field: { type: "string", minLength: 1 },
+        operator: { type: "string", enum: ["AND", "OR"] },
+        value: { type: "string", minLength: 1 },
+        conditions: { type: "array", items: { type: "object" } },
+      },
+      required: ["operator"],
+    },
+  },
+  additionalProperties: false,
+};
+
+const leafFilter = { condition: { field: "accountId", operator: "EXACT_MATCH", value: "acct-1" } };
+const compoundFilter = {
+  condition: {
+    operator: "AND",
+    conditions: [{ field: "accountId", operator: "EXACT_MATCH", value: "acct-1" }],
+  },
+};
+
+/** Validate through the same pre-flight LangChain runs before a tool call reaches the server. */
+async function callWithSchema(schema: unknown, args: unknown): Promise<string> {
+  const tool = new DynamicStructuredTool({
+    name: "search",
+    description: "search",
+    schema: schema as Record<string, unknown>,
+    func: async () => "called",
+  });
+  tool.verboseParsingErrors = true;
+  return (await tool.invoke(args as Record<string, unknown>)) as string;
+}
+
+describe("restoreFlattenedUnions", () => {
   it("restores a nullable string type removed from an optional MCP field", () => {
     const source = {
       type: "object",
@@ -23,7 +105,7 @@ describe("restoreNullableSchemaTypes", () => {
       },
     };
 
-    expect(restoreNullableSchemaTypes(adapted, source)).toEqual({
+    expect(restoreFlattenedUnions(adapted, source)).toEqual({
       type: "object",
       properties: {
         spoof_account_id: {
@@ -38,7 +120,7 @@ describe("restoreNullableSchemaTypes", () => {
 
   it("restores nullable arrays recursively without restoring the null union", () => {
     expect(
-      restoreNullableSchemaTypes(
+      restoreFlattenedUnions(
         { title: "Metrics" },
         {
           anyOf: [
@@ -55,9 +137,154 @@ describe("restoreNullableSchemaTypes", () => {
     });
   });
 
-  it("leaves non-nullable unions in the adapter's provider-compatible form", () => {
-    const adapted = { title: "Value" };
-    const source = { anyOf: [{ type: "string" }, { type: "integer" }], title: "Value" };
-    expect(restoreNullableSchemaTypes(adapted, source)).toEqual(adapted);
+  it("restores a scalar-or-array union the adapter reduces to a bare description", () => {
+    const source = {
+      type: "object",
+      properties: {
+        createdBy: {
+          description: "alias or aliases",
+          anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+        },
+      },
+    };
+    const adapted = {
+      type: "object",
+      properties: { createdBy: { description: "alias or aliases" } },
+    };
+
+    expect(restoreFlattenedUnions(adapted, source)).toEqual({
+      type: "object",
+      properties: {
+        createdBy: {
+          description: "alias or aliases",
+          anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+        },
+      },
+    });
+  });
+
+  it("restores a union nested in array items", () => {
+    const variants = [
+      {
+        type: "object",
+        properties: { slackUrl: { type: "string" } },
+        required: ["slackUrl"],
+        additionalProperties: false,
+      },
+      {
+        type: "object",
+        properties: { channelId: { type: "string" }, threadTs: { type: "string" } },
+        required: ["channelId", "threadTs"],
+        additionalProperties: false,
+      },
+    ];
+    const source = {
+      type: "object",
+      properties: { threads: { type: "array", items: { anyOf: variants } } },
+    };
+    const adapted = {
+      type: "object",
+      properties: {
+        threads: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              slackUrl: { type: "string" },
+              channelId: { type: "string" },
+              threadTs: { type: "string" },
+            },
+            additionalProperties: false,
+          },
+        },
+      },
+    };
+
+    expect(restoreFlattenedUnions(adapted, source)).toEqual({
+      type: "object",
+      properties: { threads: { type: "array", items: { anyOf: variants } } },
+    });
+  });
+
+  it("resolves a $ref hidden behind allOf and keeps the merged description", () => {
+    const restored = restoreFlattenedUnions(filterAdapted, filterSource) as {
+      properties: { condition: { description: string; anyOf: unknown[] } };
+    };
+
+    expect(restored.properties.condition.description).toBe("simple or compound conditions");
+    expect(restored.properties.condition.anyOf).toHaveLength(2);
+  });
+
+  it("degrades a self-referencing definition to a bare object rather than recursing", () => {
+    const restored = restoreFlattenedUnions(filterAdapted, filterSource) as {
+      properties: { condition: { anyOf: { properties?: { conditions?: unknown } }[] } };
+    };
+
+    expect(restored.properties.condition.anyOf[1]?.properties?.conditions).toEqual({
+      type: "array",
+      items: { type: "object" },
+    });
+  });
+
+  it("drops keys the adapter strips for provider compatibility", () => {
+    const source = {
+      type: "object",
+      properties: {
+        value: {
+          anyOf: [
+            { type: "string", $schema: "http://json-schema.org/draft-07/schema#" },
+            { type: "integer", not: { const: 0 }, unevaluatedProperties: false },
+          ],
+        },
+      },
+    };
+
+    expect(restoreFlattenedUnions({ type: "object", properties: { value: {} } }, source)).toEqual({
+      type: "object",
+      properties: { value: { anyOf: [{ type: "string" }, { type: "integer" }] } },
+    });
+  });
+
+  it("keeps a property the adapter emitted but the source never described", () => {
+    expect(
+      restoreFlattenedUnions(
+        { type: "object", properties: { extra: { type: "string" } } },
+        { type: "object", properties: {} },
+      ),
+    ).toEqual({ type: "object", properties: { extra: { type: "string" } } });
+  });
+});
+
+describe("restored MCP schemas under LangChain pre-flight validation", () => {
+  it("accepts the leaf filter the flattened schema rejected", async () => {
+    await expect(callWithSchema(filterAdapted, leafFilter)).rejects.toThrow(
+      /did not match expected schema/,
+    );
+    await expect(
+      callWithSchema(restoreFlattenedUnions(filterAdapted, filterSource), leafFilter),
+    ).resolves.toBe("called");
+  });
+
+  it("still accepts the compound filter the flattened schema already allowed", async () => {
+    await expect(callWithSchema(filterAdapted, compoundFilter)).resolves.toBe("called");
+    await expect(
+      callWithSchema(restoreFlattenedUnions(filterAdapted, filterSource), compoundFilter),
+    ).resolves.toBe("called");
+  });
+
+  it("rejects a filter that matches neither branch", async () => {
+    await expect(
+      callWithSchema(restoreFlattenedUnions(filterAdapted, filterSource), {
+        condition: { operator: "EXACT_MATCH" },
+      }),
+    ).rejects.toThrow(/did not match expected schema/);
+  });
+
+  it("names the failing constraint when verboseParsingErrors is set", async () => {
+    await expect(
+      callWithSchema(restoreFlattenedUnions(filterAdapted, filterSource), {
+        condition: { field: "accountId", operator: "NOPE", value: "acct-1" },
+      }),
+    ).rejects.toThrow(/operator/);
   });
 });

--- a/packages/plugin-sdk/src/mcp-schema.ts
+++ b/packages/plugin-sdk/src/mcp-schema.ts
@@ -1,10 +1,16 @@
 type JsonSchema = Record<string, unknown>;
 
+/** Keys the adapter strips for provider compatibility; a restored variant must not reintroduce them. */
+const ADAPTER_STRIPPED = ["$schema", "unevaluatedProperties", "not", "if", "then", "else"] as const;
+
+/** Keys that describe a field rather than constrain it, so they survive the adapter's flattening intact. */
+const ANNOTATIONS = ["description", "title", "default", "examples", "deprecated"] as const;
+
 function isJsonSchema(value: unknown): value is JsonSchema {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function nullableVariant(schema: JsonSchema): JsonSchema | undefined {
+function unionVariants(schema: JsonSchema): JsonSchema[] | undefined {
   const union = Array.isArray(schema.anyOf)
     ? schema.anyOf
     : Array.isArray(schema.oneOf)
@@ -13,32 +19,113 @@ function nullableVariant(schema: JsonSchema): JsonSchema | undefined {
   if (!union) return undefined;
 
   const variants = union.filter(isJsonSchema);
-  const nonNull = variants.filter((variant) => variant.type !== "null");
-  const hasNull = variants.some((variant) => variant.type === "null");
-  return hasNull && nonNull.length === 1 && variants.length === union.length
-    ? nonNull[0]
-    : undefined;
+  return variants.length === union.length ? variants : undefined;
 }
 
 /**
- * Restore the non-null type that mcp-adapters drops from nullable non-object
- * unions while retaining its other provider-compatibility simplifications.
+ * mcp-adapters inlines `$ref`s before it flattens, so the source has to be inlined
+ * the same way to line up with the adapted schema — including degrading a
+ * self-referencing definition to a bare object, which is where its recursion stops.
  */
-export function restoreNullableSchemaTypes(
-  adaptedSchema: unknown,
-  sourceSchema: unknown,
-): unknown {
+function dereference(schema: JsonSchema): JsonSchema {
+  const definitions = isJsonSchema(schema.$defs)
+    ? schema.$defs
+    : isJsonSchema(schema.definitions)
+      ? schema.definitions
+      : {};
+
+  function resolve(node: unknown, seen: ReadonlySet<string>): unknown {
+    if (Array.isArray(node)) return node.map((item) => resolve(item, seen));
+    if (!isJsonSchema(node)) return node;
+
+    const ref = typeof node.$ref === "string" ? node.$ref : undefined;
+    const name = ref?.match(/^#\/(?:\$defs|definitions)\/(.+)$/)?.[1];
+    const definition = name === undefined ? undefined : definitions[name];
+    if (ref !== undefined && isJsonSchema(definition)) {
+      if (seen.has(ref)) return { type: "object" };
+      const { $ref: _ref, ...siblings } = node;
+      const resolved = resolve(definition, new Set([...seen, ref])) as JsonSchema;
+      return { ...resolved, ...siblings };
+    }
+
+    const result: JsonSchema = {};
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "$defs" || key === "definitions") continue;
+      result[key] = resolve(value, seen);
+    }
+    return result;
+  }
+
+  return resolve(schema, new Set()) as JsonSchema;
+}
+
+/** The adapter merges `allOf` members into their parent, which can hide a union one level down. */
+function collapseAllOf(schema: JsonSchema): JsonSchema {
+  if (!Array.isArray(schema.allOf)) return schema;
+  const { allOf, ...base } = schema;
+  return allOf
+    .filter(isJsonSchema)
+    .reduce<JsonSchema>((merged, member) => ({ ...merged, ...collapseAllOf(member) }), base);
+}
+
+function sanitizeVariant(schema: JsonSchema): JsonSchema {
+  const collapsed = { ...collapseAllOf(schema) };
+  for (const key of ADAPTER_STRIPPED) delete collapsed[key];
+
+  if (isJsonSchema(collapsed.properties)) {
+    collapsed.properties = Object.fromEntries(
+      Object.entries(collapsed.properties).map(([name, value]) => [
+        name,
+        isJsonSchema(value) ? sanitizeVariant(value) : value,
+      ]),
+    );
+  }
+  if (isJsonSchema(collapsed.items)) collapsed.items = sanitizeVariant(collapsed.items);
+  if (isJsonSchema(collapsed.additionalProperties)) {
+    collapsed.additionalProperties = sanitizeVariant(collapsed.additionalProperties);
+  }
+  for (const key of ["anyOf", "oneOf"] as const) {
+    const union = collapsed[key];
+    if (Array.isArray(union)) {
+      collapsed[key] = union.map((variant) =>
+        isJsonSchema(variant) ? sanitizeVariant(variant) : variant,
+      );
+    }
+  }
+  return collapsed;
+}
+
+/**
+ * Restore the unions mcp-adapters flattens, keeping its other provider-compatibility
+ * simplifications. It merges every variant of a union into one schema, which both
+ * invents combinations the server rejects and drops constraints it enforces — so the
+ * model is handed a contract its own tool description contradicts, and LangChain's
+ * pre-flight validation rejects calls the server would have accepted.
+ */
+export function restoreFlattenedUnions(adaptedSchema: unknown, sourceSchema: unknown): unknown {
   if (!isJsonSchema(adaptedSchema) || !isJsonSchema(sourceSchema)) {
     return adaptedSchema;
   }
+  return restore(adaptedSchema, dereference(sourceSchema));
+}
+
+function restore(adaptedSchema: JsonSchema, rawSourceSchema: JsonSchema): JsonSchema {
+  const sourceSchema = collapseAllOf(rawSourceSchema);
+  const variants = unionVariants(sourceSchema);
+  const nonNull = variants?.filter((variant) => variant.type !== "null") ?? [];
 
   let restored: JsonSchema = { ...adaptedSchema };
-  const variant = nullableVariant(sourceSchema);
-  if (variant) {
-    restored = {
-      ...(restoreNullableSchemaTypes(variant, variant) as JsonSchema),
-      ...restored,
+  if (variants && nonNull.length > 1) {
+    const annotations = Object.fromEntries(
+      ANNOTATIONS.filter((key) => key in adaptedSchema).map((key) => [key, adaptedSchema[key]]),
+    );
+    return {
+      ...annotations,
+      anyOf: variants.map((variant) => restore(sanitizeVariant(variant), variant)),
     };
+  }
+  if (variants && nonNull.length === 1) {
+    restored = { ...restore(nonNull[0]!, nonNull[0]!), ...restored };
   } else if (Array.isArray(sourceSchema.type)) {
     const nonNullTypes = sourceSchema.type.filter((type) => type !== "null");
     if (sourceSchema.type.includes("null") && nonNullTypes.length === 1) {
@@ -49,22 +136,23 @@ export function restoreNullableSchemaTypes(
   if (isJsonSchema(restored.properties) && isJsonSchema(sourceSchema.properties)) {
     const properties = { ...restored.properties };
     for (const [name, sourceProperty] of Object.entries(sourceSchema.properties)) {
-      if (name in properties) {
-        properties[name] = restoreNullableSchemaTypes(properties[name], sourceProperty);
+      const adaptedProperty = properties[name];
+      if (isJsonSchema(adaptedProperty) && isJsonSchema(sourceProperty)) {
+        properties[name] = restore(adaptedProperty, sourceProperty);
       }
     }
     restored.properties = properties;
   }
 
-  if (restored.items !== undefined && sourceSchema.items !== undefined) {
-    restored.items = restoreNullableSchemaTypes(restored.items, sourceSchema.items);
+  if (isJsonSchema(restored.items) && isJsonSchema(sourceSchema.items)) {
+    restored.items = restore(restored.items, sourceSchema.items);
   }
 
   if (
     isJsonSchema(restored.additionalProperties) &&
     isJsonSchema(sourceSchema.additionalProperties)
   ) {
-    restored.additionalProperties = restoreNullableSchemaTypes(
+    restored.additionalProperties = restore(
       restored.additionalProperties,
       sourceSchema.additionalProperties,
     );

--- a/packages/plugin-sdk/src/plugin-host.ts
+++ b/packages/plugin-sdk/src/plugin-host.ts
@@ -27,7 +27,7 @@ import {
   materializePlugin,
   type PluginMaterializationStatus,
 } from "./materializer.js";
-import { restoreNullableSchemaTypes } from "./mcp-schema.js";
+import { restoreFlattenedUnions } from "./mcp-schema.js";
 import {
   evaluatePluginCompatibility,
   type PluginHostContract,
@@ -468,11 +468,14 @@ export async function connectMcpServers(
               const originalName = originalNames[index]!;
               const sourceSchema = sourceSchemas.get(originalName);
               if (sourceSchema) {
-                (tool as { schema: unknown }).schema = restoreNullableSchemaTypes(
+                (tool as { schema: unknown }).schema = restoreFlattenedUnions(
                   tool.schema,
                   sourceSchema,
                 );
               }
+              // Without this, a rejected call reaches the model as a bare "did not match
+              // expected schema" and it can only guess, so it retries identical arguments.
+              (tool as unknown as { verboseParsingErrors: boolean }).verboseParsingErrors = true;
               // Bedrock rejects the entire request if any tool description is blank.
               if (
                 typeof tool.description !== "string" ||

--- a/packages/runtime-langgraph/src/tool-error-middleware.test.ts
+++ b/packages/runtime-langgraph/src/tool-error-middleware.test.ts
@@ -37,6 +37,19 @@ describe("toolErrorRecoveryMiddleware", () => {
     expect(String(out.content)).toContain("try again");
   });
 
+  it("does not blame the arguments when the tool failed on authorization", async () => {
+    const wrap = wrapToolCall();
+    const out = (await wrap(request("web_search", "call_auth"), async () => {
+      throw new Error(
+        "Authorization error - Insufficient permissions. Open Settings → AWS to authenticate.",
+      );
+    })) as ToolMessage;
+
+    expect(String(out.content)).toContain("Insufficient permissions");
+    expect(String(out.content)).toContain("credentials");
+    expect(String(out.content)).not.toMatch(/fix the arguments/);
+  });
+
   it("tells the model to stop retrying a persistently rate-limited source", async () => {
     const wrap = wrapToolCall();
     const rateLimit = Object.assign(new Error("request rejected"), {

--- a/packages/runtime-langgraph/src/tool-error-middleware.ts
+++ b/packages/runtime-langgraph/src/tool-error-middleware.ts
@@ -10,6 +10,16 @@ const RATE_LIMIT_GUIDANCE =
   "partial results with a clear coverage disclaimer.";
 
 /**
+ * Deliberately does not blame the arguments: a tool fails just as often on
+ * credentials or configuration, and telling the model to fix arguments that were
+ * already correct sends it into identical retries.
+ */
+const FAILURE_GUIDANCE =
+  "If the error names something to fix — arguments, credentials, or configuration " +
+  "— apply it and try again. Otherwise stop calling this tool for this run and " +
+  "tell the user what failed and what would unblock it.";
+
+/**
  * In langchain@1.5.2/deepagents@1.12.1, inner wrappers turn tool failures into
  * `MiddlewareError`, which @langchain/langgraph@1.4.7 rethrows instead of handing
  * to the model. This outer wrapper preserves tool-result parity and self-recovery.
@@ -28,9 +38,7 @@ export function toolErrorRecoveryMiddleware() {
         const { id, name } = request.toolCall;
         const detail = toolErrorDetail(err);
         const guidance =
-          toolErrorCode(err) === "RATE_LIMIT"
-            ? RATE_LIMIT_GUIDANCE
-            : "Please fix the arguments and try again.";
+          toolErrorCode(err) === "RATE_LIMIT" ? RATE_LIMIT_GUIDANCE : FAILURE_GUIDANCE;
         return new ToolMessage({
           status: "error",
           content: `Error running tool "${name}": ${detail}\n${guidance}`,


### PR DESCRIPTION
Fixes #56.

`@langchain/mcp-adapters` merges every branch of an `anyOf`/`oneOf` into one schema before handing a tool to the model. For a filter that accepts either a leaf comparison or a compound group, the merged result matches neither branch: `operator` enumerates only the compound operators, `required` shrinks to the intersection, and a self-referencing `items` collapses to `{"type":"object"}`. The description survives and still documents the leaf form, so the model is handed a schema that contradicts its own documentation — and LangChain's pre-flight validation rejects the leaf call the server would have accepted.

There is no opt-out: the adapter's `dereferenceJsonSchema` and `simplifyJsonSchemaForLLM` are module-private and unconditional, and `LoadMcpToolsOptions` exposes no schema setting.

## Changes

**`plugin-sdk/src/mcp-schema.ts`** — `restoreNullableSchemaTypes` becomes `restoreFlattenedUnions`. It now mirrors the adapter's `$ref` inlining (including its bare-object stop for self-referencing definitions) and collapses `allOf` so it can find a union the adapter hid one level down, then re-emits it as `anyOf`. `sanitizeVariant` keeps the adapter's other simplifications — `if`/`then`/`else`, `not`, `unevaluatedProperties`, `$schema` — so a restored branch cannot reintroduce a construct a provider rejects.

**`plugin-sdk/src/plugin-host.ts`** — sets `verboseParsingErrors` on every MCP tool. Without it a rejected call reaches the model as a bare `Received tool input did not match expected schema`, so it can only guess; it retried identical arguments three times in the run that surfaced this.

**`runtime-langgraph/src/tool-error-middleware.ts`** — the unconditional `Please fix the arguments and try again.` now defers to the error text instead of asserting a cause. An authorization failure is not an argument problem, and telling the model otherwise sent it into retries that could not succeed.

## Verification

The risk here is trading a false rejection for a false acceptance, so this was checked at three levels.

**Unit** (12 tests) — both original nullable cases pass unchanged. New cases cover each real union shape encountered (leaf-or-compound filter, `string | string[]`, union nested in array items), the `allOf` + `$ref` indirection, the recursion bound, and adapter-stripped keys. Four assert through a real `DynamicStructuredTool`, exercising LangChain's actual validation rather than schema shape.

**Integration** — a new fixture MCP server advertising the recursive filter shape, driven through the real adapter. Asserts **both** branches invoke (leaf and compound), plus the scalar and array forms, and that a genuinely malformed call still fails and now names the offending constraint.

**Live**, against a real MCP fleet — 123 tool schemas across 5 servers: 14 regained a union, all 123 still compile, none lost `verboseParsingErrors`. Then a real model call with 83 tools bound: the provider accepted every restored schema, the model emitted the exact leaf condition that previously failed 8 times, and the tool returned successfully. A follow-up end-to-end run through the app produced **zero tool errors** where the same request previously produced 9, with leaf and compound filters both working and no retries.

The governing invariant: anything the flattened schema accepted but the source union rejects is something the server would have rejected anyway, just with a worse remote error — so no working call is lost.

`npm run typecheck`, `npm run lint`, and `npm test` (21/21 tasks) are green.