### PR TITLE
fix: make the Google provider usable end to end

### DIFF
--- a/apps/web/src/components/settings/ProvidersSettings.test.ts
+++ b/apps/web/src/components/settings/ProvidersSettings.test.ts
@@ -4,6 +4,7 @@ import type { ProviderAuthMethod } from "@pizza-bot/core";
 import {
   getProviderStatus,
   secretKeysWithStoredValue,
+  secretReferenceValidationError,
   unavailableLocalSecretValidationError,
 } from "./ProvidersSettings.js";
 
@@ -187,5 +188,44 @@ describe("unavailableLocalSecretValidationError", () => {
     expect(
       unavailableLocalSecretValidationError(method, {}, unavailable, false),
     ).toBeUndefined();
+  });
+});
+
+describe("secretReferenceValidationError", () => {
+  const method: ProviderAuthMethod = {
+    id: "api-key",
+    label: "API key",
+    fields: [
+      { key: "apiKey", label: "Google API key", type: "password", required: true },
+      { key: "platform", label: "Platform", type: "text", required: false },
+    ],
+  };
+
+  it("rejects a pasted credential before the server does", () => {
+    expect(
+      secretReferenceValidationError(method, { apiKey: "AQ.some-real-key" }, false),
+    ).toBe(
+      "Google API key must reference an environment variable, like ${MY_API_KEY} — not the value itself.",
+    );
+  });
+
+  it("accepts an environment reference", () => {
+    expect(
+      secretReferenceValidationError(method, { apiKey: "${GOOGLE_API_KEY}" }, false),
+    ).toBeUndefined();
+  });
+
+  it("leaves a blank field to the stored-secret path", () => {
+    expect(secretReferenceValidationError(method, { apiKey: "  " }, false)).toBeUndefined();
+  });
+
+  it("stays out of the way when the desktop store takes raw values", () => {
+    expect(
+      secretReferenceValidationError(method, { apiKey: "AQ.some-real-key" }, true),
+    ).toBeUndefined();
+  });
+
+  it("ignores non-secret fields", () => {
+    expect(secretReferenceValidationError(method, { platform: "auto" }, false)).toBeUndefined();
   });
 });

--- a/apps/web/src/components/settings/ProvidersSettings.tsx
+++ b/apps/web/src/components/settings/ProvidersSettings.tsx
@@ -13,6 +13,7 @@ import type {
   ProviderAuthField,
   ProviderAuthMethod,
 } from "@pizza-bot/core";
+import { isEnvReference } from "@pizza-bot/core";
 import { L } from "../../lexicon.js";
 import { groupModelsByProvider, providerLabel } from "../../model-options.js";
 import { useAppToast } from "../AppToast.js";
@@ -297,6 +298,12 @@ function ProviderRow({
         localSecretStore,
       );
       if (unavailableSecretError) throw new Error(unavailableSecretError);
+      const referenceError = secretReferenceValidationError(
+        method,
+        values,
+        localSecretStore,
+      );
+      if (referenceError) throw new Error(referenceError);
 
       const out: Record<string, string> = {};
       for (const field of method.fields) {
@@ -608,7 +615,7 @@ function FieldInput({
       ) : (
         <input
           className="field-input"
-          type={field.type === "password" ? "password" : "text"}
+          type={field.type === "password" && localSecretStore ? "password" : "text"}
           value={value}
           placeholder={
             field.type === "password"
@@ -618,7 +625,9 @@ function FieldInput({
                   : L.secretEnvUnavailablePlaceholder
                 : hasStored
                   ? L.secretStoredPlaceholder
-                  : field.default ?? ""
+                  : localSecretStore
+                    ? field.default ?? ""
+                    : L.secretRefPlaceholder
               : field.default ?? ""
           }
           onChange={(e) => onChange(e.target.value)}
@@ -630,7 +639,7 @@ function FieldInput({
             ? localSecretStore
               ? L.secretUnavailableHint
               : L.secretEnvUnavailableHint
-            : isDesktop()
+            : localSecretStore
               ? L.secretKeychainHint
               : L.secretRefHint}
         </span>
@@ -689,6 +698,25 @@ export function secretKeysWithStoredValue(
     }
   }
   return keys;
+}
+
+/**
+ * Without a desktop secret store the server accepts only an `${ENV_REF}`, so a
+ * pasted credential is rejected on save. Say so before it makes that round trip.
+ */
+export function secretReferenceValidationError(
+  method: ProviderAuthMethod | undefined,
+  values: Readonly<Record<string, string>>,
+  localSecretStore: boolean,
+): string | undefined {
+  if (localSecretStore) return undefined;
+  const literal = method?.fields.find((field) => {
+    const typed = values[field.key]?.trim();
+    return field.type === "password" && !!typed && !isEnvReference(typed);
+  });
+  return literal
+    ? `${literal.label} must reference an environment variable, like \${MY_API_KEY} — not the value itself.`
+    : undefined;
 }
 
 export function unavailableLocalSecretValidationError(

--- a/apps/web/src/lexicon.ts
+++ b/apps/web/src/lexicon.ts
@@ -54,6 +54,7 @@ export const L = {
   providerEnvNote: "This provider resolves its credentials from the ambient environment — no configuration needed.",
   secretRefHint: "Enter the name of an environment variable holding this secret, referenced as ${MY_VAR}. The value is never stored — only the reference.",
   secretKeychainHint: "Stored encrypted in your OS keychain by the desktop app. Only a generated reference is sent over HTTP or saved.",
+  secretRefPlaceholder: "${MY_API_KEY}",
   secretStoredPlaceholder: "•••••••• (stored — leave blank to keep)",
   secretUnavailablePlaceholder: "Enter this credential again",
   secretUnavailableHint: "The saved credential cannot be read by this app. Enter it again and save.",

--- a/packages/inference-providers/src/providers/google-schema-fix.test.ts
+++ b/packages/inference-providers/src/providers/google-schema-fix.test.ts
@@ -100,6 +100,49 @@ describe("Gemini tool schema compatibility", () => {
     });
   });
 
+  it("inlines the references Gemini has no field for", () => {
+    expect(
+      sanitizeGeminiSchema({
+        type: "object",
+        $defs: { Id: { type: "string", pattern: "^[a-z]+$" } },
+        properties: {
+          id: { $ref: "#/$defs/Id", description: "the id" },
+          ids: { type: "array", items: { $ref: "#/$defs/Id" } },
+        },
+      }),
+    ).toEqual({
+      type: "object",
+      properties: {
+        id: { type: "string", pattern: "^[a-z]+$", description: "the id" },
+        ids: { type: "array", items: { type: "string", pattern: "^[a-z]+$" } },
+      },
+    });
+  });
+
+  it("degrades a self-referencing definition to a bare object", () => {
+    expect(
+      sanitizeGeminiSchema({
+        type: "object",
+        $defs: { Node: { type: "object", properties: { child: { $ref: "#/$defs/Node" } } } },
+        properties: { root: { $ref: "#/$defs/Node" } },
+      }),
+    ).toEqual({
+      type: "object",
+      properties: {
+        root: { type: "object", properties: { child: { type: "object" } } },
+      },
+    });
+  });
+
+  it("drops a reference it cannot resolve rather than sending it", () => {
+    expect(
+      sanitizeGeminiSchema({
+        type: "object",
+        properties: { missing: { $ref: "#/$defs/Absent", description: "kept" } },
+      }),
+    ).toEqual({ type: "object", properties: { missing: { description: "kept" } } });
+  });
+
   it("sanitizes function declarations and leaves other Gemini tools untouched", () => {
     const tools = [
       { googleSearch: {} },

--- a/packages/inference-providers/src/providers/google-schema-fix.test.ts
+++ b/packages/inference-providers/src/providers/google-schema-fix.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  sanitizeGeminiSchema,
+  sanitizeGeminiTools,
+} from "./google-schema-fix.js";
+
+describe("Gemini tool schema compatibility", () => {
+  it("rewrites the exclusive bounds Gemini rejects as unknown fields", () => {
+    const sanitized = sanitizeGeminiSchema({
+      type: "object",
+      properties: {
+        max_count: {
+          anyOf: [
+            { type: "integer", exclusiveMinimum: 0 },
+            { type: "null" },
+          ],
+          description: "Optional cap on matches",
+        },
+        ratio: { type: "number", exclusiveMinimum: 0, exclusiveMaximum: 1 },
+      },
+    });
+
+    expect(sanitized).toEqual({
+      type: "object",
+      properties: {
+        max_count: {
+          anyOf: [{ type: "integer", minimum: 1 }, { type: "null" }],
+          description: "Optional cap on matches",
+        },
+        ratio: { type: "number", minimum: 0, maximum: 1 },
+      },
+    });
+  });
+
+  it("keeps the tighter bound when a schema states both forms", () => {
+    expect(
+      sanitizeGeminiSchema({ type: "number", minimum: 2, exclusiveMinimum: 5 }),
+    ).toEqual({ type: "number", minimum: 5 });
+    expect(
+      sanitizeGeminiSchema({ type: "number", exclusiveMaximum: 5, maximum: 9 }),
+    ).toEqual({ type: "number", maximum: 5 });
+  });
+
+  it("drops keywords and formats outside Gemini's OpenAPI subset", () => {
+    expect(
+      sanitizeGeminiSchema({
+        type: "object",
+        properties: {
+          id: { type: "string", format: "uuid", minLength: 1 },
+          when: { type: "string", format: "date-time" },
+          tags: {
+            type: "array",
+            items: { type: "string", pattern: "^a" },
+            uniqueItems: true,
+          },
+          count: { type: "integer", multipleOf: 2 },
+        },
+        required: ["id"],
+        additionalProperties: false,
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+      }),
+    ).toEqual({
+      type: "object",
+      properties: {
+        id: { type: "string", minLength: 1 },
+        when: { type: "string", format: "date-time" },
+        tags: { type: "array", items: { type: "string", pattern: "^a" } },
+        count: { type: "integer" },
+      },
+      required: ["id"],
+    });
+  });
+
+  it("translates const and oneOf into the enum and anyOf Gemini understands", () => {
+    expect(
+      sanitizeGeminiSchema({
+        oneOf: [
+          { type: "string", const: "leaf", multipleOf: 1 },
+          { type: "integer", enum: [1, 2] },
+        ],
+      }),
+    ).toEqual({
+      anyOf: [{ type: "string", enum: ["leaf"] }, { type: "integer" }],
+    });
+  });
+
+  it("merges allOf members into their parent", () => {
+    expect(
+      sanitizeGeminiSchema({
+        allOf: [
+          { type: "object", properties: { a: { type: "string" } } },
+          { description: "merged", required: ["a"] },
+        ],
+      }),
+    ).toEqual({
+      type: "object",
+      properties: { a: { type: "string" } },
+      description: "merged",
+      required: ["a"],
+    });
+  });
+
+  it("sanitizes function declarations and leaves other Gemini tools untouched", () => {
+    const tools = [
+      { googleSearch: {} },
+      {
+        functionDeclarations: [
+          {
+            name: "grep",
+            description: "Search files",
+            parameters: {
+              type: "object",
+              properties: {
+                max_count: { type: "integer", exclusiveMinimum: 0 },
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(sanitizeGeminiTools(tools)).toEqual([
+      { googleSearch: {} },
+      {
+        functionDeclarations: [
+          {
+            name: "grep",
+            description: "Search files",
+            parameters: {
+              type: "object",
+              properties: { max_count: { type: "integer", minimum: 1 } },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/inference-providers/src/providers/google-schema-fix.ts
+++ b/packages/inference-providers/src/providers/google-schema-fix.ts
@@ -1,0 +1,169 @@
+/**
+ * Gemini function declarations take a narrow OpenAPI subset, and its parser
+ * rejects the whole request on the first field it does not know. LangChain only
+ * strips `additionalProperties`, so anything else JSON Schema allows — a
+ * `z.number().positive()` becoming `exclusiveMinimum` — reaches the wire as
+ * `Unknown name "exclusiveMinimum" ... Cannot find field`.
+ */
+
+type JsonSchema = Record<string, unknown>;
+
+/** `Gemini.Schema`, plus the `$ref`/`$defs` pair the API resolves but LangChain's type omits. */
+const SUPPORTED_KEYS = new Set([
+  "$defs",
+  "$ref",
+  "anyOf",
+  "default",
+  "description",
+  "enum",
+  "example",
+  "format",
+  "items",
+  "maxItems",
+  "maxLength",
+  "maxProperties",
+  "maximum",
+  "minItems",
+  "minLength",
+  "minProperties",
+  "minimum",
+  "nullable",
+  "pattern",
+  "properties",
+  "propertyOrdering",
+  "required",
+  "title",
+  "type",
+]);
+
+/** The only `format` values Gemini acts on; it rejects the rest of JSON Schema's vocabulary. */
+const SUPPORTED_FORMATS: Record<string, ReadonlySet<string>> = {
+  string: new Set(["enum", "date-time"]),
+  number: new Set(["float", "double"]),
+  integer: new Set(["int32", "int64"]),
+};
+
+function isJsonSchema(value: unknown): value is JsonSchema {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Sanitize the parameter schemas of already-converted Gemini tools, leaving other tool kinds alone. */
+export function sanitizeGeminiTools<T>(tools: readonly T[]): T[] {
+  return tools.map((tool) => {
+    if (!isJsonSchema(tool) || !Array.isArray(tool.functionDeclarations)) return tool;
+    return {
+      ...tool,
+      functionDeclarations: tool.functionDeclarations.map((declaration) =>
+        isJsonSchema(declaration) && isJsonSchema(declaration.parameters)
+          ? { ...declaration, parameters: sanitizeGeminiSchema(declaration.parameters) }
+          : declaration,
+      ),
+    } as T;
+  });
+}
+
+export function sanitizeGeminiSchema(schema: JsonSchema): JsonSchema {
+  const merged = collapseAllOf(schema);
+  const sanitized: JsonSchema = {};
+
+  for (const [key, value] of Object.entries(merged)) {
+    switch (key) {
+      case "oneOf":
+        sanitized.anyOf = value;
+        break;
+      case "const":
+        // Gemini has no `const`; a single-value enum says the same thing.
+        if (typeof value === "string") sanitized.enum = [value];
+        break;
+      case "exclusiveMinimum":
+        if (typeof value === "number") {
+          sanitized.minimum = tightest(
+            sanitized.minimum,
+            exclusiveBound(value, merged.type, 1),
+            Math.max,
+          );
+        }
+        break;
+      case "exclusiveMaximum":
+        if (typeof value === "number") {
+          sanitized.maximum = tightest(
+            sanitized.maximum,
+            exclusiveBound(value, merged.type, -1),
+            Math.min,
+          );
+        }
+        break;
+      case "minimum":
+        sanitized.minimum = tightest(sanitized.minimum, value, Math.max);
+        break;
+      case "maximum":
+        sanitized.maximum = tightest(sanitized.maximum, value, Math.min);
+        break;
+      case "enum":
+        // The field is repeated string; anything else fails the parser outright.
+        if (Array.isArray(value) && value.every((entry) => typeof entry === "string")) {
+          sanitized.enum = value;
+        }
+        break;
+      case "format":
+        if (typeof value === "string" && supportedFormat(merged.type, value)) {
+          sanitized.format = value;
+        }
+        break;
+      case "properties":
+      case "$defs":
+        if (isJsonSchema(value)) sanitized[key] = sanitizeProperties(value);
+        break;
+      case "items":
+        if (isJsonSchema(value)) sanitized.items = sanitizeGeminiSchema(value);
+        break;
+      default:
+        if (SUPPORTED_KEYS.has(key)) sanitized[key] = value;
+    }
+  }
+
+  if (Array.isArray(sanitized.anyOf)) sanitized.anyOf = sanitizeVariants(sanitized.anyOf);
+  return sanitized;
+}
+
+function sanitizeProperties(properties: JsonSchema): JsonSchema {
+  return Object.fromEntries(
+    Object.entries(properties).map(([name, value]) => [
+      name,
+      isJsonSchema(value) ? sanitizeGeminiSchema(value) : value,
+    ]),
+  );
+}
+
+function sanitizeVariants(variants: unknown[]): unknown[] {
+  return variants.map((variant) =>
+    isJsonSchema(variant) ? sanitizeGeminiSchema(variant) : variant,
+  );
+}
+
+/** Gemini only has inclusive bounds, so an integer's exclusive bound moves by one. */
+function exclusiveBound(value: number, type: unknown, step: number): number {
+  return type === "integer" ? value + step : value;
+}
+
+function tightest(
+  current: unknown,
+  candidate: unknown,
+  choose: (left: number, right: number) => number,
+): unknown {
+  if (typeof candidate !== "number") return current;
+  return typeof current === "number" ? choose(current, candidate) : candidate;
+}
+
+function supportedFormat(type: unknown, format: string): boolean {
+  return typeof type === "string" && (SUPPORTED_FORMATS[type]?.has(format) ?? false);
+}
+
+/** Gemini has no `allOf`; merging members into the parent keeps their constraints. */
+function collapseAllOf(schema: JsonSchema): JsonSchema {
+  if (!Array.isArray(schema.allOf)) return schema;
+  const { allOf, ...base } = schema;
+  return allOf
+    .filter(isJsonSchema)
+    .reduce<JsonSchema>((merged, member) => ({ ...merged, ...collapseAllOf(member) }), base);
+}

--- a/packages/inference-providers/src/providers/google-schema-fix.ts
+++ b/packages/inference-providers/src/providers/google-schema-fix.ts
@@ -8,10 +8,8 @@
 
 type JsonSchema = Record<string, unknown>;
 
-/** `Gemini.Schema`, plus the `$ref`/`$defs` pair the API resolves but LangChain's type omits. */
+/** The fields `Gemini.Schema` names; the parser rejects the request on anything else. */
 const SUPPORTED_KEYS = new Set([
-  "$defs",
-  "$ref",
   "anyOf",
   "default",
   "description",
@@ -36,7 +34,10 @@ const SUPPORTED_KEYS = new Set([
   "type",
 ]);
 
-/** The only `format` values Gemini acts on; it rejects the rest of JSON Schema's vocabulary. */
+/**
+ * The only `format` values Gemini documents. AI Studio's parser tolerates others,
+ * but Vertex is stricter, so an unhonored hint is not worth a hard failure there.
+ */
 const SUPPORTED_FORMATS: Record<string, ReadonlySet<string>> = {
   string: new Set(["enum", "date-time"]),
   number: new Set(["float", "double"]),
@@ -63,6 +64,10 @@ export function sanitizeGeminiTools<T>(tools: readonly T[]): T[] {
 }
 
 export function sanitizeGeminiSchema(schema: JsonSchema): JsonSchema {
+  return sanitizeNode(dereference(schema));
+}
+
+function sanitizeNode(schema: JsonSchema): JsonSchema {
   const merged = collapseAllOf(schema);
   const sanitized: JsonSchema = {};
 
@@ -111,11 +116,10 @@ export function sanitizeGeminiSchema(schema: JsonSchema): JsonSchema {
         }
         break;
       case "properties":
-      case "$defs":
-        if (isJsonSchema(value)) sanitized[key] = sanitizeProperties(value);
+        if (isJsonSchema(value)) sanitized.properties = sanitizeProperties(value);
         break;
       case "items":
-        if (isJsonSchema(value)) sanitized.items = sanitizeGeminiSchema(value);
+        if (isJsonSchema(value)) sanitized.items = sanitizeNode(value);
         break;
       default:
         if (SUPPORTED_KEYS.has(key)) sanitized[key] = value;
@@ -130,14 +134,14 @@ function sanitizeProperties(properties: JsonSchema): JsonSchema {
   return Object.fromEntries(
     Object.entries(properties).map(([name, value]) => [
       name,
-      isJsonSchema(value) ? sanitizeGeminiSchema(value) : value,
+      isJsonSchema(value) ? sanitizeNode(value) : value,
     ]),
   );
 }
 
 function sanitizeVariants(variants: unknown[]): unknown[] {
   return variants.map((variant) =>
-    isJsonSchema(variant) ? sanitizeGeminiSchema(variant) : variant,
+    isJsonSchema(variant) ? sanitizeNode(variant) : variant,
   );
 }
 
@@ -166,4 +170,41 @@ function collapseAllOf(schema: JsonSchema): JsonSchema {
   return allOf
     .filter(isJsonSchema)
     .reduce<JsonSchema>((merged, member) => ({ ...merged, ...collapseAllOf(member) }), base);
+}
+
+/**
+ * Gemini has no `$ref`/`$defs`, so a reference has to be inlined or the field it
+ * describes is dropped entirely. Recursion stops at a bare object, the most a
+ * self-referencing definition can say in a schema without references.
+ */
+function dereference(schema: JsonSchema): JsonSchema {
+  const definitions = isJsonSchema(schema.$defs)
+    ? schema.$defs
+    : isJsonSchema(schema.definitions)
+      ? schema.definitions
+      : {};
+
+  function resolve(node: unknown, seen: ReadonlySet<string>): unknown {
+    if (Array.isArray(node)) return node.map((item) => resolve(item, seen));
+    if (!isJsonSchema(node)) return node;
+
+    const ref = typeof node.$ref === "string" ? node.$ref : undefined;
+    const name = ref?.match(/^#\/(?:\$defs|definitions)\/(.+)$/)?.[1];
+    const definition = name === undefined ? undefined : definitions[name];
+    if (ref !== undefined && isJsonSchema(definition)) {
+      if (seen.has(ref)) return { type: "object" };
+      const { $ref: _ref, ...siblings } = node;
+      const resolved = resolve(definition, new Set([...seen, ref])) as JsonSchema;
+      return { ...resolved, ...siblings };
+    }
+
+    const result: JsonSchema = {};
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "$defs" || key === "definitions") continue;
+      result[key] = resolve(value, seen);
+    }
+    return result;
+  }
+
+  return resolve(schema, new Set()) as JsonSchema;
 }

--- a/packages/inference-providers/src/providers/google.test.ts
+++ b/packages/inference-providers/src/providers/google.test.ts
@@ -173,6 +173,91 @@ describe("Google Gemini model discovery", () => {
     expect(model.profile.maxInputTokens).toBe(1_048_576);
   });
 
+  it("falls through to Vertex when Google AI lists models but cannot generate", async () => {
+    const listing = () => new Response(JSON.stringify({
+      models: [{ name: "models/gemini-flash-lite", supportedGenerationMethods: ["generateContent"] }],
+    }), { status: 200 });
+    const fetchFn = vi.fn().mockImplementation((input: URL | string, init?: RequestInit) =>
+      init?.method === "POST"
+        ? Promise.resolve(new Response(JSON.stringify({
+            error: { message: "Requests to this API are blocked." },
+          }), { status: 403 }))
+        : Promise.resolve(listing()));
+    const provider = new GoogleLangChainModelProvider({
+      apiKey: "test-key",
+      aiApiBase: "https://google-ai.example",
+      fetch: fetchFn,
+      modelsDevFetch: vi.fn().mockResolvedValue(new Response("", { status: 503 })),
+    });
+
+    await expect(provider.listModels()).resolves.toEqual([
+      expect.objectContaining({ id: "gemini-2.5-flash" }),
+    ]);
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      2,
+      "https://google-ai.example/v1beta/models/gemini-flash-lite:generateContent",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("keeps Google AI when the verification probe only hits a rate limit", async () => {
+    const fetchFn = vi.fn().mockImplementation((input: URL | string, init?: RequestInit) =>
+      init?.method === "POST"
+        ? Promise.resolve(new Response(JSON.stringify({
+            error: { message: "Resource has been exhausted (e.g. check quota)." },
+          }), { status: 429 }))
+        : Promise.resolve(new Response(JSON.stringify({
+            models: [{ name: "models/gemini-2.5-flash", supportedGenerationMethods: ["generateContent"] }],
+          }), { status: 200 })));
+    const provider = new GoogleLangChainModelProvider({
+      apiKey: "test-key",
+      aiApiBase: "https://google-ai.example",
+      fetch: fetchFn,
+    });
+
+    await expect(provider.listModels()).resolves.toEqual([
+      expect.objectContaining({ id: "gemini-2.5-flash", displayName: "gemini-2.5-flash (Google)" }),
+    ]);
+  });
+
+  it("takes an explicit Google AI choice at its word without probing", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      models: [{ name: "models/gemini-2.5-flash", supportedGenerationMethods: ["generateContent"] }],
+    }), { status: 200 }));
+    const provider = new GoogleLangChainModelProvider({
+      apiKey: "test-key",
+      aiApiBase: "https://google-ai.example",
+      platform: "gai",
+      fetch: fetchFn,
+    });
+
+    await provider.listModels();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the resolved platform on the auto-detect option once it is known", async () => {
+    const fetchFn = vi.fn().mockImplementation((input: URL | string, init?: RequestInit) =>
+      init?.method === "POST"
+        ? Promise.resolve(new Response("{}", { status: 200 }))
+        : Promise.resolve(new Response(JSON.stringify({
+            models: [{ name: "models/gemini-2.5-flash", supportedGenerationMethods: ["generateContent"] }],
+          }), { status: 200 })));
+    const provider = new GoogleLangChainModelProvider({
+      apiKey: "test-key",
+      aiApiBase: "https://google-ai.example",
+      fetch: fetchFn,
+    });
+    const optionsOf = () => provider.authSchema[0]?.fields
+      .find((field) => field.key === "platform")?.options;
+
+    expect(optionsOf()).toContainEqual({ value: "auto", label: "Auto-detect" });
+    await provider.listModels();
+    expect(optionsOf()).toContainEqual({
+      value: "auto",
+      label: "Auto-detect (using Google AI Studio)",
+    });
+  });
+
   it("exposes explicit platform choices with auto-detection as the default", () => {
     const provider = new GoogleLangChainModelProvider();
     const platform = provider.authSchema[0]?.fields.find(
@@ -188,6 +273,23 @@ describe("Google Gemini model discovery", () => {
         { value: "gcp", label: "Vertex AI Express" },
       ],
     });
+  });
+});
+
+describe("Google Gemini error translation", () => {
+  it("does not blame credentials when the API is blocked for the key", () => {
+    const blocked = Object.assign(
+      new Error("Requests to this API generativelanguage.googleapis.com are blocked."),
+      { status: 403 },
+    );
+
+    expect(translateGoogleError(blocked)).toBeUndefined();
+  });
+
+  it("still reports a plain authorization failure as expired credentials", () => {
+    const denied = Object.assign(new Error("Permission denied"), { status: 403 });
+
+    expect(translateGoogleError(denied)).toBe("AUTH_EXPIRED");
   });
 });
 

--- a/packages/inference-providers/src/providers/google.ts
+++ b/packages/inference-providers/src/providers/google.ts
@@ -14,6 +14,7 @@ import {
   convertGoogleChunksToEvents,
   prepareGoogleMessages,
 } from "./google-tool-call-fix.js";
+import { sanitizeGeminiTools } from "./google-schema-fix.js";
 import {
   enrichModelDescriptor,
   resolveModelsDevCatalog,
@@ -204,6 +205,12 @@ export class GoogleLangChainModelProvider implements ModelProvider {
     class ThoughtSignatureSafeChatGoogle extends ChatGoogle {
       override get profile() {
         return withContextWindow(super.profile, descriptor?.contextWindow);
+      }
+
+      override invocationParams(options: this["ParsedCallOptions"]) {
+        const params = super.invocationParams(options);
+        if (!params.tools) return params;
+        return { ...params, tools: sanitizeGeminiTools(params.tools) };
       }
 
       override async _generate(

--- a/packages/inference-providers/src/providers/google.ts
+++ b/packages/inference-providers/src/providers/google.ts
@@ -33,6 +33,11 @@ const FETCH_TIMEOUT_MS = 5_000;
 const MAX_CATALOG_PAGES = 10;
 const VERTEX_FALLBACK_MODEL = "gemini-2.5-flash";
 
+const PLATFORM_LABELS: Record<GooglePlatform, string> = {
+  gai: "Google AI Studio",
+  gcp: "Vertex AI Express",
+};
+
 type GooglePlatform = "gai" | "gcp";
 type GooglePlatformSetting = GooglePlatform | "auto";
 
@@ -109,7 +114,6 @@ const AUTH_SCHEMA: readonly ProviderAuthMethod[] = [
 
 export class GoogleLangChainModelProvider implements ModelProvider {
   readonly id = "google";
-  readonly authSchema = AUTH_SCHEMA;
   private readonly aiApiBase: string;
   private readonly fetchFn: typeof fetch;
   private readonly modelsDev: ModelsDevCatalogLoader;
@@ -119,6 +123,28 @@ export class GoogleLangChainModelProvider implements ModelProvider {
   private maxOutputTokens: number;
   private platform: GooglePlatformSetting;
   private detectedPlatform: GooglePlatform | undefined;
+  private aiStudioGeneration: Promise<boolean> | undefined;
+
+  /** Auto-detect reports which platform it settled on; the field is otherwise silent about it. */
+  get authSchema(): readonly ProviderAuthMethod[] {
+    const detected = this.detectedPlatform;
+    if (!detected || this.platform !== "auto") return AUTH_SCHEMA;
+    return AUTH_SCHEMA.map((method) => ({
+      ...method,
+      fields: method.fields.map((field) =>
+        field.key === "platform" && field.options
+          ? {
+              ...field,
+              options: field.options.map((option) =>
+                option.value === "auto"
+                  ? { ...option, label: `${option.label} (using ${PLATFORM_LABELS[detected]})` }
+                  : option,
+              ),
+            }
+          : field,
+      ),
+    }));
+  }
 
   constructor(opts: GoogleProviderOptions = {}) {
     this.aiApiBase = (
@@ -145,6 +171,7 @@ export class GoogleLangChainModelProvider implements ModelProvider {
       positiveInteger(cfg.values.maxOutputTokens) ?? DEFAULT_MAX_OUTPUT_TOKENS;
     this.platform = validPlatform(cfg.values.platform) ?? "auto";
     this.detectedPlatform = undefined;
+    this.aiStudioGeneration = undefined;
     if (!this.models) this.descriptors.clear();
   }
 
@@ -281,7 +308,11 @@ export class GoogleLangChainModelProvider implements ModelProvider {
   private async discover(apiKey: string): Promise<DiscoveryResult | undefined> {
     if (this.platform !== "gcp") {
       const models = await this.discoverAiModels(apiKey);
-      if (models) return { platform: "gai", models };
+      // An explicit choice is honored as given; only auto-detect needs the evidence.
+      if (models && this.platform === "gai") return { platform: "gai", models };
+      if (models && (await this.aiStudioCanGenerate(apiKey, models))) {
+        return { platform: "gai", models };
+      }
       if (this.platform === "gai") return undefined;
     }
 
@@ -326,6 +357,49 @@ export class GoogleLangChainModelProvider implements ModelProvider {
       if (!pageToken) break;
     }
     return uniqueModels(discovered);
+  }
+
+  /**
+   * Listing models proves only that the key is known to AI Studio, not that the
+   * platform will serve a generation — depleted prepay credits and a key blocked
+   * for the API both list fine and then fail every run.
+   */
+  private async aiStudioCanGenerate(
+    apiKey: string,
+    models: readonly ModelDescriptor[],
+  ): Promise<boolean> {
+    this.aiStudioGeneration ??= this.probeAiGeneration(apiKey, models);
+    return this.aiStudioGeneration;
+  }
+
+  private async probeAiGeneration(
+    apiKey: string,
+    models: readonly ModelDescriptor[],
+  ): Promise<boolean> {
+    const probe = probeModelId(models);
+    if (!probe) return true;
+    try {
+      const response = await this.fetchFn(
+        `${this.aiApiBase}/v1beta/models/${probe}:generateContent`,
+        {
+          method: "POST",
+          headers: { "x-goog-api-key": apiKey, "content-type": "application/json" },
+          body: JSON.stringify({
+            contents: [{ role: "user", parts: [{ text: "hi" }] }],
+            generationConfig: { maxOutputTokens: 1 },
+          }),
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        },
+      );
+      if (response.ok) return true;
+      const body = (await response.json().catch(() => ({}))) as {
+        error?: { message?: string };
+      };
+      return !platformRejected(response.status, body.error?.message ?? "");
+    } catch {
+      // A transient failure is no evidence about the platform; keep the listing's verdict.
+      return true;
+    }
   }
 
   private async discoverModelsDev(provider: string): Promise<ModelDescriptor[]> {
@@ -403,11 +477,13 @@ export function translateGoogleError(
   error: unknown,
 ): "AUTH_EXPIRED" | "RATE_LIMIT" | undefined {
   const status = statusOf(error);
-  if (status === 401 || status === 403) return "AUTH_EXPIRED";
-  if (status === 429) return "RATE_LIMIT";
   const message =
     error instanceof Error ? `${error.name} ${error.message}` : String(error);
   const normalized = message.toLowerCase();
+  // A key blocked for the API is valid; re-authenticating cannot enable the service.
+  if (serviceBlocked(normalized)) return undefined;
+  if (status === 401 || status === 403) return "AUTH_EXPIRED";
+  if (status === 429) return "RATE_LIMIT";
   if (
     normalized.includes("api key not valid") ||
     normalized.includes("api_key_invalid") ||
@@ -425,6 +501,32 @@ export function translateGoogleError(
     return "RATE_LIMIT";
   }
   return undefined;
+}
+
+/** Terminal for the platform, as opposed to a rate limit or a bad model id. */
+function platformRejected(status: number, message: string): boolean {
+  const normalized = message.toLowerCase();
+  if (status === 403) return true;
+  return status === 429 && /credit|billing|prepay/.test(normalized);
+}
+
+function serviceBlocked(normalized: string): boolean {
+  return (
+    normalized.includes("api_key_service_blocked") ||
+    normalized.includes("are blocked") ||
+    normalized.includes("has not been used in project") ||
+    normalized.includes("it is disabled")
+  );
+}
+
+/** The cheapest model available, so verifying a platform costs as little as possible. */
+function probeModelId(models: readonly ModelDescriptor[]): string | undefined {
+  const byPreference = ["flash-lite", "flash"];
+  for (const hint of byPreference) {
+    const match = models.find((model) => model.id.includes(hint));
+    if (match) return match.id;
+  }
+  return models[0]?.id;
 }
 
 function validPlatform(value: string | undefined): GooglePlatformSetting | undefined {


### PR DESCRIPTION
Fixes #62.

Picking a Gemini model failed every turn with `Invalid JSON payload received. Unknown name "exclusiveMinimum"`. Fixing that uncovered two more problems behind it, each of which would have been the next wall.

## 1. Tool schemas Gemini's parser rejects

`function_declarations[6].properties[3]` was DeepAgents' `grep` tool, whose `max_count: z.coerce.number().int().positive()` renders as `exclusiveMinimum: 0`. Gemini function declarations accept a narrow OpenAPI subset and the proto parser rejects the whole request on the first unknown field; `@langchain/google` strips only `additionalProperties` and `$schema`.

Converted declarations are now filtered to the fields `Gemini.Schema` names, translating what has an equivalent — exclusive bounds to inclusive (shifted by one for integers), `oneOf` to `anyOf`, `const` to a single-value `enum`, `allOf` merged into its parent, `$ref` inlined against `$defs`. Applied in an `invocationParams` override, so only the wire payload changes and the tools the graph executes are untouched.

Which keywords are actually rejected was established against the live API rather than from the SDK typings — the table is [in the issue](https://github.com/pizza-bot-app/pizza-bot/issues/62#issuecomment-5567826913). `$ref`/`$defs` are rejected despite appearing in some Google SDK surfaces, which is why they are inlined rather than passed through.

## 2. Auto-detect inferred the platform from the wrong evidence

`discover()` treated a successful `ListModels` as proof a platform would serve a run. It is not: a key whose AI Studio prepay credits are depleted lists its whole catalog and then fails every generation, while the same key works on Vertex express.

The AI Studio branch now verifies with a one-token generation on the cheapest listed model, falling through to Vertex only on a failure terminal for the platform — a 403, or a 429 naming credits. A rate limit or a transient error is no evidence, so the listing's verdict stands. An explicit platform choice is honored without probing, and the result is memoized until config changes.

The resolved platform is now reported on the auto-detect option's label (`Auto-detect (using Vertex AI Express)`), which the settings panel already re-reads from the live provider per request. Nothing previously surfaced which of the two platforms a key had landed on.

Also stops translating a blocked-service 403 to `AUTH_EXPIRED`: the key is valid, and re-authenticating cannot enable an API for a project.

## 3. Secret fields masked what could not be a secret

Without the desktop bridge, a secret field cannot hold a secret — the server persists only an `${ENV_REF}` and rejects anything else (`routes-providers.ts:143`). Masking the input hid an environment variable name and gave no clue what to type; the format only became apparent after a save returned 400.

The field now renders as text unless the desktop secret store is present, placeholds with the reference shape, and validates against the same `isEnvReference` the server enforces. This is the one renderer every provider's fields pass through, so all providers change together.

## Verification

Unit tests cover each change (17 new). Beyond those, the full production path was driven against live Gemini — `GoogleLangChainModelProvider` → `createPizzaBotAgent` → `streamProtocol` on `gemini-3.8-flash`, with platform detection left on auto:

```
auto-detect resolved to: Auto-detect (using Vertex AI Express)
- ai:   write_file({"content":"TODO: buy pizza\n","file_path":"/notes.txt"})
- tool: Successfully wrote to '/notes.txt'
- ai:   grep({"max_count":5,"pattern":"TODO","output_mode":"content","path":"/notes.txt"})
- tool: /notes.txt:   1: TODO: buy pizza
```

That is `grep` called with `max_count: 5` — the exact parameter whose schema was killing every request. The settings UI was also driven in a browser against a standalone server on a blank data root.

`npm test`, `npm run typecheck`, and `npm run lint` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C73RsH3nmrWmUWk78QnyAf