### PR TITLE
feat: let a custom OpenAI endpoint go without an API key

### DIFF
--- a/apps/api-server/src/routes-providers.test.ts
+++ b/apps/api-server/src/routes-providers.test.ts
@@ -277,6 +277,28 @@ describe("provider routes", () => {
     expect(host.providerConfigs.getConfig("anthropic")?.values.apiKey).toBe("${ANTHROPIC_API_KEY}");
   });
 
+  it("saves a blank key for a custom OpenAI endpoint", async () => {
+    const res = await put("openai", {
+      method: "api-key",
+      values: { apiKey: "", baseUrl: "http://127.0.0.1:4599/v1" },
+    });
+
+    expect(res.status).toBe(200);
+    const openai = (await list()).find((p) => p.id === "openai")!;
+    expect(openai.config).toMatchObject({
+      method: "api-key",
+      values: { apiKey: { hasValue: false }, baseUrl: "http://127.0.0.1:4599/v1" },
+    });
+  });
+
+  it("still refuses a blank key without a custom endpoint", async () => {
+    const res = await put("openai", { method: "api-key", values: { apiKey: "", baseUrl: "" } });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toContain("Base URL");
+    expect(host.providerConfigs.getConfig("openai")).toBeUndefined();
+  });
+
   it("the unchanged sentinel keeps the stored secret", async () => {
     await put("anthropic", { method: "api-key", values: { apiKey: "${ANTHROPIC_API_KEY}" } });
     await put("anthropic", { method: "api-key", values: { apiKey: "__unchanged__" } });

--- a/apps/api-server/src/routes-providers.ts
+++ b/apps/api-server/src/routes-providers.ts
@@ -140,7 +140,9 @@ export function providerRoutes(host: AgentHost): Hono {
         }
         // The server is the trust boundary: a secret may only be persisted as an
         // `${ENV_REF}`, never a raw value, so plaintext keys never reach SQLite.
-        if (!isEnvReference(value)) {
+        // An empty value is the absence of a credential, not a pasted literal —
+        // an endpoint that authenticates nobody has nothing to reference.
+        if (value !== "" && !isEnvReference(value)) {
           return c.json(
             {
               error: `Secret field "${key}" must be an \${ENV_REF} reference, not a literal value.`,

--- a/packages/inference-providers/src/providers/openai.test.ts
+++ b/packages/inference-providers/src/providers/openai.test.ts
@@ -48,6 +48,7 @@ describe("OpenAI model discovery", () => {
   });
 
   it("reports missing credentials without calling discovery", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "");
     const fetchFn = vi.fn();
     const provider = new OpenAiLangChainModelProvider({ apiKey: "", fetch: fetchFn });
 
@@ -57,6 +58,36 @@ describe("OpenAI model discovery", () => {
       retryable: false,
     });
     expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("discovers models from a keyless endpoint without an authorization header", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+    const fetchFn = vi.fn(async () => Response.json({ data: [{ id: "local-chat-model" }] }));
+    const provider = new OpenAiLangChainModelProvider({
+      baseUrl: "http://localhost:8080/v1",
+      fetch: fetchFn,
+    });
+
+    await expect(provider.listModels()).resolves.toMatchObject([{ id: "local-chat-model" }]);
+    expect(fetchFn).toHaveBeenCalledWith(
+      "http://localhost:8080/v1/models",
+      expect.objectContaining({ headers: {} }),
+    );
+  });
+
+  it("rejects a blank API key unless a custom endpoint is configured", () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+    vi.stubEnv("OPENAI_BASE_URL", "");
+    const provider = new OpenAiLangChainModelProvider({ fetch: vi.fn() });
+
+    expect(() => provider.configure({ method: "api-key", values: { apiKey: "" } }))
+      .toThrow(/Base URL/);
+    expect(() =>
+      provider.configure({
+        method: "api-key",
+        values: { apiKey: "", baseUrl: "http://localhost:8080/v1" },
+      })
+    ).not.toThrow();
   });
 
   it("excludes known non-chat model families", () => {
@@ -146,6 +177,29 @@ describe("OpenAI model construction", () => {
     });
 
     await expect(provider.buildModel("private-deployment")).resolves.toBeDefined();
+  });
+
+  it("sends a placeholder bearer token to a keyless endpoint", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+    const authorizations: (string | null)[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      authorizations.push(new Headers(init?.headers).get("authorization"));
+      return openAiError("stop");
+    }));
+    const provider = new OpenAiLangChainModelProvider({
+      baseUrl: "http://localhost:8080/v1",
+      apiMode: "chat-completions",
+      models: [{
+        id: "local-chat-model",
+        provider: "openai",
+        displayName: "Local Chat Model",
+      }],
+    });
+
+    const model = await provider.buildModel("local-chat-model");
+    await expect(consume(model.stream("hello"))).rejects.toThrow();
+
+    expect(authorizations).toEqual(["Bearer none"]);
   });
 
   it("keeps catalog context windows model-specific", async () => {

--- a/packages/inference-providers/src/providers/openai.ts
+++ b/packages/inference-providers/src/providers/openai.ts
@@ -27,6 +27,9 @@ import {
 import { normalizeMultimodalToolResultsForOpenAiResponses } from "./openai-multimodal-fix.js";
 
 const DEFAULT_BASE_URL = "https://api.openai.com/v1";
+// The `openai` SDK refuses to construct a client without a credential, so an
+// OpenAI-compatible endpoint that authenticates nobody still needs a bearer token.
+const KEYLESS_API_KEY = "none";
 const FETCH_TIMEOUT_MS = 5_000;
 const DEFAULT_MAX_TOKENS = 8_192;
 
@@ -93,7 +96,7 @@ const AUTH_SCHEMA: readonly ProviderAuthMethod[] = [
     id: "api-key",
     label: "API key",
     fields: [
-      { key: "apiKey", label: "API key", type: "password", required: true },
+      { key: "apiKey", label: "API key", type: "password", required: false },
       { key: "baseUrl", label: "Base URL", type: "text", required: false },
       {
         key: "apiMode",
@@ -156,6 +159,13 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
     const key = cfg.values.apiKey?.trim();
     if (key) this.apiKey = key;
     this.baseUrl = cfg.values.baseUrl?.trim() || undefined;
+    // Only a custom endpoint may go keyless; api.openai.com without a key is a
+    // config that could never run, so reject it while the user can still fix it.
+    if (!this.resolvedApiKey() && !this.resolvedBaseUrl()) {
+      throw new Error(
+        "An API key is required unless you set a Base URL for an OpenAI-compatible endpoint.",
+      );
+    }
     this.maxTokens = positiveInteger(cfg.values.maxTokens) ?? DEFAULT_MAX_TOKENS;
     this.catalogProvider = cfg.values.catalogProvider?.trim() || undefined;
     this.apiMode = parseApiMode(cfg.values.apiMode);
@@ -164,14 +174,14 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
 
   async listModels(): Promise<ModelDescriptor[]> {
     if (this.models) return this.models;
-    const apiKey = this.apiKey ?? process.env.OPENAI_API_KEY;
-    if (!apiKey) throw missingCatalogCredentials("OpenAI");
-    const baseUrl =
-      (this.baseUrl ?? process.env.OPENAI_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+    const apiKey = this.resolvedApiKey();
+    const configuredBaseUrl = this.resolvedBaseUrl();
+    if (!apiKey && !configuredBaseUrl) throw missingCatalogCredentials("OpenAI");
+    const baseUrl = (configuredBaseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
 
     try {
       const response = await this.fetchFn(`${baseUrl}/models`, {
-        headers: { authorization: `Bearer ${apiKey}` },
+        headers: apiKey ? { authorization: `Bearer ${apiKey}` } : {},
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       });
       if (!response.ok) throw catalogHttpError("OpenAI", response.status);
@@ -201,6 +211,14 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
     }
   }
 
+  private resolvedApiKey(): string | undefined {
+    return this.apiKey || process.env.OPENAI_API_KEY || undefined;
+  }
+
+  private resolvedBaseUrl(): string | undefined {
+    return this.baseUrl || process.env.OPENAI_BASE_URL || undefined;
+  }
+
   async buildModel(modelId: string): Promise<BaseChatModel> {
     try {
       return await this.construct(modelId);
@@ -213,11 +231,11 @@ export class OpenAiLangChainModelProvider implements ModelProvider {
   }
 
   private async construct(modelId: string): Promise<BaseChatModel> {
-    const apiKey = this.apiKey ?? process.env.OPENAI_API_KEY;
+    const configuredBaseUrl = this.resolvedBaseUrl();
+    const apiKey = this.resolvedApiKey() ?? (configuredBaseUrl ? KEYLESS_API_KEY : undefined);
     if (!apiKey) {
       throw new OpenAiBuildError("No OpenAI API key configured (set OPENAI_API_KEY).", "AUTH_EXPIRED");
     }
-    const configuredBaseUrl = this.baseUrl ?? process.env.OPENAI_BASE_URL;
     if (!this.descriptors.has(modelId)) {
       await this.listModels().catch(() => []);
     }


### PR DESCRIPTION
# What and why

Closes #65.

Some OpenAI-compatible endpoints authenticate nobody, but the OpenAI provider
demanded a key. Saving a blank one returned
`400 Required field "API key" is missing.`, and outside the desktop shell a
secret field must be an `${ENV_REF}`, so there was no way to satisfy the
requirement short of exporting a junk environment variable.

Neither `@langchain/openai` nor the `openai` SDK requires a real key —
`chat_models/base.js` just falls back to `OPENAI_API_KEY` with no throw, and the
SDK only checks that *some* credential is present when constructing a client.
The requirement was entirely ours, in two places:

- `apiKey` is now `required: false` in the provider's `AUTH_SCHEMA`, and
  `configure()` rejects a blank key only when no Base URL is set — so
  `api.openai.com` still fails at save time, with a message naming the fix.
- An empty secret now clears the `${ENV_REF}` gate in `routes-providers.ts`. The
  absence of a credential is not a pasted literal, and an endpoint that
  authenticates nobody has nothing to reference. A non-empty literal is still
  refused.

Catalog discovery sends no `authorization` header when there is no key, and model
construction falls back to a placeholder bearer token, which the `openai` SDK
needs to build a client at all.

## Gates

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

## Verified how

- [x] Drove the change in a real app (web/desktop/CLI) - describe what you saw
- [ ] Tests only (explain why that is sufficient here)

Ran `apps/api-server` on a scratch `PIZZA_DATA_ROOT` against a local
OpenAI-compatible server that requires no credential, and drove
`PUT /providers/openai` by hand:

| Request | Before | After |
| --- | --- | --- |
| blank key + custom Base URL | `400 Required field "API key" is missing.` | `200`, config persisted with `apiKey: {hasValue: false}` |
| blank key, no Base URL | `400` (required field) | `400 An API key is required unless you set a Base URL for an OpenAI-compatible endpoint.` |
| literal key `sk-…` | `400` (env-ref) | `400` (env-ref), unchanged |

Then drove the provider itself against that endpoint: discovery hit `/v1/models`
with **no** `authorization` header, `buildModel` + `invoke` returned a completion,
and the endpoint logged the placeholder `Bearer none` on `/v1/chat/completions`.

The live run is what caught the second gate — the unit tests bypass the route and
passed while a blank key was still rejected with the `${ENV_REF}` error.

## Layering

- [x] `packages/core` gained no `node:*`, DOM, `deepagents`, or `@langchain/langgraph` import
- [x] Only `packages/runtime-langgraph` imports the graph engine
- [x] `apps/web` imports no runtime and no model binding
- [x] Docs touched by this change were updated (README / AGENTS.md / docs/ARCHITECTURE.md)

No doc changes needed: README already says OpenAI and Anthropic accept custom
base URLs, and this only removes a restriction on that path.
