### PR TITLE
fix: reject unrecognized protocol commands instead of answering 204

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,9 +148,10 @@ when done.
 When driving the protocol endpoints by hand, two contracts trip people up:
 
 - `POST /threads/:id/commands` expects `{id, method, params}` (`run.start`,
-  `input.respond`, …). An unrecognized method returns `418` with an
-  `unsupported_method` error envelope; only a `run.stop` with nothing to stop
-  returns an empty `204`.
+  `input.respond`, …). A body that is not a JSON object returns `400
+  invalid_argument`; an unrecognized method returns `422 unknown_command`. The
+  only empty `204` is `run.stop`'s acknowledgement, whether it stopped a run or
+  found none.
 - `POST /threads/:id/stream/events` filters by `channels`, and an empty/absent
   array *silently* matches no frames (`frameMatchesFilter`), which looks like a
   broken server. Name them explicitly:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,13 +145,15 @@ against live Bedrock and inspects the emitted `ProtocolEvent` frames (needs
 launch the app per `docs/RUNNING.md` and drive it. Delete throwaway probe scripts
 when done.
 
-When driving the protocol endpoints by hand, two contracts fail *silently* rather
-than erroring — both look like a broken server:
+When driving the protocol endpoints by hand, two contracts trip people up:
 
 - `POST /threads/:id/commands` expects `{id, method, params}` (`run.start`,
-  `input.respond`, …). An unrecognized body returns `204`, so nothing runs.
+  `input.respond`, …). An unrecognized method returns `418` with an
+  `unsupported_method` error envelope; only a `run.stop` with nothing to stop
+  returns an empty `204`.
 - `POST /threads/:id/stream/events` filters by `channels`, and an empty/absent
-  array matches no frames (`frameMatchesFilter`). Name them explicitly:
+  array *silently* matches no frames (`frameMatchesFilter`), which looks like a
+  broken server. Name them explicitly:
   `values`, `messages`, `updates`, `lifecycle`, `tools`, `tasks`, `input`, `custom`.
 
 `apps/api-server` needs `PIZZA_ALLOWED_ORIGINS` set to the web origin when Vite

--- a/apps/api-server/src/protocol-commands.ts
+++ b/apps/api-server/src/protocol-commands.ts
@@ -15,7 +15,8 @@ interface StateReader {
 export type ProtocolCommandOutcome =
   | { kind: "success"; id: number; result: Record<string, unknown> }
   | { kind: "no_content" }
-  | { kind: "cancellation_pending"; id: number };
+  | { kind: "cancellation_pending"; id: number }
+  | { kind: "unsupported"; method: string };
 
 export class ProtocolCommandError extends Error {
   constructor(
@@ -68,7 +69,7 @@ export async function dispatchProtocolCommand(opts: {
       };
     }
     default:
-      return { kind: "no_content" };
+      return { kind: "unsupported", method: String(command.method) };
   }
 }
 

--- a/apps/api-server/src/protocol-commands.ts
+++ b/apps/api-server/src/protocol-commands.ts
@@ -16,7 +16,7 @@ export type ProtocolCommandOutcome =
   | { kind: "success"; id: number; result: Record<string, unknown> }
   | { kind: "no_content" }
   | { kind: "cancellation_pending"; id: number }
-  | { kind: "unsupported"; method: string };
+  | { kind: "unknown_command"; method: string };
 
 export class ProtocolCommandError extends Error {
   constructor(
@@ -69,7 +69,7 @@ export async function dispatchProtocolCommand(opts: {
       };
     }
     default:
-      return { kind: "unsupported", method: String(command.method) };
+      return { kind: "unknown_command", method: String(command.method) };
   }
 }
 

--- a/apps/api-server/src/routes-protocol.ts
+++ b/apps/api-server/src/routes-protocol.ts
@@ -19,7 +19,14 @@ export function protocolRoutes(host: AgentHost): Hono {
     if (!runs) return c.json({ type: "error", id: null, error: "not_supported", message: "protocol seam disabled" }, 501);
 
     const threadId = c.req.param("thread_id");
-    const cmd = (await c.req.json().catch(() => ({}))) as ProtocolCommand;
+    const body: unknown = await c.req.json().catch(() => undefined);
+    if (body === null || typeof body !== "object" || Array.isArray(body)) {
+      return c.json(
+        { type: "error", id: null, error: "invalid_argument", message: "command body must be a JSON object" },
+        400,
+      );
+    }
+    const cmd = body as ProtocolCommand;
     try {
       const outcome = await dispatchProtocolCommand({
         runs,
@@ -50,20 +57,21 @@ export function protocolRoutes(host: AgentHost): Hono {
           409,
         );
       }
-      if (outcome.kind === "unsupported") {
+      if (outcome.kind === "unknown_command") {
         // The SDK reads an empty 2xx as "applied", so an unknown method must fail
-        // loudly; 418 (RFC 2324) because this server will not brew that.
+        // loudly. 422 is on the SDK caller's no-retry list; 418 and 501 are not.
         return c.json(
           {
             type: "error",
             id: cmd.id ?? null,
-            error: "unsupported_method",
-            message: `unsupported command method ${JSON.stringify(outcome.method)}`,
+            error: "unknown_command",
+            message: `unknown command method ${JSON.stringify(outcome.method)}`,
           },
-          418,
+          422,
         );
       }
-      // The SDK treats an empty 204 as applied for fire-and-forget commands.
+      // run.stop acknowledgement (stopped, or nothing to stop): the SDK treats
+      // an empty 204 as applied.
       return c.body(null, 204);
     } catch (error) {
       if (error instanceof ProtocolCommandError) {

--- a/apps/api-server/src/routes-protocol.ts
+++ b/apps/api-server/src/routes-protocol.ts
@@ -50,6 +50,19 @@ export function protocolRoutes(host: AgentHost): Hono {
           409,
         );
       }
+      if (outcome.kind === "unsupported") {
+        // The SDK reads an empty 2xx as "applied", so an unknown method must fail
+        // loudly; 418 (RFC 2324) because this server will not brew that.
+        return c.json(
+          {
+            type: "error",
+            id: cmd.id ?? null,
+            error: "unsupported_method",
+            message: `unsupported command method ${JSON.stringify(outcome.method)}`,
+          },
+          418,
+        );
+      }
       // The SDK treats an empty 204 as applied for fire-and-forget commands.
       return c.body(null, 204);
     } catch (error) {

--- a/apps/api-server/src/routes.test.ts
+++ b/apps/api-server/src/routes.test.ts
@@ -461,6 +461,46 @@ describe("api-server: checkpoint-shaped state surface", () => {
     expect(clearThreadAwaitingAction).toHaveBeenCalledWith("t1");
   });
 
+  it("refuses an unrecognized command method with 418 and an error envelope", async () => {
+    const starts: Array<{ threadId: string }> = [];
+    const app = buildApp(fakeHost("ready", undefined, starts));
+    const res = await app.request("/threads/t1/commands", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: 7, method: "pizza.order", params: { toppings: ["pineapple"] } }),
+    });
+
+    expect(res.status).toBe(418);
+    expect(await res.json()).toEqual({
+      type: "error",
+      id: 7,
+      error: "unsupported_method",
+      message: 'unsupported command method "pizza.order"',
+    });
+    expect(starts).toEqual([]);
+  });
+
+  it("refuses a body that is not a command at all with 418", async () => {
+    const res = await buildApp(fakeHost()).request("/threads/t1/commands", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: "hello" }),
+    });
+
+    expect(res.status).toBe(418);
+    expect(await res.json()).toMatchObject({ type: "error", id: null, error: "unsupported_method" });
+  });
+
+  it("keeps the empty 204 for a run.stop with nothing to stop", async () => {
+    const res = await buildApp(fakeHost()).request("/threads/t1/commands", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: 8, method: "run.stop", params: {} }),
+    });
+
+    expect(res.status).toBe(204);
+  });
+
   it("GET /threads/:id/history returns the checkpoint list (newest-first)", async () => {
     const res = await buildApp(fakeHost()).request("/threads/t1/history");
     const list = (await res.json()) as Array<{ thread_id: string; checkpoint_id: string }>;

--- a/apps/api-server/src/routes.test.ts
+++ b/apps/api-server/src/routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { delimiter as pathDelimiter } from "node:path";
 import { ToolMessage } from "@langchain/core/messages";
+import { Client } from "@langchain/langgraph-sdk";
 import { PROTOCOL_VERSION } from "@pizza-bot/core";
 import {
   buildApp,
@@ -461,7 +462,7 @@ describe("api-server: checkpoint-shaped state surface", () => {
     expect(clearThreadAwaitingAction).toHaveBeenCalledWith("t1");
   });
 
-  it("refuses an unrecognized command method with 418 and an error envelope", async () => {
+  it("refuses an unrecognized command method with 422 and an unknown_command envelope", async () => {
     const starts: Array<{ threadId: string }> = [];
     const app = buildApp(fakeHost("ready", undefined, starts));
     const res = await app.request("/threads/t1/commands", {
@@ -470,25 +471,41 @@ describe("api-server: checkpoint-shaped state surface", () => {
       body: JSON.stringify({ id: 7, method: "pizza.order", params: { toppings: ["pineapple"] } }),
     });
 
-    expect(res.status).toBe(418);
+    expect(res.status).toBe(422);
     expect(await res.json()).toEqual({
       type: "error",
       id: 7,
-      error: "unsupported_method",
-      message: 'unsupported command method "pizza.order"',
+      error: "unknown_command",
+      message: 'unknown command method "pizza.order"',
     });
     expect(starts).toEqual([]);
   });
 
-  it("refuses a body that is not a command at all with 418", async () => {
+  it("refuses an object body with no method as unknown_command", async () => {
     const res = await buildApp(fakeHost()).request("/threads/t1/commands", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ input: "hello" }),
     });
 
-    expect(res.status).toBe(418);
-    expect(await res.json()).toMatchObject({ type: "error", id: null, error: "unsupported_method" });
+    expect(res.status).toBe(422);
+    expect(await res.json()).toMatchObject({ type: "error", id: null, error: "unknown_command" });
+  });
+
+  it.each([
+    ["JSON null", "null"],
+    ["a JSON array", "[]"],
+    ["a JSON string", '"run.start"'],
+    ["unparseable text", "{not json"],
+  ])("rejects %s as invalid_argument instead of crashing", async (_label, body) => {
+    const res = await buildApp(fakeHost()).request("/threads/t1/commands", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ type: "error", id: null, error: "invalid_argument" });
   });
 
   it("keeps the empty 204 for a run.stop with nothing to stop", async () => {
@@ -499,6 +516,25 @@ describe("api-server: checkpoint-shaped state surface", () => {
     });
 
     expect(res.status).toBe(204);
+  });
+
+  it("fails an unknown command in one attempt through the SDK's default retrying transport", async () => {
+    const app = buildApp(fakeHost());
+    const fetchSpy = vi.fn(async (input: string | URL, init?: RequestInit) =>
+      app.request(String(input).replace(/^https?:\/\/[^/]+/, ""), init),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+    try {
+      const client = new Client({ apiUrl: "http://pizza.test" });
+      const thread = client.threads.stream("t1", { assistantId: "pizza-bot" });
+
+      await expect(thread.state.fork({ checkpoint_id: "chk1" })).rejects.toThrow(/422/);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    const commandCalls = fetchSpy.mock.calls.filter(([url]) => String(url).endsWith("/threads/t1/commands"));
+    expect(commandCalls).toHaveLength(1);
   });
 
   it("GET /threads/:id/history returns the checkpoint list (newest-first)", async () => {

--- a/apps/api-server/src/test-utils/in-process-transport.ts
+++ b/apps/api-server/src/test-utils/in-process-transport.ts
@@ -60,6 +60,9 @@ export class InProcessTransport {
     if (outcome.kind === "cancellation_pending") {
       throw new Error("run did not stop before the cancellation deadline");
     }
+    if (outcome.kind === "unsupported") {
+      throw new Error(`unsupported command method ${JSON.stringify(outcome.method)}`);
+    }
   }
 
   openEventStream(params: SubscribeParams): EventStreamHandle {

--- a/apps/api-server/src/test-utils/in-process-transport.ts
+++ b/apps/api-server/src/test-utils/in-process-transport.ts
@@ -60,8 +60,8 @@ export class InProcessTransport {
     if (outcome.kind === "cancellation_pending") {
       throw new Error("run did not stop before the cancellation deadline");
     }
-    if (outcome.kind === "unsupported") {
-      throw new Error(`unsupported command method ${JSON.stringify(outcome.method)}`);
+    if (outcome.kind === "unknown_command") {
+      throw new Error(`unknown command method ${JSON.stringify(outcome.method)}`);
     }
   }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -346,8 +346,8 @@ cap, so a future provider adapter declares its own without touching the store.
   a success envelope with `result.run_id` synchronously (or the SDK deadlocks
   waiting to open its SSE); `input.respond` resumes a HITL interrupt; `run.stop`
   cancels; `state.get` returns checkpointed state. Any other method is refused
-  with `418` and an `unsupported_method` error envelope, because the SDK reads
-  an empty 2xx as "applied".
+  with `422 unknown_command` (a status on the SDK caller's no-retry list),
+  because the SDK reads an empty 2xx as "applied" and retries most non-2xx.
 - `POST /threads/:id/runs/:run_id/cancel` — the REST cancellation route the SDK's
   `stop()` calls in preference to the `run.stop` command. Cancellation is matched
   on `runId` so a late abort cannot kill a replacement run on the same thread.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -345,7 +345,9 @@ cap, so a future provider adapter declares its own without touching the store.
 - `POST /threads/:id/commands` — a `ProtocolCommand` (JSON). `run.start` returns
   a success envelope with `result.run_id` synchronously (or the SDK deadlocks
   waiting to open its SSE); `input.respond` resumes a HITL interrupt; `run.stop`
-  cancels; `state.get` returns checkpointed state.
+  cancels; `state.get` returns checkpointed state. Any other method is refused
+  with `418` and an `unsupported_method` error envelope, because the SDK reads
+  an empty 2xx as "applied".
 - `POST /threads/:id/runs/:run_id/cancel` — the REST cancellation route the SDK's
   `stop()` calls in preference to the `run.stop` command. Cancellation is matched
   on `runId` so a late abort cannot kill a replacement run on the same thread.


### PR DESCRIPTION
# What and why

`POST /threads/:id/commands` answered an unrecognized command method with an empty `204`. The `@langchain/langgraph-sdk` HTTP transport treats any empty `2xx` as "applied" (`http.js` `send()` returns on `202`/`204` without reading a body), so a typo'd method or a body that is not a command at all looked like a successful fire-and-forget while nothing ran. AGENTS.md documented this as one of the two ways the endpoint "fails silently and looks like a broken server".

The endpoint now answers with the protocol's own error vocabulary:

| Body | Before | After |
| --- | --- | --- |
| JSON object with an unrecognized `method` | `204` | `422` `unknown_command` |
| JSON object with no `method` | `204` | `422` `unknown_command` |
| `null`, array, string, or unparseable body | `500` (TypeError in `assertThreadAuthority`) | `400` `invalid_argument` |
| `run.stop` (stopped, or nothing to stop) | `204` | `204` (unchanged) |

```json
{ "type": "error", "id": 7, "error": "unknown_command", "message": "unknown command method \"pizza.order\"" }
```

Why 422 and not 400: 400 is already the envelope for a *recognized* command with bad params (`ProtocolCommandError`, e.g. `thread_id_mismatch`), and now also for a body that is not an object. Why 422 and not 418 or 501: the SDK's `AsyncCaller` retries every status outside its no-retry list (`400–409, 422`), with four retries and jittered backoff. A 418 turned an immediate failure into five attempts over roughly twenty seconds through the default `client.threads.stream()` transport, which is the opposite of the fail-fast goal. 422 stays on the no-retry list and keeps the distinction from 400. `unknown_command` and `invalid_argument` are members of `@langchain/protocol`'s closed `ErrorCode` union.

Changes:

- `protocol-commands.ts`: the `default` branch returns a new `unknown_command` outcome instead of `no_content`.
- `routes-protocol.ts`: rejects non-object bodies with `400 invalid_argument` before dispatch; maps `unknown_command` to `422` + error envelope; `no_content` keeps the `204`.
- `test-utils/in-process-transport.ts`: `unknown_command` throws, mirroring the HTTP path.
- Tests: the `422` envelope, an object with no method, four non-object bodies, the preserved `204` for `run.stop`, and one that drives the real Hono app through the SDK's default retrying transport via `state.fork()` and asserts exactly one request hits the commands endpoint.
- AGENTS.md and `docs/ARCHITECTURE.md` describe the new contract, including that `run.stop` returns `204` whether or not it found a run.

Not done here: annotating the envelope as `@langchain/protocol`'s `ErrorResponse`. The api-server only depends on `@langchain/protocol` transitively through the SDK, and the SDK does not re-export the type, so that needs either a direct dependency or a local mirror of the union. That would also cover the pre-existing `cancellation_pending` code, which is not in the union either. Follow-up.

No client in this repo sends anything but `run.start`, `input.respond`, `run.stop`, and `state.get`. The SDK's `input.inject()`, `state.fork()`, `state.listCheckpoints()`, and `agent.getTree()` send methods this server never implemented; those now fail in one round trip instead of pretending to succeed.

## Gates

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

## Verified how

- [x] Drove the change in a real app: started the api-server standalone (`PORT=8091 PIZZA_DATA_ROOT=<scratch> npx tsx apps/api-server/src/index.ts`) and drove the endpoint with curl. `{"method":"pizza.order"}` and `{"input":"hello"}` returned `HTTP/1.1 422 Unprocessable Entity` with the `unknown_command` envelope; a bare `null` body returned `HTTP/1.1 400 Bad Request` with `invalid_argument`; `{"method":"run.stop"}` with no run returned `HTTP/1.1 204 No Content`. Scratch data root deleted afterwards.
- [x] The retry behavior is covered by a test through the SDK's real `Client` and `AsyncCaller` rather than `app.request()` or curl. With the earlier 418 in place that test timed out at vitest's five-second limit; with 422 it completes in one request.
- [ ] Tests only

## Layering

- [x] `packages/core` gained no `node:*`, DOM, `deepagents`, or `@langchain/langgraph` import
- [x] Only `packages/runtime-langgraph` imports the graph engine
- [x] `apps/web` imports no runtime and no model binding
- [x] Docs touched by this change were updated (README / AGENTS.md / docs/ARCHITECTURE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
