### PR TITLE
fix: stop killing the sidecar while it is still starting up

### DIFF
--- a/apps/desktop-shell/README.md
+++ b/apps/desktop-shell/README.md
@@ -18,6 +18,15 @@ Electron main (dist/main.js)
   │                     remote bearer token; switches replace the renderer
 ```
 
+`sidecar-health.ts` decides what a failing probe means, because the naive answer
+loops forever. A sidecar connecting many stdio MCP servers stalls its own event
+loop for seconds, so an unanswered probe during the startup grace window is
+patience, not a kill: killing there means startup can never finish, and the
+replacement repeats the same stall. Only probes that answer `HealthyBusy` prove
+liveness without readiness. Restarts are forgiven only after the child stays
+healthy for a stability window — a single healthy probe between kills must not
+refill the budget, or the breaker never trips and the loop is silent.
+
 The main process uses `powerMonitor` to pause embedded cron timers on suspend.
 After resume it checks the sidecar, restarts an unhealthy child, or asks a
 healthy host to reconnect MCP servers before recovering one missed cron

--- a/apps/desktop-shell/src/main.ts
+++ b/apps/desktop-shell/src/main.ts
@@ -351,6 +351,31 @@ function registerPowerLifecycle(): void {
   });
 }
 
+/**
+ * The renderer can only say the backend is unreachable and that it keeps
+ * retrying, which is untrue once the breaker trips — say so here instead.
+ */
+function reportSidecarFatal(err: Error): void {
+  if (shuttingDown) return;
+  const dataRoot = resolveDataRoot();
+  void dialog
+    .showMessageBox({
+      type: "error",
+      title: "Pizza Bot cannot start its local backend",
+      message: "Pizza Bot restarted its local backend repeatedly without it staying up, so it stopped retrying.",
+      detail: [
+        `Slow or failing MCP servers are the usual cause. Move "${path.join(dataRoot, ".mcp.json")}" aside, restart Pizza Bot, then add servers back a few at a time.`,
+        err.message,
+      ].join("\n\n"),
+      buttons: ["Open Logs Folder", "Close"],
+      defaultId: 1,
+      cancelId: 1,
+    })
+    .then(({ response }) => {
+      if (response === 0) void shell.openPath(path.join(dataRoot, "logs"));
+    });
+}
+
 /** Fork the sidecar with secrets decrypted from current storage. */
 async function bootSidecar(dataRoot: string, apiToken: string): Promise<Sidecar> {
   const mcpNodePath = resolveMcpNodePath();
@@ -373,7 +398,18 @@ async function bootSidecar(dataRoot: string, apiToken: string): Promise<Sidecar>
         }
       : {}),
     onFatal: (err) => {
-      console.error("[shell] sidecar fatal:", err.message);
+      shellLogger.error("Sidecar supervision gave up", err, {
+        event: "desktop.sidecar_fatal",
+      });
+      reportSidecarFatal(err);
+    },
+    onHealthProbeFailed: ({ outcome, consecutiveFailures, killing }) => {
+      shellLogger.warn("Sidecar health probe did not report healthy", {
+        event: "desktop.sidecar_health_probe_failed",
+        outcome,
+        consecutiveFailures,
+        killing,
+      });
     },
     onReady: (hs) => {
       console.log(`[shell] sidecar ready on port ${hs.port} (pid ${hs.pid})`);

--- a/apps/desktop-shell/src/sidecar-health.test.ts
+++ b/apps/desktop-shell/src/sidecar-health.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyProbe,
+  DEFAULT_HEALTH_POLICY,
+  initialHealthState,
+  type HealthPolicyLimits,
+  type ProbeOutcome,
+} from "./sidecar-health.js";
+
+const limits: HealthPolicyLimits = {
+  failureThreshold: 3,
+  startupGraceMs: 10_000,
+  stabilityMs: 30_000,
+};
+
+/** Feeds a probe sequence from a fresh spawn, one probe per 5s tick. */
+function run(
+  outcomes: ProbeOutcome[],
+  policy: HealthPolicyLimits = limits,
+): { kills: number; clears: number; failures: number } {
+  const spawnedAt = 1_000_000;
+  let state = initialHealthState(spawnedAt);
+  let kills = 0;
+  let clears = 0;
+  outcomes.forEach((outcome, i) => {
+    const decision = applyProbe(state, outcome, spawnedAt + 5_000 * (i + 1), policy);
+    state = decision.state;
+    if (decision.kill) kills += 1;
+    if (decision.clearRestartBudget) clears += 1;
+  });
+  return { kills, clears, failures: state.consecutiveFailures };
+}
+
+describe("applyProbe", () => {
+  it("never kills a warming sidecar, however long it warms", () => {
+    expect(run(Array<ProbeOutcome>(40).fill("warming")).kills).toBe(0);
+  });
+
+  it("tolerates unanswered probes inside the startup grace window", () => {
+    // Two ticks land at +5s and +10s; only the second is past the 10s grace.
+    expect(run(["unreachable", "unreachable"]).kills).toBe(0);
+  });
+
+  it("kills once unanswered probes reach the threshold past the grace window", () => {
+    // Ticks at +5s (in grace), +10s and +15s (past it) reach the threshold.
+    expect(run(Array<ProbeOutcome>(2).fill("unreachable")).kills).toBe(0);
+    expect(run(Array<ProbeOutcome>(3).fill("unreachable")).kills).toBe(1);
+  });
+
+  it("does not kill twice for one failure streak", () => {
+    const spawnedAt = 0;
+    let state = initialHealthState(spawnedAt);
+    const at = (tick: number): boolean => {
+      const decision = applyProbe(state, "unreachable", tick * 5_000, limits);
+      state = decision.state;
+      return decision.kill;
+    };
+    expect([at(1), at(2), at(3), at(4)]).toEqual([false, false, true, false]);
+  });
+
+  it("kills a refusing sidecar without waiting out the grace window", () => {
+    expect(run(["unhealthy", "unhealthy", "unhealthy"]).kills).toBe(1);
+  });
+
+  it("clears a failure streak when the sidecar answers again", () => {
+    expect(run(["unreachable", "unreachable", "healthy"]).failures).toBe(0);
+    expect(run(["unreachable", "unreachable", "warming"]).failures).toBe(0);
+  });
+
+  it("requires sustained health, not one probe, to clear the restart budget", () => {
+    // Healthy from +5s: the run reaches stabilityMs only on the 7th tick.
+    expect(run(Array<ProbeOutcome>(6).fill("healthy")).clears).toBe(0);
+    expect(run(Array<ProbeOutcome>(8).fill("healthy")).clears).toBeGreaterThan(0);
+  });
+
+  it("restarts the stability clock after any non-healthy probe", () => {
+    const outcomes: ProbeOutcome[] = [
+      ...Array<ProbeOutcome>(5).fill("healthy"),
+      "unreachable",
+      ...Array<ProbeOutcome>(5).fill("healthy"),
+    ];
+    expect(run(outcomes).clears).toBe(0);
+  });
+
+  it("reproduces the reported restart loop under the previous policy", () => {
+    // One failed probe killing the child, and any healthy probe clearing the
+    // restart budget, is what let a slow startup loop forever.
+    const previous: HealthPolicyLimits = {
+      failureThreshold: 1,
+      startupGraceMs: 0,
+      stabilityMs: 0,
+    };
+    const cycle: ProbeOutcome[] = ["healthy", "unreachable"];
+    const outcomes = Array.from({ length: 20 }, (_, i) => cycle[i % 2] as ProbeOutcome);
+    expect(run(outcomes, previous)).toMatchObject({ kills: 10, clears: 10 });
+    // The shipped policy neither kills nor forgives the restart budget here.
+    expect(run(outcomes)).toMatchObject({ kills: 0, clears: 0 });
+  });
+
+  it("ships a grace window wider than the health interval and its timeout", () => {
+    expect(DEFAULT_HEALTH_POLICY.startupGraceMs).toBeGreaterThan(
+      DEFAULT_HEALTH_POLICY.failureThreshold * (5_000 + 3_000),
+    );
+  });
+});

--- a/apps/desktop-shell/src/sidecar-health.ts
+++ b/apps/desktop-shell/src/sidecar-health.ts
@@ -1,0 +1,84 @@
+/**
+ * Decides when a failing sidecar health probe justifies killing the child, and
+ * when a child has been healthy long enough to earn a fresh restart budget.
+ */
+
+/** `unreachable` is a probe that never answered; `unhealthy` is a refusal. */
+export type ProbeOutcome = "healthy" | "warming" | "unhealthy" | "unreachable";
+
+export interface HealthPolicyLimits {
+  /** Consecutive failing probes tolerated before the child is killed. */
+  failureThreshold: number;
+  /**
+   * Unanswered probes are tolerated for this long after a spawn. A sidecar
+   * connecting many stdio MCP servers stalls its event loop for seconds at a
+   * time, and killing it there means startup can never finish.
+   */
+  startupGraceMs: number;
+  /** Uninterrupted healthy time that clears the restart budget. */
+  stabilityMs: number;
+}
+
+export const DEFAULT_HEALTH_POLICY: HealthPolicyLimits = {
+  failureThreshold: 3,
+  startupGraceMs: 120_000,
+  stabilityMs: 60_000,
+};
+
+export interface HealthState {
+  /** Handshake time of the current child, not of the supervisor. */
+  spawnedAt: number;
+  consecutiveFailures: number;
+  healthySince: number | undefined;
+}
+
+export interface HealthDecision {
+  state: HealthState;
+  kill: boolean;
+  clearRestartBudget: boolean;
+}
+
+export function initialHealthState(spawnedAt: number): HealthState {
+  return { spawnedAt, consecutiveFailures: 0, healthySince: undefined };
+}
+
+export function applyProbe(
+  state: HealthState,
+  outcome: ProbeOutcome,
+  now: number,
+  limits: HealthPolicyLimits = DEFAULT_HEALTH_POLICY,
+): HealthDecision {
+  if (outcome === "healthy") {
+    const healthySince = state.healthySince ?? now;
+    return {
+      state: { ...state, consecutiveFailures: 0, healthySince },
+      kill: false,
+      clearRestartBudget: now - healthySince >= limits.stabilityMs,
+    };
+  }
+
+  // A warming sidecar answered, so it is not wedged; restarting only replays the
+  // same startup work. Waiting is the sole way for a slow warm-up to complete.
+  if (outcome === "warming") {
+    return {
+      state: { ...state, consecutiveFailures: 0, healthySince: undefined },
+      kill: false,
+      clearRestartBudget: false,
+    };
+  }
+
+  const consecutiveFailures = state.consecutiveFailures + 1;
+  const withinGrace =
+    outcome === "unreachable" && now - state.spawnedAt < limits.startupGraceMs;
+  const kill = !withinGrace && consecutiveFailures >= limits.failureThreshold;
+  return {
+    // The counter's job ends at the kill; the replacement child starts clean.
+    state: {
+      ...state,
+      consecutiveFailures: kill ? 0 : consecutiveFailures,
+      healthySince: undefined,
+    },
+    kill,
+    clearRestartBudget: false,
+  };
+}

--- a/apps/desktop-shell/src/sidecar.test.ts
+++ b/apps/desktop-shell/src/sidecar.test.ts
@@ -8,6 +8,7 @@ import { build } from "esbuild";
 import {
   fetchWithTimeout,
   startSidecar,
+  type HealthProbeReport,
   type Sidecar,
 } from "./sidecar.js";
 
@@ -232,6 +233,69 @@ describe("startSidecar (real api-server)", () => {
     expect(["Healthy", "HealthyBusy"]).toContain((await res.json() as { status: string }).status);
     await sidecar.stop();
     sidecar = undefined;
+  }, 90_000);
+
+  it("keeps a child whose probes never answer during the startup grace window", async () => {
+    const dataRoot = tempRoot("electron-shell-grace-");
+    const { pluginsDir, builtinSkillsDir } = emptyContributionDirs(dataRoot);
+    const reports: HealthProbeReport[] = [];
+    sidecar = await startSidecar({
+      serverModulePath: serverEntry(),
+      dataRoot,
+      pluginsDir,
+      builtinSkillsDir,
+      expectedApiVersion: "1",
+      handshakeTimeoutMs: 60_000,
+      healthIntervalMs: 50,
+      healthTimeoutMs: 50,
+      healthPolicy: { failureThreshold: 1, startupGraceMs: 30_000 },
+      // A stalled event loop is indistinguishable from this: the probe is sent
+      // and never answered.
+      fetch: (() => new Promise<Response>(() => {})) as typeof fetch,
+      onHealthProbeFailed: (report) => reports.push(report),
+    });
+    const originalPid = sidecar.handshake.pid;
+    const originalEndpoint = sidecar.baseUrl;
+
+    await new Promise((r) => setTimeout(r, 1_500));
+
+    expect(reports.length).toBeGreaterThan(2);
+    expect(reports.every((r) => r.outcome === "unreachable" && !r.killing)).toBe(true);
+    expect(sidecar.handshake.pid).toBe(originalPid);
+    expect(sidecar.baseUrl).toBe(originalEndpoint);
+    // The real server is untouched and still serving on the original port.
+    expect((await fetch(`${originalEndpoint}/ping`)).status).toBe(200);
+  }, 90_000);
+
+  it("trips the breaker instead of restarting forever past the grace window", async () => {
+    const dataRoot = tempRoot("electron-shell-breaker-");
+    const { pluginsDir, builtinSkillsDir } = emptyContributionDirs(dataRoot);
+    let resolveFatal!: (err: Error) => void;
+    const fatal = new Promise<Error>((resolve) => {
+      resolveFatal = resolve;
+    });
+    sidecar = await startSidecar({
+      serverModulePath: serverEntry(),
+      dataRoot,
+      pluginsDir,
+      builtinSkillsDir,
+      expectedApiVersion: "1",
+      handshakeTimeoutMs: 60_000,
+      healthIntervalMs: 50,
+      healthTimeoutMs: 50,
+      healthPolicy: { failureThreshold: 1, startupGraceMs: 0 },
+      maxRestarts: 0,
+      fetch: (() => new Promise<Response>(() => {})) as typeof fetch,
+      onFatal: (err) => resolveFatal(err),
+    });
+
+    const err = await Promise.race([
+      fatal,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("breaker never tripped")), 30_000),
+      ),
+    ]);
+    expect(err.message).toContain("circuit breaker tripped");
   }, 90_000);
 
   it("reports a changed endpoint after recovering a crashed child", async () => {

--- a/apps/desktop-shell/src/sidecar.ts
+++ b/apps/desktop-shell/src/sidecar.ts
@@ -9,6 +9,14 @@ import {
   type SidecarSecretUpdate,
 } from "@pizza-bot/api-server/sidecar-ipc";
 import { findSystemNode } from "@pizza-bot/plugin-sdk/runtime-resolver";
+import {
+  applyProbe,
+  DEFAULT_HEALTH_POLICY,
+  initialHealthState,
+  type HealthPolicyLimits,
+  type HealthState,
+  type ProbeOutcome,
+} from "./sidecar-health.js";
 
 /**
  * Development native modules target system Node's ABI, not Electron's. Resolve a
@@ -68,8 +76,11 @@ export interface SidecarOptions {
   expectedApiVersion: string;
   healthIntervalMs?: number;
   healthTimeoutMs?: number;
+  /** Patience knobs for the health probe; each falls back to the shared default. */
+  healthPolicy?: Partial<HealthPolicyLimits>;
   lifecycleTimeoutMs?: number;
   handshakeTimeoutMs?: number;
+  /** Restarts tolerated before the breaker trips, unless the child stabilizes. */
   maxRestarts?: number;
   /**
    * Graceful-stop deadline before group SIGKILL. The default 10s exceeds the
@@ -80,6 +91,14 @@ export interface SidecarOptions {
   onFatal?: (err: Error) => void;
   onReady?: (handshake: SidecarHandshake) => void;
   onEndpointChanged?: (baseUrl: string, handshake: SidecarHandshake) => void;
+  /** Reports every probe the child did not answer as healthy, kill or not. */
+  onHealthProbeFailed?: (report: HealthProbeReport) => void;
+}
+
+export interface HealthProbeReport {
+  outcome: ProbeOutcome;
+  consecutiveFailures: number;
+  killing: boolean;
 }
 
 export interface Sidecar {
@@ -258,13 +277,18 @@ export async function startSidecar(opts: SidecarOptions): Promise<Sidecar> {
   const lifecycleTimeoutMs = opts.lifecycleTimeoutMs ?? 60_000;
   const maxRestarts = opts.maxRestarts ?? 5;
   const stopTimeoutMs = opts.stopTimeoutMs ?? 10_000;
+  const healthPolicy: HealthPolicyLimits = {
+    ...DEFAULT_HEALTH_POLICY,
+    ...opts.healthPolicy,
+  };
 
   let child: ChildProcess;
   let handshake: SidecarHandshake;
   let baseUrl: string;
   let stopped = false;
   let healthTimer: NodeJS.Timeout | undefined;
-  let consecutiveFailures = 0;
+  let health: HealthState;
+  let restartAttempts = 0;
   let restartInFlight: Promise<void> | undefined;
   let secretRequestId = 0;
 
@@ -272,9 +296,10 @@ export async function startSidecar(opts: SidecarOptions): Promise<Sidecar> {
   child = boot.child;
   handshake = boot.handshake;
   baseUrl = `http://127.0.0.1:${handshake.port}`;
+  health = initialHealthState(Date.now());
   opts.onReady?.(handshake);
 
-  async function ping(): Promise<boolean> {
+  async function probe(): Promise<ProbeOutcome> {
     try {
       const res = await fetchWithTimeout(
         doFetch,
@@ -282,12 +307,19 @@ export async function startSidecar(opts: SidecarOptions): Promise<Sidecar> {
         {},
         healthTimeoutMs,
       );
-      if (!res.ok) return false;
+      if (!res.ok) return "unhealthy";
       const body = (await res.json()) as { status?: string };
-      return body.status === "Healthy" || body.status === "HealthyBusy";
+      if (body.status === "Healthy") return "healthy";
+      if (body.status === "HealthyBusy") return "warming";
+      return "unhealthy";
     } catch {
-      return false;
+      return "unreachable";
     }
+  }
+
+  async function ping(): Promise<boolean> {
+    const outcome = await probe();
+    return outcome === "healthy" || outcome === "warming";
   }
 
   async function postLifecycle(
@@ -329,16 +361,16 @@ export async function startSidecar(opts: SidecarOptions): Promise<Sidecar> {
   async function restartLoop(reason: string): Promise<void> {
     let lastReason = reason;
     while (!stopped) {
-      consecutiveFailures += 1;
-      if (consecutiveFailures > maxRestarts) {
+      restartAttempts += 1;
+      if (restartAttempts > maxRestarts) {
         const err = new Error(
-          `sidecar circuit breaker tripped after ${maxRestarts} restarts (last reason: ${lastReason})`,
+          `sidecar circuit breaker tripped after ${maxRestarts} restarts without stabilizing (last reason: ${lastReason})`,
         );
         stopped = true;
         opts.onFatal?.(err);
         return;
       }
-      const backoff = Math.min(250 * 2 ** (consecutiveFailures - 1), 10_000);
+      const backoff = Math.min(250 * 2 ** (restartAttempts - 1), 10_000);
       await sleep(backoff);
       if (stopped) return;
 
@@ -353,6 +385,7 @@ export async function startSidecar(opts: SidecarOptions): Promise<Sidecar> {
         child = replacement.child;
         handshake = replacement.handshake;
         baseUrl = `http://127.0.0.1:${handshake.port}`;
+        health = initialHealthState(Date.now());
         attach();
         opts.onReady?.(handshake);
         if (baseUrl !== previousBaseUrl) {
@@ -449,15 +482,23 @@ export async function startSidecar(opts: SidecarOptions): Promise<Sidecar> {
   const scheduleHealth = (): void => {
     healthTimer = setTimeout(async () => {
       if (stopped) return;
-      const healthy = await ping();
+      const outcome = await probe();
       if (stopped) return;
-      if (healthy) {
-        consecutiveFailures = 0;
-      } else {
+      const decision = applyProbe(health, outcome, Date.now(), healthPolicy);
+      health = decision.state;
+      if (decision.clearRestartBudget) restartAttempts = 0;
+      if (outcome !== "healthy") {
+        opts.onHealthProbeFailed?.({
+          outcome,
+          consecutiveFailures: health.consecutiveFailures,
+          killing: decision.kill,
+        });
+      }
+      if (decision.kill) {
         if (child.exitCode === null && child.signalCode === null) {
           killTree(child, "SIGKILL");
         } else {
-          void restart("health ping failed");
+          void restart(`health probe ${outcome}`);
         }
       }
       if (!stopped) scheduleHealth();


### PR DESCRIPTION
Fixes #85.

## The bug

The shell health-pinged `/ping` every 5s with a 3s timeout and `taskkill /T /F`'d the whole sidecar tree on the **first** failure. A sidecar connecting many stdio MCP servers stalls its own event loop for seconds at a time, so it got killed mid-startup, respawned, and stalled again — a permanent restart loop in which MCP connect could never finish. The reporter's logs show 118 sidecar starts in 35 minutes, with every server stuck at `mcp.loading / attempt: 1` and not one ever reaching `loaded`.

The circuit breaker could not end it either: `consecutiveFailures` was reset by a single healthy probe, and on the slower cycles one probe did succeed — so the counter never reached `maxRestarts` and `onFatal` never fired. The renderer just showed "Can't reach the embedded backend. Retrying automatically." forever.

## The fix

`sidecar-health.ts` (new) holds the probe policy as a pure function, so the interesting decisions are testable without a child process:

- `/ping` outcomes are classified `healthy | warming | unhealthy | unreachable` instead of collapsing to a boolean, which is what erased the difference between "did not answer" and "answered, still warming".
- An **unanswered** probe inside a 120s startup grace window is patience, not a kill — killing there means startup can never finish, and the replacement repeats the same stall.
- A **`HealthyBusy`** answer never kills, however long it lasts. The child answered, so it is not wedged, and restarting only replays the same startup work.
- Killing needs **3 consecutive** failures, and the counter resets at the kill so one streak cannot stack kills.
- A definitive refusal (`unhealthy`) skips the grace window — that server answered and is broken.

`sidecar.ts` splits the overloaded counter into probe failures and a separate `restartAttempts` budget. The budget clears only after **60s of uninterrupted health**, so the alternating healthy/timed-out pattern that kept the breaker asleep now trips it.

`main.ts` makes both outcomes legible:

- Failed probes log a structured `desktop.sidecar_health_probe_failed` event (outcome, streak, whether it killed). Diagnosing #85 required inferring the kills from restart cadence because `/ping` is a debug-level quiet route; the next report will show them directly.
- A tripped breaker shows an error dialog that names `<dataRoot>/.mcp.json` as the thing to move aside, with an "Open Logs Folder" button — the renderer can only claim it is still retrying, which is untrue once the breaker trips.

## Tests

- 10 policy unit tests, including a regression case that reproduces the reported loop under the old thresholds (`failureThreshold: 1`, no grace, no stability window) and shows the shipped policy neither kills nor forgives the budget on the same probe sequence.
- Two integration tests against a **real forked api-server**, using an injected fetch that never settles — the faithful stand-in for a stalled event loop:
  - a child whose probes never answer survives the grace window with its original pid and port, and still serves `/ping` afterwards;
  - past the grace window the breaker fires instead of looping.

`apps/desktop-shell` (62 tests), full `npm run typecheck`, and `npm run lint` are green.

## Not covered

- **I could not launch the packaged app to see the dialog** — Electron's binary never finished downloading/launching in my environment, so `main.ts`'s new wiring is covered by typecheck and a successful esbuild bundle only. Worth one manual launch before merging.
- The underlying event-loop starvation is untouched: `agent-host` still connects every MCP server at once, so a first boot like the reporter's will stay sluggish for up to a minute — it just will not die. Bounding that concurrency is noted as follow-up in #85.
