### PR TITLE
fix: unblock desktop packaging on Node 25 and describe the Linux packages

### DIFF
--- a/apps/desktop-shell/README.md
+++ b/apps/desktop-shell/README.md
@@ -74,14 +74,23 @@ cross-package hazard. Type-checking is still done by `tsc --noEmit` (the
 
 ## Packaging prerequisites (important)
 
-- **Use Node 24 to package** (`npm run make`/`package`). The repo requires Node
-  `>=24`; Node 26 is affected by an Electron Forge extraction hang
+- **Use Node 24 or 25 to package** (`npm run make`/`package`). The repo requires
+  Node `>=24`; Node 26 and newer are affected by an Electron Forge extraction hang
   ([electron/forge#4277]). On
   macOS the root
   `npm run desktop:package` / `desktop:make` scripts use Homebrew's `node@24`
   binary automatically. On other platforms they fail early unless the selected
   runtime is Node 24, so prefer those scripts. To invoke directly:
   `PATH="/opt/homebrew/opt/node@24/bin:$PATH" npm run make -w @pizza-bot/desktop-shell`.
+- **Linux packaging needs `dpkg` and `fakeroot` for deb, `rpmbuild` for rpm.**
+  Forge checks a maker's external binaries while resolving targets, so a host
+  missing one fails before packaging starts, naming the binary. Debian/Ubuntu:
+  `sudo apt install dpkg fakeroot rpm`. To build only what a host can produce,
+  pass the maker's **short** name — `npm run desktop:make -- --targets deb`.
+  Forge matches `--targets` against `maker.name` (`deb`, `rpm`, `zip`, `dmg`,
+  `squirrel`), and an unmatched value is treated as a fresh maker with default
+  options rather than an error, which silently discards this repo's `bin` and
+  `name` settings.
 - **No compiler toolchain required to package.** `better-sqlite3` (v13+) runs on
   N-API and bundles prebuilt binaries for every packaged platform, so packaging does
   not compile natives — it just stages the module into `dist-server/node_modules`.

--- a/apps/desktop-shell/forge.config.ts
+++ b/apps/desktop-shell/forge.config.ts
@@ -75,6 +75,10 @@ if (process.platform === "win32") {
 }
 
 const iconsDir = path.join(repoRoot, "assets", "icons");
+
+const LINUX_DESCRIPTION = "An inbox for asynchronous AI work";
+const LINUX_PRODUCT_DESCRIPTION =
+  "An inbox for asynchronous AI work, built on DeepAgents and LangGraph.";
 // Forge appends the per-platform extension, so these stay extensionless. macOS
 // uses its own variant, padded for the rounded-rect mask Apple applies.
 const appIcon = path.join(iconsDir, process.platform === "darwin" ? "icon-mac" : "icon");
@@ -149,11 +153,16 @@ const config: ForgeConfig = {
     }),
     new MakerZIP({}, ["darwin"]),
     new MakerDMG({ format: "ULFO", icon: path.join(iconsDir, "icon-mac.icns") }, ["darwin"]),
+    // Both Linux makers describe the app to a package manager. Left unset they
+    // inherit this workspace's package.json description, which documents the
+    // Electron main process for contributors rather than the app for users.
     new MakerRpm({
       options: {
         name: "pizza-bot-oss",
         bin: "pizza-bot-oss",
         icon: path.join(iconsDir, "icon.png"),
+        description: LINUX_DESCRIPTION,
+        productDescription: LINUX_PRODUCT_DESCRIPTION,
       },
     }),
     new MakerDeb({
@@ -161,6 +170,8 @@ const config: ForgeConfig = {
         name: "pizza-bot-oss",
         bin: "pizza-bot-oss",
         icon: path.join(iconsDir, "icon.png"),
+        description: LINUX_DESCRIPTION,
+        productDescription: LINUX_PRODUCT_DESCRIPTION,
       },
     }),
   ],

--- a/scripts/desktop-forge.mjs
+++ b/scripts/desktop-forge.mjs
@@ -25,9 +25,15 @@ if (nodeExecPath === brewNode) {
 const selectedVersion = spawnSync(nodeExecPath, ["--version"], {
   encoding: "utf8",
 }).stdout?.trim();
-if (!/^v24\./.test(selectedVersion ?? "")) {
+// Node 26 hangs extracting Electron inside Forge (electron/forge#4277); the
+// repo floor is 24. Verified: 24 and 25 both package cleanly.
+const selectedMajor = Number(/^v(\d+)\./.exec(selectedVersion ?? "")?.[1]);
+if (!(selectedMajor >= 24 && selectedMajor < 26)) {
   console.error(
-    `desktop packaging requires Node 24 (selected ${selectedVersion || nodeExecPath})`,
+    `desktop packaging requires Node 24 or 25 (selected ${selectedVersion || nodeExecPath}).`,
+  );
+  console.error(
+    "Node 26 and newer hang extracting Electron: https://github.com/electron/forge/issues/4277",
   );
   process.exit(1);
 }


### PR DESCRIPTION
Three rough edges found while building a `.deb` from `main` on Linux. Each one cost a full build cycle to diagnose.

## The Node guard was stricter than its own reason

`scripts/desktop-forge.mjs` tested `^v24.` and exited. The recorded reason for an upper bound is an Electron Forge extraction hang, and that hang starts at **Node 26** ([electron/forge#4277]) — so Node 25 was turned away for no stated reason, which is what a current `nvm` default now installs.

Widened to 24–25 only after measuring it: Node 25.9.0 packaged a complete 120M `.deb` at exit 0. Node 26+ stays blocked, and the error now names the hang and links the issue rather than stating a bare version.

## Linux packaging prerequisites were undocumented

`MakerDeb` requires `dpkg` and `fakeroot`; `MakerRpm` requires `rpmbuild`. Forge checks these while *resolving targets*, so a host missing one fails before packaging starts — on a stock Debian/Ubuntu box `rpmbuild` is absent and `npm run desktop:make` cannot complete at all.

Documented in the packaging prerequisites section, along with the way to build a subset. That deserves its own note, because the failure mode is quiet: Forge matches `--targets` against a maker's **short** name (`deb`, `rpm`, `zip`, `dmg`, `squirrel`), and `generateTargets` treats an unmatched value as a fresh maker with default options instead of erroring:

```js
forgeConfig.makers.find((maker) => maker.name === target) || { name: target }
```

So `--targets @electron-forge/maker-deb` silently discards this repo's `bin` and `name` options and fails later with `could not find the Electron app binary at "@pizza-bot/desktop-shell"` — an error that points at packaging when the cause is the flag.

## The Linux packages described the wrong thing

Neither Linux maker set a description, so both inherited `apps/desktop-shell/package.json` — a note aimed at contributors. A package manager showed:

> Electron main process: sidecar supervisor (port negotiation, health checks, restart, graceful shutdown) + window. Talks to the sidecar over HTTP/SSE only.

Now:

```
Description: An inbox for asynchronous AI work
 An inbox for asynchronous AI work, built on DeepAgents and LangGraph.
```

## Verification

Built the deb through the wrapper under Node 25 — the version the old guard rejected — and read the metadata back out of the resulting package. `npm test`, `npm run typecheck`, and `npm run lint` are green.

Not covered: the rpm maker, since this host has no `rpmbuild`. The description change applies to both makers by the same mechanism, but only the deb path was exercised.

[electron/forge#4277]: https://github.com/electron/forge/issues/4277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C73RsH3nmrWmUWk78QnyAf