### PR TITLE
docs: point container users at building the image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,10 @@ order:
    maintainer to inspect and publish.
 3. the [`backend-image`](.github/actions/backend-image/action.yml) action again,
    then a push of `ghcr.io/pizza-bot-app/pizza-bot` as `latest`, `1.1.0`, `1.1`,
-   and `sha-<sha>`.
+   and `sha-<sha>`. That package is not currently available publicly, so it is not
+   pullable without credentials;
+   [STANDALONE_BACKEND.md](docs/STANDALONE_BACKEND.md#registry-images) points users
+   at building the image instead.
 
 The registry push is last because it is the one step that cannot be undone:
 nothing reaches GHCR until signing has succeeded, its reviewer has approved, and

--- a/docs/STANDALONE_BACKEND.md
+++ b/docs/STANDALONE_BACKEND.md
@@ -349,31 +349,41 @@ up first. Automations stored there run as soon as the server starts.
 
 [`docker-compose.yml`](../docker-compose.yml) runs the same image with a named
 data volume and a loopback-only published port, reading provider credentials
-from an optional `.env` beside it:
+from an optional `.env` beside it. Pass `--build` so Compose builds from this
+checkout instead of resolving the `image:` reference from a registry:
 
 ```bash
 PIZZA_API_TOKEN="$(openssl rand -hex 32)" \
 PIZZA_ALLOWED_ORIGINS=https://pizza.example.com \
-docker compose up --detach
+docker compose up --detach --build
 ```
 
-### Published images
+Rebuild after pulling with the same `--build`; without it Compose reuses the
+image it built earlier.
 
-The [`backend-image`](../.github/actions/backend-image/action.yml) action builds
-the `runtime` target for
-`linux/amd64` and smokes it with
-[`smoke-container.sh`](../scripts/smoke-container.sh). CI runs it on every pull
-request without pushing; a `v*` tag release runs it again and pushes to
-`ghcr.io/<owner>/<repo>` as `latest`, the release version, `<major>.<minor>`, and
-`sha-<commit>`.
+### Registry images
 
-Only a release publishes, so `latest` tracks releases rather than the tip of
-`main`. To run unreleased code, build the image from a checkout. Note that tags
-pushed before this policy took effect came from `main`, so `latest` points at an
-unreleased build until the first `v*` release moves it.
+**Build the image yourself — the published one is not available.** A release
+pushes `ghcr.io/pizza-bot-app/pizza-bot`, but that package is not currently
+available publicly, so pulling it anonymously fails with `403`. Everything
+needed to build it is in this repository; [Docker](#docker) above is the supported
+path, and it needs no registry at all.
 
-The package inherits the repository's visibility, so a private repository needs
-registry credentials wherever the image is pulled:
+A container registry is not required to deploy. Build once, then either run the
+image on that host or push it to a registry you control:
+
+```bash
+docker build -t registry.example.com/pizza-bot:1.0.0 .
+docker push registry.example.com/pizza-bot:1.0.0
+```
+
+Tag it with the release version you built from — `git describe --tags` — so a
+deployed container can be traced back to a commit.
+
+If you do have access to the published package, a release pushes `latest`, the
+release version, `<major>.<minor>`, and `sha-<commit>`; only a release publishes,
+so `latest` tracks releases rather than the tip of `main`. Pulling it needs
+credentials wherever the image is used:
 
 ```bash
 kubectl create secret docker-registry ghcr \
@@ -385,7 +395,8 @@ kubectl create secret docker-registry ghcr \
 
 ### Kubernetes
 
-Beyond the image reference and its pull secret, a deployment needs:
+Beyond the image reference — and a pull secret, if it comes from a registry that
+needs one — a deployment needs:
 
 - `PIZZA_HOST=0.0.0.0`, so the listener accepts cluster traffic. That binding
   requires `PIZZA_API_TOKEN` of at least 32 characters and


### PR DESCRIPTION
The published container package is private pending review, so an anonymous `docker pull` returns `403`. Everything needed to build the image is already in this repository — this makes the docs say so.

Docs only. Nothing publishes on a merge to `main` (releases are `v*`-tag driven), so this cannot produce a release or touch the registry.

## Changes

**`docs/STANDALONE_BACKEND.md`**

- *Published images* → *Registry images*, leading with "build the image yourself" and pointing at the existing [Docker](docs/STANDALONE_BACKEND.md#docker) section, which needs no registry at all.
- Removed the claim that "the package inherits the repository's visibility" — the repo is public and the package is not, so that was simply wrong.
- Added pushing to a registry you control, since a registry isn't required to deploy but is useful if you have one.
- Kept the pull-secret recipe, now framed as "if you do have access".
- Compose gains `--build`, and Kubernetes no longer implies a pull secret is always needed.

**`CONTRIBUTING.md`** — the release step still pushes those tags, so it now notes the package is private and links to the guidance above.

## Verified

- Every anchor and relative link in the touched files resolves.
- `compose build` from a clean checkout builds and tags the image as `ghcr.io/pizza-bot-app/pizza-bot:latest`, so the local build satisfies the `image:` reference and no pull happens.
- Compose needs `PIZZA_API_TOKEN` set even to build (the file marks it required), which the documented command already does.

One limitation worth noting: I could not exercise `docker compose` itself here, only `finch compose`, because finch runs nerdctl in a VM that doesn't receive host environment variables — so the `.env` path was used to verify. The `build:` context and target are the same ones CI builds on every pull request.