### PR TITLE
fix: show the delegation indicator on the mobile Activity button

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -575,6 +575,9 @@ export function App() {
                                   onClick={() => setShowRail((v) => !v)}
                                 >
                                   <Activity size={16} />
+                                  {Object.keys(delegations).length > 0 && (
+                                    <span className="rail-toggle-indicator" aria-hidden="true" />
+                                  )}
                                 </button>
                               ) : undefined
                             }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -380,7 +380,10 @@ button.sidebar-folder-row:hover,
   border-color: color-mix(in oklch, var(--brand) 40%, var(--border));
 }
 .rail-toggle.active:hover { background: color-mix(in oklch, var(--brand) 20%, transparent); }
-.rail-toggle.icon-only { width: 30px; padding: 0; justify-content: center; gap: 0; }
+.rail-toggle.icon-only { width: 30px; padding: 0; justify-content: center; gap: 0; position: relative; }
+/* Fixed-width icon button: overlay the badge instead of letting it consume
+   flex space and shove the icon off-centre. */
+.rail-toggle.icon-only .rail-toggle-indicator { position: absolute; top: 3px; right: 3px; }
 .rail-toggle-indicator {
   width: 6px; height: 6px; flex: 0 0 auto; border-radius: 50%;
   background: var(--brand);


### PR DESCRIPTION
# What and why

Fixes #67.

Below the 768px breakpoint the Activity button never showed the delegation
indicator, so a running subagent produced no visible signal anywhere in the UI.

`App.tsx` renders two rail toggles. The desktop one appends
`rail-toggle-indicator` when `Object.keys(delegations).length > 0`; the
icon-only one passed as `headerActions` when `isMobile` did not. On mobile the
desktop button lives in the inbox `ModuleHeader`, which is off-screen in chat
view, so the only reachable toggle was the one without the badge.

The badge is positioned as an overlay for the icon-only variant.
`.rail-toggle.icon-only` is a fixed 30px centred flex box (`width: 30px;
padding: 0; gap: 0`), so adding the dot as a flex sibling would consume space
and push the icon off-centre.

Layout-branch only — no data, transport, or SDK change. The events reach the
client on every platform; the indicator that surfaces them was missing.

## Gates

- [x] `npm run build` — 11/11 tasks
- [x] `npm run typecheck` — 19/19 tasks
- [x] `npm run lint` — clean
- [x] `npm test` — 21/21 tasks (`@pizza-bot/web` 295/295)

## Verified how

- [x] Drove the change in a real app (web/desktop/CLI)
- [ ] Tests only

Built the container image, deployed it, and loaded the browser app on an iPhone
(iOS 18.7, home-screen PWA) against that backend. Sent a prompt that delegates
to a subagent: the indicator now appears on the Activity button while the
subagent runs, and opening the rail shows the subagent's transcript streaming
in live. Confirmed the same at a desktop browser narrowed below 768px, and
confirmed the desktop layout above 768px is unchanged.

Before the fix, the same build on the same backend showed no indicator on
either — which is how the breakpoint, rather than the platform, was identified.

## Layering

- [x] `packages/core` gained no `node:*`, DOM, `deepagents`, or `@langchain/langgraph` import
- [x] Only `packages/runtime-langgraph` imports the graph engine
